### PR TITLE
fix FloatLiteral pattern

### DIFF
--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -122,9 +122,8 @@ createToken({ name: "OctalLiteral", pattern: /0_*[0-7]([0-7_]*[0-7])?[lL]?/ });
 createToken({
   name: "FloatLiteral",
   pattern: MAKE_PATTERN(
-    "\\.{{Digits}}({{ExponentPart}})?({{FloatTypeSuffix}})?|" +
-      "{{Digits}}\\.({{Digits}})?({{ExponentPart}})?({{FloatTypeSuffix}})?|" +
-      "{{Digits}}\\.({{Digits}})?({{FloatTypeSuffix}})?|" +
+    "{{Digits}}\\.({{Digits}})?({{ExponentPart}})?({{FloatTypeSuffix}})?|" +
+      "\\.{{Digits}}({{ExponentPart}})?({{FloatTypeSuffix}})?|" +
       "{{Digits}}{{ExponentPart}}({{FloatTypeSuffix}})?|" +
       "{{Digits}}({{ExponentPart}})?{{FloatTypeSuffix}}"
   )

--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -122,8 +122,9 @@ createToken({ name: "OctalLiteral", pattern: /0_*[0-7]([0-7_]*[0-7])?[lL]?/ });
 createToken({
   name: "FloatLiteral",
   pattern: MAKE_PATTERN(
-    "{{Digits}}\\.({{Digits}})?({{FloatTypeSuffix}})?|" +
-      "\\.{{Digits}}({{ExponentPart}})?({{FloatTypeSuffix}})?|" +
+    "\\.{{Digits}}({{ExponentPart}})?({{FloatTypeSuffix}})?|" +
+      "{{Digits}}\\.({{Digits}})?({{ExponentPart}})?({{FloatTypeSuffix}})?|" +
+      "{{Digits}}\\.({{Digits}})?({{FloatTypeSuffix}})?|" +
       "{{Digits}}{{ExponentPart}}({{FloatTypeSuffix}})?|" +
       "{{Digits}}({{ExponentPart}})?{{FloatTypeSuffix}}"
   )

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -9,3 +9,10 @@ describe("The Java Parser fixed bugs", () => {
     expect(() => javaParser.parse(input, "expression")).to.not.throw();
   });
 });
+
+describe("The Java Parser fixed bugs", () => {
+  it("issue #131 - 1.0e-10", () => {
+    const input = "1.0e-10";
+    expect(() => javaParser.parse(input, "expression")).to.not.throw();
+  });
+});


### PR DESCRIPTION
The FloatLiteral pattern could now parse scientific notation as 1.0e-10 or 1.e-1

Fix #131