### PR TITLE
fix(parser): fixmissing semicolon consuming in break statement

### DIFF
--- a/packages/java-parser/src/productions/blocks-and-statements.js
+++ b/packages/java-parser/src/productions/blocks-and-statements.js
@@ -294,6 +294,7 @@ function defineRules($, t) {
     $.OPTION(() => {
       $.CONSUME(t.Identifier);
     });
+    $.CONSUME(t.Semicolon);
   });
 
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-ContinueStatement

--- a/packages/java-parser/test/samples-spec.js
+++ b/packages/java-parser/test/samples-spec.js
@@ -10,7 +10,7 @@ const javaParser = require("../src/index");
 describe("The Java Parser", () => {
   createSampleSpecs("java-design-patterns");
   createSampleSpecs("spring-boot");
-  createFailingSampleSpec("guava", 36, 0);
+  createFailingSampleSpec("guava", 32, 0);
 });
 
 function createSampleSpecs(sampleName) {


### PR DESCRIPTION
I started working on test failures on Guava samples. The first I tried to tackle is https://github.com/google/guava/blob/838560034dfaa1afdf51a126afe6b8b8e6cce3dd/android/guava/src/com/google/common/cache/Striped64.java#L216

It seems for me that there were an issue in breakStatement : the semiColon was not consumed. 
(https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-BreakStatement)
 