### PR TITLE
fix(EnumConstant): align EnumConstant rule with the spec

### DIFF
--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -628,10 +628,12 @@ function defineRules($, t) {
     $.CONSUME(t.Identifier);
     $.OPTION(() => {
       $.CONSUME(t.LBrace);
-      $.SUBRULE($.argumentList);
+      $.OPTION2(() => {
+        $.SUBRULE($.argumentList);
+      });
       $.CONSUME(t.RBrace);
     });
-    $.OPTION2(() => {
+    $.OPTION3(() => {
       $.SUBRULE($.classBody);
     });
   });

--- a/packages/java-parser/test/samples-spec.js
+++ b/packages/java-parser/test/samples-spec.js
@@ -10,7 +10,7 @@ const javaParser = require("../src/index");
 describe("The Java Parser", () => {
   createSampleSpecs("java-design-patterns");
   createSampleSpecs("spring-boot");
-  createFailingSampleSpec("guava", 32, 0);
+  createFailingSampleSpec("guava", 22, 0);
 });
 
 function createSampleSpecs(sampleName) {


### PR DESCRIPTION
Allow optional `([ArgumentList])` : see https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-EnumConstantList

Fix https://github.com/google/guava/blob/838560034dfaa1afdf51a126afe6b8b8e6cce3dd/guava-tests/test/com/google/common/hash/HashTestUtils.java#L95 parsing