### PR TITLE
Fix dim exprs rule

### DIFF
--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -628,10 +628,12 @@ function defineRules($, t) {
     $.CONSUME(t.Identifier);
     $.OPTION(() => {
       $.CONSUME(t.LBrace);
-      $.SUBRULE($.argumentList);
+      $.OPTION2(() => {
+        $.SUBRULE($.argumentList);
+      });
       $.CONSUME(t.RBrace);
     });
-    $.OPTION2(() => {
+    $.OPTION3(() => {
       $.SUBRULE($.classBody);
     });
   });

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -443,6 +443,7 @@ function defineRules($, t) {
     });
   });
 
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
   $.RULE("arrayCreationExpression", () => {
     $.CONSUME(t.New);
     $.OR([
@@ -462,6 +463,7 @@ function defineRules($, t) {
     ]);
   });
 
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
   $.RULE("arrayCreationDefaultInitSuffix", () => {
     $.SUBRULE($.dimExprs);
     $.OPTION(() => {
@@ -469,18 +471,22 @@ function defineRules($, t) {
     });
   });
 
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
   $.RULE("arrayCreationExplicitInitSuffix", () => {
     $.SUBRULE($.dims);
     $.SUBRULE($.arrayInitializer);
   });
 
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
   $.RULE("dimExprs", () => {
     $.SUBRULE($.dimExpr);
-    $.OPTION(() => {
-      $.SUBRULE2($.dimExpr);
+    $.OPTION({
+      GATE: $.BACKTRACK($.dimExpr),
+      DEF: () => $.SUBRULE2($.dimExpr)
     });
   });
 
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
   $.RULE("dimExpr", () => {
     $.MANY(() => {
       $.SUBRULE($.annotation);

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -480,8 +480,8 @@ function defineRules($, t) {
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
   $.RULE("dimExprs", () => {
     $.SUBRULE($.dimExpr);
-    $.OPTION({
-      GATE: $.BACKTRACK($.dimExpr),
+    $.MANY({
+      GATE: () => $.LA(2).tokenType !== t.RSquare,
       DEF: () => $.SUBRULE2($.dimExpr)
     });
   });

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -463,7 +463,6 @@ function defineRules($, t) {
     ]);
   });
 
-  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
   $.RULE("arrayCreationDefaultInitSuffix", () => {
     $.SUBRULE($.dimExprs);
     $.OPTION(() => {
@@ -471,22 +470,25 @@ function defineRules($, t) {
     });
   });
 
-  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
   $.RULE("arrayCreationExplicitInitSuffix", () => {
     $.SUBRULE($.dims);
     $.SUBRULE($.arrayInitializer);
   });
 
-  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-DimExprs
   $.RULE("dimExprs", () => {
     $.SUBRULE($.dimExpr);
     $.MANY({
+      // The GATE is to distinguish DimExpr from Dims :
+      // the only difference between these two is the presence of an expression in the DimExpr
+      // Example: If the GATE is not present double[3][] won't be parsed as the parser will try to parse "[]"
+      // as a dimExpr instead of a dims
       GATE: () => $.LA(2).tokenType !== t.RSquare,
       DEF: () => $.SUBRULE2($.dimExpr)
     });
   });
 
-  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1
+  // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-DimExpr
   $.RULE("dimExpr", () => {
     $.MANY(() => {
       $.SUBRULE($.annotation);

--- a/packages/java-parser/test/samples-spec.js
+++ b/packages/java-parser/test/samples-spec.js
@@ -10,7 +10,7 @@ const javaParser = require("../src/index");
 describe("The Java Parser", () => {
   createSampleSpecs("java-design-patterns");
   createSampleSpecs("spring-boot");
-  createFailingSampleSpec("guava", 32, 0);
+  createFailingSampleSpec("guava", 22, 0);
 });
 
 function createSampleSpecs(sampleName) {

--- a/packages/java-parser/test/samples-spec.js
+++ b/packages/java-parser/test/samples-spec.js
@@ -10,7 +10,7 @@ const javaParser = require("../src/index");
 describe("The Java Parser", () => {
   createSampleSpecs("java-design-patterns");
   createSampleSpecs("spring-boot");
-  createFailingSampleSpec("guava", 22, 0);
+  createFailingSampleSpec("guava", 10, 0);
 });
 
 function createSampleSpecs(sampleName) {


### PR DESCRIPTION
Use backtracking in dimExprs rule because dims were confused as dimExpr in the parser (https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.10.1)

Fix parsing of https://github.com/google/guava/blob/838560034dfaa1afdf51a126afe6b8b8e6cce3dd/guava-tests/benchmark/com/google/common/math/StatsBenchmark.java#L149

Include #136 commits to avoid merge conflict in packages/java-parser/test/samples-spec.js