### PR TITLE
WIP fix(parser): fix VariableArityParameter parsing

### DIFF
--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -245,8 +245,9 @@ function defineRules($, t) {
       {
         ALT: () => {
           $.SUBRULE($.unannClassOrInterfaceType);
-          $.OPTION(() => {
-            $.SUBRULE2($.dims);
+          $.OPTION({
+            GATE: $.BACKTRACK($.dims),
+            DEF: () => $.SUBRULE2($.dims)
           });
         }
       }


### PR DESCRIPTION
Fix parsing of `@Nullable Object @Nullable... errorMessageArgs` in https://github.com/google/guava/blob/838560034dfaa1afdf51a126afe6b8b8e6cce3dd/guava/src/com/google/common/base/Verify.java#L122

The parser try to parse the second @Nullable... as dims, which is incorrect

Should be the last bug in the parser for the guava repo with #137 and #138.

WIP : There is probably a better way than using backtracking here. 