### PR TITLE
Fix annotation: accepting comma as last element in ElementValueList

### DIFF
--- a/packages/java-parser/src/productions/interfaces.js
+++ b/packages/java-parser/src/productions/interfaces.js
@@ -305,7 +305,13 @@ function defineRules($, t) {
     $.SUBRULE($.elementValue);
     $.MANY(() => {
       $.CONSUME(t.Comma);
-      $.SUBRULE2($.elementValue);
+      /*
+      To be compliant with the JAVA specification we should remove the Option.
+      However, JAVA accept that ElementValueList ends with a comma (,)
+      */
+      $.OPTION(() => {
+        $.SUBRULE2($.elementValue);
+      });
     });
   });
 

--- a/packages/java-parser/src/productions/interfaces.js
+++ b/packages/java-parser/src/productions/interfaces.js
@@ -303,15 +303,12 @@ function defineRules($, t) {
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html#jls-ElementValueList
   $.RULE("elementValueList", () => {
     $.SUBRULE($.elementValue);
-    $.MANY(() => {
-      $.CONSUME(t.Comma);
-      /*
-      To be compliant with the JAVA specification we should remove the Option.
-      However, JAVA accept that ElementValueList ends with a comma (,)
-      */
-      $.OPTION(() => {
+    $.MANY({
+      GATE: () => $.LA(2).tokenType !== t.RCurly,
+      DEF: () => {
+        $.CONSUME(t.Comma);
         $.SUBRULE2($.elementValue);
-      });
+      }
     });
   });
 


### PR DESCRIPTION
As I was trying to parse the spring-framework repository, this file was failing to parse https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/test/java/org/springframework/context/annotation/PropertySourceAnnotationTests.java#L442 (L442 and L451) due to the metadata content in the annotation. It seems that JAVA accept ElementValueList to end with a comma even though the JAVA specification says otherwise https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html#jls-ElementValueList.