### PR TITLE
Fix DecimalLiteral regex

### DIFF
--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -140,7 +140,7 @@ createToken({
 });
 createToken({
   name: "DecimalLiteral",
-  pattern: MAKE_PATTERN("(0|[1-9](({{Digits}})?|_+{{Digits}}))[lL]?")
+  pattern: MAKE_PATTERN("(0|[1-9](_+{{Digits}}|({{Digits}})?))[lL]?")
 });
 // https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.10.4
 createToken({


### PR DESCRIPTION
I was trying to parse this file https://github.com/jhipster/jhipster/blob/master/jhipster-framework/src/main/java/io/github/jhipster/config/JHipsterDefaults.java#L193, however it failed at line 193 ```int durationInSeconds = 3_600; ``` with the following error:
```
{ [MismatchedTokenException: Expecting --> ';' <-- but found --> '_600' <--]
  name: 'MismatchedTokenException',
  message: 'Expecting --> \';\' <-- but found --> \'_600\' <--',
  token:
   { image: '_600',
     startOffset: 4660,
     endOffset: 4663,
     startLine: 193,
     endLine: 193,
     startColumn: 38,
     endColumn: 41,
     tokenTypeIdx: 2,
     tokenType:
      { PATTERN: /[a-zA-Z_\\$][a-zA-Z_\\$0-9]*/,
        tokenTypeIdx: 2,
        CATEGORIES: [],
        categoryMatches: [Array],
        categoryMatchesMap: [Object],
        tokenName: 'Identifier',
        isParent: true } },
  previousToken:
   { image: '3',
     startOffset: 4659,
     endOffset: 4659,
     startLine: 193,
     endLine: 193,
     startColumn: 37,
     endColumn: 37,
     tokenTypeIdx: 18,
     tokenType:
      { PATTERN:
         /(0|[1-9](([0-9]([0-9_]*[0-9])?)?|_+[0-9]([0-9_]*[0-9])?))[lL]?/,
        tokenTypeIdx: 18,
        CATEGORIES: [],
        categoryMatches: [],
        categoryMatchesMap: {},
        tokenName: 'DecimalLiteral',
        isParent: false,
        LABEL: '\'DecimalLiteral\'' } },
  resyncedTokens: [],
  context:
   { ruleStack:
      [ 'compilationUnit',
        'ordinaryCompilationUnit',
        'typeDeclaration',
        'interfaceDeclaration',
        'normalInterfaceDeclaration',
        'interfaceBody',
        'interfaceMemberDeclaration',
        'interfaceDeclaration',
        'normalInterfaceDeclaration',
        'interfaceBody',
        'interfaceMemberDeclaration',
        'interfaceDeclaration',
        'normalInterfaceDeclaration',
        'interfaceBody',
        'interfaceMemberDeclaration',
        'constantDeclaration' ],
     ruleOccurrenceStack: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] } }
```
As we can see, 3_600 should be defined as a DecimalLiteral token but we instead have 2 different tokens  3 (DecimalLiteral) and _600 (Identifier). This is due to the fact that regex is eager, it will stops after the first match and since DecimalLiteral pattern is defined as (0|[1-9](({{Digits}})?|_+{{Digits}}))[lL]?, it will only match 3 as a DecimalLiteral. A quick fix is to swap the two alternatives.