### PR TITLE
Aligned whitespace definition with Java Specs

### DIFF
--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -30,6 +30,7 @@ FRAGMENT("ExponentPart", "[eE][+-]?{{Digits}}");
 FRAGMENT("HexDigit", "[0-9a-fA-F]");
 FRAGMENT("HexDigits", "{{HexDigit}}(({{HexDigit}}|'_')*{{HexDigit}})?");
 FRAGMENT("FloatTypeSuffix", "[fFdD]");
+FRAGMENT("LineTerminator", "(\\x0A|(\\x0D(\\x0A)?))");
 
 const Identifier = createTokenOrg({
   name: "Identifier",
@@ -105,8 +106,15 @@ const UnarySuffixOperator = createToken({
   pattern: Lexer.NA
 });
 
-// TODO: align with Java Spec
-createToken({ name: "WhiteSpace", pattern: /\s+/, group: Lexer.SKIPPED });
+// https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.6
+// Note [\\x09\\x20\\x0C] is equivalent to [\\t\\x20\\f] and that \\x20 represents
+// space character
+createToken({
+  name: "WhiteSpace",
+  pattern: MAKE_PATTERN("[\\x09\\x20\\x0C]|{{LineTerminator}}"),
+  group: Lexer.SKIPPED
+});
+
 createToken({
   name: "LineComment",
   pattern: /\/\/[^\n\r]*/,


### PR DESCRIPTION
As suggested in (https://github.com/jhipster/prettier-java/pull/145) I've re-opened a PR with only changing the whitespace redefinition.