### PR TITLE
Using tokenMatcher instead of === to compare tokenType

### DIFF
--- a/packages/java-parser/src/productions/arrays.js
+++ b/packages/java-parser/src/productions/arrays.js
@@ -1,4 +1,7 @@
 "use strict";
+
+const { tokenMatcher } = require("chevrotain");
+
 function defineRules($, t) {
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-10.html#jls-ArrayInitializer
   $.RULE("arrayInitializer", () => {
@@ -17,7 +20,7 @@ function defineRules($, t) {
     $.SUBRULE($.variableInitializer);
     $.MANY({
       // The optional last "Comma" of an "arrayInitializer"
-      GATE: () => this.LA(2).tokenType !== t.RCurly,
+      GATE: () => tokenMatcher(this.LA(2).tokenType, t.RCurly) === false,
       DEF: () => {
         $.CONSUME(t.Comma);
         $.SUBRULE2($.variableInitializer);

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -1,4 +1,5 @@
 "use strict";
+const { tokenMatcher } = require("chevrotain");
 function defineRules($, t) {
   $.RULE("constantExpression", () => {
     $.SUBRULE($.expression);
@@ -617,8 +618,8 @@ function defineRules($, t) {
     const firstTokTypeAfterRBrace = this.LA(1).tokenType;
 
     return (
-      firstForUnaryExpressionNotPlusMinus.find(
-        tokType => tokType === firstTokTypeAfterRBrace
+      firstForUnaryExpressionNotPlusMinus.find(tokType =>
+        tokenMatcher(firstTokTypeAfterRBrace, tokType)
       ) !== undefined
     );
   });

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -44,8 +44,9 @@ function defineRules($, t) {
           const nextTokType = this.LA(1).tokenType;
           const nextNextTokType = this.LA(2).tokenType;
           return (
-            nextTokType === t.Identifier &&
-            (nextNextTokType === t.RBrace || nextNextTokType === t.Comma)
+            tokenMatcher(nextTokType, t.Identifier) &&
+            (tokenMatcher(nextNextTokType, t.RBrace) ||
+              tokenMatcher(nextNextTokType, t.Comma))
           );
         },
         ALT: () => $.SUBRULE($.inferredLambdaParameterList)
@@ -138,7 +139,8 @@ function defineRules($, t) {
           // TODO: this is a bug in Chevrotain lookahead calculation. the "BinaryOperator" token can match "Less" or "Greater"
           //   as well, but because it is a **token Category** Chevrotain does not understand it need to looks two tokens ahead.
           GATE: () =>
-            $.LA(2).tokenType === t.Less || $.LA(2).tokenType === t.Greater,
+            tokenMatcher($.LA(2).tokenType, t.Less) ||
+            tokenMatcher($.LA(2).tokenType, t.Greater),
           ALT: () => {
             $.OR2([
               {
@@ -199,7 +201,7 @@ function defineRules($, t) {
 
   $.RULE("primaryPrefix", () => {
     let isCastExpression = false;
-    if ($.LA(1).tokenType === t.LBrace) {
+    if (tokenMatcher($.LA(1).tokenType, t.LBrace)) {
       isCastExpression = this.BACKTRACK_LOOKAHEAD($.isCastExpression);
     }
 
@@ -255,9 +257,9 @@ function defineRules($, t) {
       // ".class" is a classLiteralSuffix
       GATE: () =>
         // avoids ambiguity with ".this" and ".new" which are parsed as a primary suffix.
-        this.LA(2).tokenType !== t.Class &&
-        this.LA(2).tokenType !== t.This &&
-        this.LA(2).tokenType !== t.New,
+        tokenMatcher(this.LA(2).tokenType, t.Class) === false &&
+        tokenMatcher(this.LA(2).tokenType, t.This) === false &&
+        tokenMatcher(this.LA(2).tokenType, t.New) === false,
       DEF: () => {
         $.CONSUME(t.Dot);
         $.SUBRULE2($.fqnOrRefTypePart);
@@ -268,7 +270,9 @@ function defineRules($, t) {
     $.OPTION({
       // it is not enough to check only the opening "[", we must avoid conflict with
       // arrayAccessSuffix
-      GATE: () => $.LA(1).tokenType === t.At || $.LA(2).tokenType === t.RSquare,
+      GATE: () =>
+        tokenMatcher($.LA(1).tokenType, t.At) ||
+        tokenMatcher($.LA(2).tokenType, t.RSquare),
       DEF: () => {
         $.SUBRULE($.dims);
       }
@@ -303,7 +307,7 @@ function defineRules($, t) {
     // TODO: performance optimization evaluation: avoid doing this backtracking for every "<" encountered.
     //       we could do it once (using global state) per "fqnOrRefType"
     // We could do it only once for
-    if ($.LA(1).tokenType === t.Less) {
+    if (tokenMatcher($.LA(1).tokenType, t.Less)) {
       isRefTypeInMethodRef = this.BACKTRACK_LOOKAHEAD($.isRefTypeInMethodRef);
     }
 
@@ -484,7 +488,7 @@ function defineRules($, t) {
       // the only difference between these two is the presence of an expression in the DimExpr
       // Example: If the GATE is not present double[3][] won't be parsed as the parser will try to parse "[]"
       // as a dimExpr instead of a dims
-      GATE: () => $.LA(2).tokenType !== t.RSquare,
+      GATE: () => tokenMatcher($.LA(2).tokenType, t.RSquare) === false,
       DEF: () => $.SUBRULE2($.dimExpr)
     });
   });
@@ -535,7 +539,7 @@ function defineRules($, t) {
     const firstTokenAfterNew = this.LA(1).tokenType;
 
     // not an array initialization due to the prefix "TypeArguments"
-    if (firstTokenAfterNew === t.Less) {
+    if (tokenMatcher(firstTokenAfterNew, t.Less)) {
       return newExpressionTypes.unqualifiedClassInstanceCreationExpression;
     }
 
@@ -548,7 +552,7 @@ function defineRules($, t) {
     }
 
     const firstTokenAfterClassType = this.LA(1).tokenType;
-    if (firstTokenAfterClassType === t.LBrace) {
+    if (tokenMatcher(firstTokenAfterClassType, t.LBrace)) {
       return newExpressionTypes.unqualifiedClassInstanceCreationExpression;
     }
 
@@ -567,13 +571,16 @@ function defineRules($, t) {
     const firstTokenType = this.LA(1).tokenType;
     const secondTokenType = this.LA(2).tokenType;
     // no parent lambda "x -> x * 2"
-    if (firstTokenType === t.Identifier && secondTokenType === t.Arrow) {
+    if (
+      tokenMatcher(firstTokenType, t.Identifier) &&
+      tokenMatcher(secondTokenType, t.Arrow)
+    ) {
       return true;
     }
     // Performance optimizations, fail fast if it is not a LBrace.
-    else if (firstTokenType === t.LBrace) {
+    else if (tokenMatcher(firstTokenType, t.LBrace)) {
       $.SUBRULE($.lambdaParametersWithBraces);
-      const followedByArrow = this.LA(1).tokenType === t.Arrow;
+      const followedByArrow = tokenMatcher(this.LA(1).tokenType, t.Arrow);
       return followedByArrow;
     }
     return false;
@@ -633,7 +640,7 @@ function defineRules($, t) {
     });
 
     const firstTokTypeAfterTypeArgs = this.LA(1).tokenType;
-    if (firstTokTypeAfterTypeArgs === t.ColonColon) {
+    if (tokenMatcher(firstTokTypeAfterTypeArgs, t.ColonColon)) {
       return true;
     }
     // we must be at the end of a "referenceType" if "dims" were encountered
@@ -649,7 +656,7 @@ function defineRules($, t) {
     });
 
     const firstTokTypeAfterRefType = this.LA(1).tokenType;
-    return firstTokTypeAfterRefType === t.ColonColon;
+    return tokenMatcher(firstTokTypeAfterRefType, t.ColonColon);
   });
 }
 

--- a/packages/java-parser/src/productions/interfaces.js
+++ b/packages/java-parser/src/productions/interfaces.js
@@ -304,7 +304,7 @@ function defineRules($, t) {
   $.RULE("elementValueList", () => {
     $.SUBRULE($.elementValue);
     $.MANY({
-      GATE: () => $.LA(2).tokenType !== t.RCurly,
+      GATE: () => tokenMatcher($.LA(2).tokenType, t.RCurly) === false,
       DEF: () => {
         $.CONSUME(t.Comma);
         $.SUBRULE2($.elementValue);
@@ -317,7 +317,7 @@ function defineRules($, t) {
   // ------------------------------------
   $.RULE("identifyInterfaceBodyDeclarationType", () => {
     let nextTokenType = this.LA(1).tokenType;
-    if (nextTokenType === t.Semicolon) {
+    if (tokenMatcher(nextTokenType, t.Semicolon)) {
       return InterfaceBodyTypes.semiColon;
     }
 
@@ -325,8 +325,8 @@ function defineRules($, t) {
     $.MANY({
       // To avoid ambiguity with @interface ("AnnotationTypeDeclaration" vs "Annotaion")
       GATE: () =>
-        ($.LA(1).tokenType === t.At && $.LA(2).tokenType === t.Interface) ===
-        false,
+        (tokenMatcher($.LA(1).tokenType, t.At) &&
+          tokenMatcher($.LA(2).tokenType, t.Interface)) === false,
       DEF: () => {
         // This alternation includes all possible modifiers for all types of "interfaceMemberDeclaration"
         // Certain combinations are syntactically invalid, this is **not** checked here,
@@ -348,13 +348,22 @@ function defineRules($, t) {
     });
 
     nextTokenType = this.LA(1).tokenType;
-    if (nextTokenType === t.Class || nextTokenType === t.Enum) {
+    if (
+      tokenMatcher(nextTokenType, t.Class) ||
+      tokenMatcher(nextTokenType, t.Enum)
+    ) {
       return InterfaceBodyTypes.classDeclaration;
     }
-    if (nextTokenType === t.Interface || nextTokenType === t.At) {
+    if (
+      tokenMatcher(nextTokenType, t.Interface) ||
+      tokenMatcher(nextTokenType, t.At)
+    ) {
       return InterfaceBodyTypes.interfaceDeclaration;
     }
-    if (nextTokenType === t.Void || nextTokenType === t.Less) {
+    if (
+      tokenMatcher(nextTokenType, t.Void) ||
+      tokenMatcher(nextTokenType, t.Less)
+    ) {
       // method with result type "void"
       return InterfaceBodyTypes.interfaceMethodDeclaration;
     }
@@ -369,7 +378,7 @@ function defineRules($, t) {
     // "foo(..." --> look like method start
     if (
       tokenMatcher(nextToken, t.Identifier) &&
-      nextNextTokenType === t.LBrace
+      tokenMatcher(nextNextTokenType, t.LBrace)
     ) {
       return InterfaceBodyTypes.interfaceMethodDeclaration;
     }
@@ -382,7 +391,7 @@ function defineRules($, t) {
 
   $.RULE("identifyAnnotationBodyDeclarationType", () => {
     let nextTokenType = this.LA(1).tokenType;
-    if (nextTokenType === t.Semicolon) {
+    if (tokenMatcher(nextTokenType, t.Semicolon)) {
       return AnnotationBodyTypes.semiColon;
     }
 
@@ -390,8 +399,8 @@ function defineRules($, t) {
     $.MANY({
       // To avoid ambiguity with @interface ("AnnotationTypeDeclaration" vs "Annotaion")
       GATE: () =>
-        ($.LA(1).tokenType === t.At && $.LA(2).tokenType === t.Interface) ===
-        false,
+        (tokenMatcher($.LA(1).tokenType, t.At) &&
+          tokenMatcher($.LA(2).tokenType, t.Interface)) === false,
       DEF: () => {
         // This alternation includes all possible modifiers for all types of "annotationTypeMemberDeclaration"
         // Certain combinations are syntactically invalid, this is **not** checked here,
@@ -412,10 +421,16 @@ function defineRules($, t) {
     });
 
     nextTokenType = this.LA(1).tokenType;
-    if (nextTokenType === t.Class || nextTokenType === t.Enum) {
+    if (
+      tokenMatcher(nextTokenType, t.Class) ||
+      tokenMatcher(nextTokenType, t.Enum)
+    ) {
       return AnnotationBodyTypes.classDeclaration;
     }
-    if (nextTokenType === t.Interface || nextTokenType === t.At) {
+    if (
+      tokenMatcher(nextTokenType, t.Interface) ||
+      tokenMatcher(nextTokenType, t.At)
+    ) {
       return AnnotationBodyTypes.interfaceDeclaration;
     }
 
@@ -427,11 +442,14 @@ function defineRules($, t) {
     nextTokenType = this.LA(1).tokenType;
     const nextNextTokenType = this.LA(2).tokenType;
     // "foo(..." --> look like annotationTypeElement start
-    if (nextTokenType === t.Identifier && nextNextTokenType === t.LBrace) {
+    if (
+      tokenMatcher(nextTokenType, t.Identifier) &&
+      tokenMatcher(nextNextTokenType, t.LBrace)
+    ) {
       return AnnotationBodyTypes.annotationTypeElementDeclaration;
     }
     // a valid constant
-    if (nextTokenType === t.Identifier) {
+    if (tokenMatcher(nextTokenType, t.Identifier)) {
       return AnnotationBodyTypes.constantDeclaration;
     }
     return AnnotationBodyTypes.unknown;

--- a/packages/java-parser/src/productions/names.js
+++ b/packages/java-parser/src/productions/names.js
@@ -1,4 +1,5 @@
 "use strict";
+const { tokenMatcher } = require("chevrotain");
 function defineRules($, t) {
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-6.html#jls-ModuleName
   $.RULE("moduleName", () => {
@@ -40,7 +41,7 @@ function defineRules($, t) {
       // expressionName could be called by "qualifiedExplicitConstructorInvocation"
       // in that case it may be followed by ".super" so we need to look two tokens
       // ahead.
-      GATE: () => this.LA(2).tokenType === t.Identifier,
+      GATE: () => tokenMatcher(this.LA(2).tokenType, t.Identifier),
       DEF: () => {
         $.CONSUME(t.Dot);
         $.CONSUME2(t.Identifier);
@@ -62,7 +63,7 @@ function defineRules($, t) {
       // only look a single token ahead (Dot) to determine if another iteration
       // exists which will cause a parsing error for inputs such as:
       // "import a.b.c.*"
-      GATE: () => this.LA(2).tokenType !== t.Star,
+      GATE: () => tokenMatcher(this.LA(2).tokenType, t.Star) === false,
       DEF: () => {
         $.CONSUME(t.Dot);
         $.CONSUME2(t.Identifier);

--- a/packages/java-parser/src/productions/packages-and-modules.js
+++ b/packages/java-parser/src/productions/packages-and-modules.js
@@ -1,5 +1,5 @@
 "use strict";
-const { isRecognitionException } = require("chevrotain");
+const { isRecognitionException, tokenMatcher } = require("chevrotain");
 
 function defineRules($, t) {
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#CompilationUnit
@@ -208,8 +208,8 @@ function defineRules($, t) {
       $.MANY2({
         // To avoid ambiguity with @interface ("AnnotationTypeDeclaration" vs "Annotaion")
         GATE: () =>
-          ($.LA(1).tokenType === t.At && $.LA(2).tokenType === t.Interface) ===
-          false,
+          (tokenMatcher($.LA(1).tokenType, t.At) &&
+            tokenMatcher($.LA(2).tokenType, t.Interface)) === false,
         DEF: () => {
           $.SUBRULE($.annotation);
         }
@@ -225,7 +225,10 @@ function defineRules($, t) {
       }
     }
     const nextTokenType = this.LA(1).tokenType;
-    return nextTokenType === t.Open || nextTokenType === t.Module;
+    return (
+      tokenMatcher(nextTokenType, t.Open) ||
+      tokenMatcher(nextTokenType, t.Module)
+    );
   });
 }
 

--- a/packages/java-parser/src/productions/types-values-and-variables.js
+++ b/packages/java-parser/src/productions/types-values-and-variables.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { tokenMatcher } = require("chevrotain");
+
 function defineRules($, t) {
   // ---------------------
   // Productions from §4 (Types, Values, and Variables)
@@ -103,7 +105,7 @@ function defineRules($, t) {
         // To avoid confusion with "TypeArgumentsOrDiamond" rule
         // as we use the "classType" rule in the "identifyNewExpressionType"
         // optimized lookahead rule.
-        GATE: () => $.LA(2).tokenType !== t.Greater,
+        GATE: () => tokenMatcher($.LA(2).tokenType, t.Greater) === false,
         DEF: () => {
           $.SUBRULE2($.typeArguments);
         }


### PR DESCRIPTION
I this PR I changed the comparison of tokenType with "===" by tokenMatcher as it supports token categories and at the same time it fix #138.