### PR TITLE
Fix try with resources: acception semicolon as last token

### DIFF
--- a/packages/java-parser/src/productions/blocks-and-statements.js
+++ b/packages/java-parser/src/productions/blocks-and-statements.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { tokenMatcher } = require("chevrotain");
+
 // Spec Deviation: The "*NoShortIf" variations were removed as the ambiguity of
 //                 the dangling else is resolved by attaching an "else" block
 //                 to the nearest "if"
@@ -422,9 +424,12 @@ function defineRules($, t) {
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-ResourceList
   $.RULE("resourceList", () => {
     $.SUBRULE($.resource);
-    $.MANY(() => {
-      $.CONSUME(t.Semicolon);
-      $.SUBRULE2($.resource);
+    $.MANY({
+      GATE: () => tokenMatcher($.LA(2).tokenType, t.RBrace) === false,
+      DEF: () => {
+        $.CONSUME(t.Semicolon);
+        $.SUBRULE2($.resource);
+      }
     });
   });
 


### PR DESCRIPTION
Hello, this time I tried to parse the jenkins repository and it failed at this line https://github.com/jenkinsci/jenkins/blob/master/test/src/test/java/hudson/cli/CLITest.java#L268 due to the semicolon at the end of the try with resources. The problem is similar to #142 and can be fixed with a GATE as well.