### PR TITLE
Fix the running test

### DIFF
--- a/packages/java-parser/test/samples-spec.js
+++ b/packages/java-parser/test/samples-spec.js
@@ -28,7 +28,7 @@ describe("The Java Parser", () => {
   createSampleSpecs("jhipster-sample-app-oauth2");
   createSampleSpecs("jhipster-sample-app-react");
   createSampleSpecs("jhipster-sample-app-websocket");
-  createFailingSampleSpec("guava", 8, 0);
+  createFailingSampleSpec("guava", 4, 0);
 });
 
 function createSampleSpecs(sampleName) {


### PR DESCRIPTION
Since we fixed #147, the tests are failing with Guava repository because it expects 8 fails, but the fix reduced the number of fails down to 4.