### PR TITLE
Fix brackets considered as a cast

### DIFF
--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -250,8 +250,10 @@ function defineRules($, t) {
     ]);
   });
 
+  // See https://github.com/jhipster/prettier-java/pull/154 to understand
+  // why fqnOrRefTypePart is split in two rules (First and Rest)
   $.RULE("fqnOrRefType", () => {
-    $.SUBRULE($.fqnOrRefTypePart);
+    $.SUBRULE($.fqnOrRefTypePartFirst);
 
     $.MANY2({
       // ".class" is a classLiteralSuffix
@@ -262,7 +264,7 @@ function defineRules($, t) {
         tokenMatcher(this.LA(2).tokenType, t.New) === false,
       DEF: () => {
         $.CONSUME(t.Dot);
-        $.SUBRULE2($.fqnOrRefTypePart);
+        $.SUBRULE2($.fqnOrRefTypePartRest);
       }
     });
 
@@ -285,7 +287,7 @@ function defineRules($, t) {
   //       3. "Super" cannot be mixed with "classTypeArguments" or "annotation".
   //       4. At most one "Super" may be used.
   //       5. "Super" may be last or one before last (last may also be first if there is only a single part).
-  $.RULE("fqnOrRefTypePart", () => {
+  $.RULE("fqnOrRefTypePartRest", () => {
     $.MANY(() => {
       $.SUBRULE($.annotation);
     });
@@ -297,6 +299,10 @@ function defineRules($, t) {
       }
     });
 
+    $.SUBRULE($.fqnOrRefTypePartCommon);
+  });
+
+  $.RULE("fqnOrRefTypePartCommon", () => {
     $.OR([
       { ALT: () => $.CONSUME(t.Identifier) },
       { ALT: () => $.CONSUME(t.Super) }
@@ -322,6 +328,14 @@ function defineRules($, t) {
         $.SUBRULE3($.typeArguments);
       }
     });
+  });
+
+  $.RULE("fqnOrRefTypePartFirst", () => {
+    $.MANY(() => {
+      $.SUBRULE($.annotation);
+    });
+
+    $.SUBRULE($.fqnOrRefTypePartCommon);
   });
 
   $.RULE("parenthesisExpression", () => {

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -32,3 +32,15 @@ describe("The Java Parser fixed bugs", () => {
     ).to.not.throw();
   });
 });
+
+describe("The Java Parser fixed bugs", () => {
+  it("cast expression, parenthesis and binary shift", () => {
+    const input = "(left) << right";
+    expect(() => javaParser.parse(input, "expression")).to.not.throw();
+  });
+
+  it("cast expression, parenthesis and lessThan", () => {
+    const input = "(left) < right";
+    expect(() => javaParser.parse(input, "expression")).to.not.throw();
+  });
+});


### PR DESCRIPTION
This time I was trying to parse the elasticsearch repository, I have multiple fails caused due to different bugs (8 files that fails, 5 of them are fixed with the PR #152 ). Two of them is due to this kind of line ```return (long)(left) << right;``` https://github.com/elastic/elasticsearch/blob/master/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java#L964 and https://github.com/elastic/elasticsearch/blob/v6.6.1/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IndexableBinaryStringTools.java#L188.
This is the rule stack:
```
[ 'typeDeclaration',
        'classDeclaration',
        'normalClassDeclaration',
        'classBody',
        'classBodyDeclaration',
        'classMemberDeclaration',
        'methodDeclaration',
        'methodBody',
        'block',
        'blockStatements',
        'blockStatement',
        'statement',
        'statementWithoutTrailingSubstatement',
        'returnStatement',
        'expression',
        'ternaryExpression',
        'binaryExpression',
        'unaryExpression',
        'primary',
        'primaryPrefix',
        'castExpression',
        'primitiveCastExpression',
        'unaryExpression',
        'primary',
        'primaryPrefix',
        'castExpression',
        'referenceTypeCastExpression',
        'unaryExpressionNotPlusMinus',
        'primary',
        'primaryPrefix',
        'fqnOrRefType',
        'fqnOrRefTypePart',
        'typeArguments',
        'typeArgumentList',
        'typeArgument' ]
```
It seems that the (long) is recognized as a cast which true but (left) is also recognized as a cast.
But this problem is only present when it is followed by ```<<``` or ```>>```.
This is due to the rule "isCastExpression" return true for (left) because **firstForUnaryExpressionNotPlusMinus** contains ">" and "<" tokens. The only fix I thought of is to manually check the next token. I don't really know if there is a better way to fix it.