### PR TITLE
fix lexer: case where the lexer recognize OctalLiteral instead of Flo…

### DIFF
--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -126,7 +126,6 @@ createToken({
   group: "comments"
 });
 createToken({ name: "BinaryLiteral", pattern: /0[bB][01]([01_]*[01])?[lL]?/ });
-createToken({ name: "OctalLiteral", pattern: /0_*[0-7]([0-7_]*[0-7])?[lL]?/ });
 createToken({
   name: "FloatLiteral",
   pattern: MAKE_PATTERN(
@@ -136,6 +135,7 @@ createToken({
       "{{Digits}}({{ExponentPart}})?{{FloatTypeSuffix}}"
   )
 });
+createToken({ name: "OctalLiteral", pattern: /0_*[0-7]([0-7_]*[0-7])?[lL]?/ });
 createToken({
   name: "HexFloatLiteral",
   pattern: MAKE_PATTERN(


### PR DESCRIPTION
…atLiteral

I was still trying to parse elasticsearch and I found another file that did not parse https://github.com/elastic/elasticsearch/blob/v6.6.1/server/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java#L239.
The lexer is the culprit due to ```001.0``` to be recognized as 2 distinct tokens (001 as an octalLiteral and .0 as a FloatLiteral). Since the lexer choose the first match, a simple fix is to swap the order of creation between an OctalLiteral and FloatLiteral.
This bug should be the last one for this repository (#152 and #154).