### PR TITLE
fix imports accept double semi-colon

### DIFF
--- a/packages/java-parser/src/productions/packages-and-modules.js
+++ b/packages/java-parser/src/productions/packages-and-modules.js
@@ -64,9 +64,6 @@ function defineRules($, t) {
     //                 distinguishing between the alternatives due to unbound common prefix.
     // TODO: A post parsing step is required to align with the official specs.
     //       The Identifier "var" is not allowed in all positions and variations of the importDeclaration
-    // Spec Deviation: The spec do not allow empty statement in between imports.
-    //                 However Java compiler consider empty statements valid, we chose
-    //                 to support that case, thus deviate from the spec.
     $.OR([
       {
         ALT: () => {
@@ -82,6 +79,10 @@ function defineRules($, t) {
           $.CONSUME(t.Semicolon);
         }
       },
+      // Spec Deviation: The spec do not allow empty statement in between imports.
+      //                 However Java compiler consider empty statements valid, we chose
+      //                 to support that case, thus deviate from the spec.
+      //                 See here: https://github.com/jhipster/prettier-java/pull/158
       {
         ALT: () => $.SUBRULE($.emptyStatement)
       }

--- a/packages/java-parser/src/productions/packages-and-modules.js
+++ b/packages/java-parser/src/productions/packages-and-modules.js
@@ -64,16 +64,28 @@ function defineRules($, t) {
     //                 distinguishing between the alternatives due to unbound common prefix.
     // TODO: A post parsing step is required to align with the official specs.
     //       The Identifier "var" is not allowed in all positions and variations of the importDeclaration
-    $.CONSUME(t.Import);
-    $.OPTION(() => {
-      $.CONSUME(t.Static);
-    });
-    $.SUBRULE($.packageOrTypeName);
-    $.OPTION2(() => {
-      $.CONSUME(t.Dot);
-      $.CONSUME(t.Star);
-    });
-    $.CONSUME(t.Semicolon);
+    // Spec Deviation: The spec do not allow empty statement in between imports.
+    //                 However Java compiler consider empty statements valid, we chose
+    //                 to support that case, thus deviate from the spec.
+    $.OR([
+      {
+        ALT: () => {
+          $.CONSUME(t.Import);
+          $.OPTION(() => {
+            $.CONSUME(t.Static);
+          });
+          $.SUBRULE($.packageOrTypeName);
+          $.OPTION2(() => {
+            $.CONSUME(t.Dot);
+            $.CONSUME(t.Star);
+          });
+          $.CONSUME(t.Semicolon);
+        }
+      },
+      {
+        ALT: () => $.SUBRULE($.emptyStatement)
+      }
+    ]);
   });
 
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#jls-TypeDeclaration

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -23,3 +23,12 @@ describe("The Java Parser fixed bugs", () => {
     expect(() => javaParser.parse(input)).to.not.throw();
   });
 });
+
+describe("The Java Parser fixed bugs", () => {
+  it("issue #158 - semicolons inside imports", () => {
+    const input = "import Foo;;import Bar;";
+    expect(() =>
+      javaParser.parse(input, "ordinaryCompilationUnit")
+    ).to.not.throw();
+  });
+});


### PR DESCRIPTION
Hello, this time the parser failed with https://github.com/thinkaurelius/titan/blob/titan10/titan-all/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/plugin/TitanGremlinPlugin.java#L12. This is due to the double semi-colon ```;;``` that is accepted by Java. I did an ad hoc fix that does not look pretty..., another solution would also be to add a big OPTION in "importDeclaration" rule.
But honestly I think ```;;``` is really ugly and I just want to PR the repository to delete the semi-colon :joy:.