### PR TITLE
fix(providesModuleDirective parser): parse missing typeName

### DIFF
--- a/packages/java-parser/src/productions/packages-and-modules.js
+++ b/packages/java-parser/src/productions/packages-and-modules.js
@@ -174,11 +174,12 @@ function defineRules($, t) {
   $.RULE("providesModuleDirective", () => {
     // Spec Deviation: extracted from "moduleDirective"
     $.CONSUME(t.Provides);
-    $.CONSUME(t.With);
     $.SUBRULE($.typeName);
+    $.CONSUME(t.With);
+    $.SUBRULE2($.typeName);
     $.MANY(() => {
       $.CONSUME(t.Comma);
-      $.SUBRULE2($.typeName);
+      $.SUBRULE3($.typeName);
     });
     $.CONSUME(t.Semicolon);
   });


### PR DESCRIPTION
See https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#jls-ModuleDirective

Fix parsing of

```java
module com.client.myservicelient {
  provides fr.soat.vending.machine.services.DrinksService
  with fr.soat.coffee.maker.CoffeeService;
}
```