### PR TITLE
fix annotation in packageDeclaration

### DIFF
--- a/packages/java-parser/src/productions/packages-and-modules.js
+++ b/packages/java-parser/src/productions/packages-and-modules.js
@@ -19,11 +19,14 @@ function defineRules($, t) {
 
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#jls-OrdinaryCompilationUnit
   $.RULE("ordinaryCompilationUnit", () => {
-    $.OPTION(() => {
-      $.SUBRULE($.packageDeclaration);
+    $.OPTION({
+      GATE: $.BACKTRACK($.packageDeclaration),
+      DEF: () => {
+        $.SUBRULE($.packageDeclaration);
+      }
     });
     $.MANY(() => {
-      $.SUBRULE($.importDeclaration);
+      $.SUBRULE3($.importDeclaration);
     });
     $.MANY2(() => {
       $.SUBRULE($.typeDeclaration);

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -32,3 +32,10 @@ describe("The Java Parser fixed bugs", () => {
     ).to.not.throw();
   });
 });
+
+describe("The Java Parser fixed bugs", () => {
+  it("issue #177 - annotation in packageDeclaration", () => {
+    const input = "@Test public class Foo{}";
+    expect(() => javaParser.parse(input)).to.not.throw();
+  });
+});


### PR DESCRIPTION
The parser fails with the following code (thanks @clement26695  for having found this bug :smile: ) :
```JAVA
@Test
public class Foo{}
```
The parser go to the rule ```packageDeclaration``` instead of ```typeDeclaration``` because both can start with annotation. This can be easily fixed with a Gate and I have not found a way to make it work without it.