### PR TITLE
attach comments to tokens

### DIFF
--- a/packages/java-parser/src/index.js
+++ b/packages/java-parser/src/index.js
@@ -14,7 +14,6 @@ const BaseJavaCstVisitorWithDefaults = parser.getBaseCstVisitorConstructorWithDe
 function parse(inputText, entryPoint = "compilationUnit") {
   // Lex
   const lexResult = JavaLexer.tokenize(inputText);
-  parser.input = lexResult.tokens;
 
   if (lexResult.errors.length > 0) {
     const firstError = lexResult.errors[0];
@@ -27,6 +26,8 @@ function parse(inputText, entryPoint = "compilationUnit") {
         firstError.message
     );
   }
+
+  parser.input = attachComments(lexResult.tokens, lexResult.groups.comments);
 
   // Automatic CST created when parsing
   const cst = parser[entryPoint]();
@@ -45,6 +46,71 @@ function parse(inputText, entryPoint = "compilationUnit") {
   }
 
   return cst;
+}
+
+function attachComments(tokens, comments) {
+  const attachComments = [...comments];
+
+  // edge case: when the file start with comments, it attaches as leadingComments to the first token
+  const firstToken = tokens[0];
+  const headComments = [];
+  while (
+    attachComments.length > 0 &&
+    attachComments[0].endOffset < firstToken.startOffset
+  ) {
+    headComments.push(attachComments[0]);
+    attachComments.splice(0, 1);
+  }
+
+  if (headComments.length > 0) {
+    firstToken.leadingComments = headComments;
+  }
+
+  // edge case: when the file end with comments, it attaches as trailingComments to the last token
+  const lastToken = tokens[tokens.length - 1];
+  const tailComments = [];
+  while (
+    attachComments.length > 0 &&
+    attachComments[attachComments.length - 1].startOffset > lastToken.endOffset
+  ) {
+    tailComments.push(attachComments[attachComments.length - 1]);
+    attachComments.splice(attachComments.length - 1, 1);
+  }
+
+  if (tailComments.length > 0) {
+    lastToken.trailingComments = tailComments.reverse();
+  }
+
+  let currentToken = 0;
+  attachComments.forEach(element => {
+    // find the correct position to place the comment
+    while (
+      !(
+        element.startOffset > tokens[currentToken].endOffset &&
+        element.endOffset < tokens[currentToken + 1].startOffset
+      )
+    ) {
+      currentToken++;
+    }
+
+    // attach comment to the closest token
+    if (
+      element.startOffset - tokens[currentToken].endOffset <=
+      tokens[currentToken + 1].startOffset - element.endOffset
+    ) {
+      if (!tokens[currentToken].hasOwnProperty("trailingComments")) {
+        tokens[currentToken].trailingComments = [];
+      }
+      tokens[currentToken].trailingComments.push(element);
+    } else {
+      if (!tokens[currentToken + 1].hasOwnProperty("leadingComments")) {
+        tokens[currentToken + 1].leadingComments = [];
+      }
+      tokens[currentToken + 1].leadingComments.push(element);
+    }
+  });
+
+  return tokens;
 }
 
 module.exports = {


### PR DESCRIPTION
I have added the comment attachment on tokens in the parser.
Since the cst printer is using the npm java-parser and not the one from the master, can we release a new version ? Since I need the comment attachment to add the support of comment in the cst printer.