### PR TITLE
fix(tryWithResourcesStatement): fix printing with multiple resources

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
@@ -463,19 +463,19 @@ class BlocksAndStatementPrettierVisitor {
     const resourceList = this.visit(ctx.resourceList);
     const optionalSemicolon = ctx.Semicolon ? ctx.Semicolon[0] : "";
 
-    return rejectAndConcat([
+    return putIntoBraces(
+      rejectAndConcat([resourceList, optionalSemicolon]),
+      softline,
       ctx.LBrace[0],
-      resourceList,
-      optionalSemicolon,
       ctx.RBrace[0]
-    ]);
+    );
   }
 
   resourceList(ctx) {
     const resources = this.mapVisit(ctx.resource);
     const semicolons = ctx.Semicolon
       ? ctx.Semicolon.map(elt => {
-          return concat([elt, " "]);
+          return concat([elt, line]);
         })
       : [""];
     return rejectAndJoinSeps(semicolons, resources);

--- a/packages/prettier-plugin-java/test/unit-test/try_catch/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/try_catch/_input.java
@@ -54,4 +54,12 @@ public class TryCatch {
     }
   }
 
+  void multiResourceTry() {
+    try (FirstResource firstResource = new FirstResource(); SecondResource secondResource = new SecondResource()) {
+      return br.readLine();
+    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
+      System.out.println("Warning: Not breaking multi exceptions");
+    }
+  }
+
 }

--- a/packages/prettier-plugin-java/test/unit-test/try_catch/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/try_catch/_output.java
@@ -57,4 +57,15 @@ public class TryCatch {
       System.out.println("Warning: Not breaking multi exceptions");
     }
   }
+
+  void multiResourceTry() {
+    try (
+      FirstResource firstResource = new FirstResource();
+      SecondResource secondResource = new SecondResource()
+    ) {
+      return br.readLine();
+    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
+      System.out.println("Warning: Not breaking multi exceptions");
+    }
+  }
 }


### PR DESCRIPTION
Format 

```java
void multiResourceTry() {
    try (FirstResource firstResource = new FirstResource(); SecondResource secondResource = new SecondResource()) {
      return br.readLine();
    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
      System.out.println("Warning: Not breaking multi exceptions");
    }
}
```
to 
```java
void multiResourceTry() {
    try (
      FirstResource firstResource = new FirstResource();
      SecondResource secondResource = new SecondResource()
    ) {
      return br.readLine();
    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
      System.out.println("Warning: Not breaking multi exceptions");
    }
}
```
