### PR TITLE
refactor: extract curly braces blocks logic into printer-utils

### DIFF
--- a/packages/prettier-plugin-java/src/printers/arrays.js
+++ b/packages/prettier-plugin-java/src/printers/arrays.js
@@ -1,9 +1,12 @@
 "use strict";
 /* eslint-disable no-unused-vars */
 
-const { line } = require("prettier").doc.builders;
-const { group, indent } = require("./prettier-builder");
-const { rejectAndConcat, rejectAndJoinSeps } = require("./printer-utils");
+const { line, softline } = require("prettier").doc.builders;
+const {
+  rejectAndConcat,
+  rejectAndJoinSeps,
+  putIntoCurlyBraces
+} = require("./printer-utils");
 
 class ArraysPrettierVisitor {
   arrayInitializer(ctx) {
@@ -12,17 +15,11 @@ class ArraysPrettierVisitor {
     );
     const optionalComma = ctx.Comma ? ctx.Comma[0] : "";
 
-    const separator = ctx.variableInitializerList || ctx.Comma ? line : "";
-
-    return group(
-      rejectAndConcat([
-        ctx.LCurly[0],
-        indent(
-          rejectAndConcat([optionalVariableInitializerList, optionalComma])
-        ),
-        separator,
-        ctx.RCurly[0]
-      ])
+    return putIntoCurlyBraces(
+      rejectAndConcat([optionalVariableInitializerList, optionalComma]),
+      line,
+      ctx.LCurly[0],
+      ctx.RCurly[0]
     );
   }
 
@@ -34,10 +31,7 @@ class ArraysPrettierVisitor {
         })
       : [];
 
-    return rejectAndConcat([
-      line,
-      rejectAndJoinSeps(commas, variableInitializers)
-    ]);
+    return rejectAndJoinSeps(commas, variableInitializers);
   }
 }
 

--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
@@ -11,39 +11,25 @@ const {
 } = require("./prettier-builder");
 const {
   displaySemicolon,
-  hasLeadingComments,
-  hasTrailingComments,
   rejectAndConcat,
   rejectAndJoin,
   rejectAndJoinSeps,
   getBlankLinesSeparator,
   rejectSeparators,
-  putIntoBraces
+  putIntoBraces,
+  putIntoCurlyBraces
 } = require("./printer-utils");
 
 class BlocksAndStatementPrettierVisitor {
   block(ctx) {
     const blockStatements = this.visit(ctx.blockStatements);
 
-    if (blockStatements !== "") {
-      return putIntoBraces(
-        blockStatements,
-        hardline,
-        ctx.LCurly[0],
-        ctx.RCurly[0]
-      );
-    }
-
-    if (
-      hasTrailingComments(ctx.LCurly[0]) ||
-      hasLeadingComments(ctx.RCurly[0])
-    ) {
-      // TODO: Find a more efficient way to deal with comments in empty block
-      // It does not work with multi-lines comments, for instance
-      return concat([ctx.LCurly[0], indent(hardline), ctx.RCurly[0]]);
-    }
-
-    return concat([ctx.LCurly[0], ctx.RCurly[0]]);
+    return putIntoCurlyBraces(
+      blockStatements,
+      hardline,
+      ctx.LCurly[0],
+      ctx.RCurly[0]
+    );
   }
 
   blockStatements(ctx) {

--- a/packages/prettier-plugin-java/src/printers/interfaces.js
+++ b/packages/prettier-plugin-java/src/printers/interfaces.js
@@ -15,8 +15,7 @@ const {
   sortModifiers,
   rejectAndJoinSeps,
   putIntoBraces,
-  hasTrailingComments,
-  hasLeadingComments
+  putIntoCurlyBraces
 } = require("./printer-utils");
 
 class InterfacesPrettierVisitor {
@@ -88,25 +87,12 @@ class InterfacesPrettierVisitor {
       interfaceMemberDeclaration
     );
 
-    if (joinedInterfaceMemberDeclaration !== "") {
-      return putIntoBraces(
-        joinedInterfaceMemberDeclaration,
-        hardline,
-        ctx.LCurly[0],
-        ctx.RCurly[0]
-      );
-    }
-
-    if (
-      hasTrailingComments(ctx.LCurly[0]) ||
-      hasLeadingComments(ctx.RCurly[0])
-    ) {
-      // TODO: Find a more efficient way to deal with comments in empty interface body
-      // It does not work with multi-lines comments, for instance
-      return concat([ctx.LCurly[0], indent(hardline), ctx.RCurly[0]]);
-    }
-
-    return concat([ctx.LCurly[0], ctx.RCurly[0]]);
+    return putIntoCurlyBraces(
+      joinedInterfaceMemberDeclaration,
+      hardline,
+      ctx.LCurly[0],
+      ctx.RCurly[0]
+    );
   }
 
   interfaceMemberDeclaration(ctx) {

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -282,6 +282,18 @@ function putIntoBraces(argument, separator, LBrace, RBrace) {
   );
 }
 
+function putIntoCurlyBraces(argument, separator, LBrace, RBrace) {
+  if (argument !== undefined && argument !== "") {
+    return putIntoBraces(argument, separator, LBrace, RBrace);
+  }
+
+  if (hasTrailingComments(LBrace) || hasLeadingComments(RBrace)) {
+    return concat([LBrace, indent(hardline), RBrace]);
+  }
+
+  return concat([LBrace, RBrace]);
+}
+
 module.exports = {
   buildFqn,
   reject,
@@ -302,5 +314,6 @@ module.exports = {
   displaySemicolon,
   rejectSeparators,
   handleClassBodyDeclaration,
-  putIntoBraces
+  putIntoBraces,
+  putIntoCurlyBraces
 };


### PR DESCRIPTION
The logic to create a curly braces block was duplicated. This PR is to excract this logic to limit code duplication.

The putIntoCurlyBraces function is to print curly braces bloc with correct indentation, and handling empty curly braces block with just an inner comment. 