### PR TITLE
Fix comment only code

### DIFF
--- a/packages/java-parser/src/index.js
+++ b/packages/java-parser/src/index.js
@@ -57,7 +57,7 @@ function attachComments(tokens, comments) {
 
   // edge case: when the file only contains comments
   if (tokens.length === 1) {
-    tokens[0].trailingComments = [...comments];
+    tokens[0].leadingComments = [...comments];
     return tokens;
   }
 

--- a/packages/java-parser/src/index.js
+++ b/packages/java-parser/src/index.js
@@ -43,6 +43,8 @@ function parse(inputText, entryPoint = "compilationUnit") {
 
   if (lexResult.tokens.length === 0) {
     const EOF = Object.assign({}, cst.children.EOF[0]);
+    EOF.startOffset = Number.MAX_SAFE_INTEGER;
+    EOF.endOffset = Number.MAX_SAFE_INTEGER;
     cst.children.EOF = [EOF];
     attachComments(cst.children.EOF, lexResult.groups.comments);
   } else {
@@ -55,9 +57,21 @@ function parse(inputText, entryPoint = "compilationUnit") {
 function attachComments(tokens, comments) {
   const attachComments = [...comments];
 
-  // edge case: when the file only contains comments
+  // edge case: when the file contains only one token (;/if no token then EOF)
   if (tokens.length === 1) {
-    tokens[0].leadingComments = [...comments];
+    attachComments.forEach(comment => {
+      if (comment.endOffset < tokens[0].startOffset) {
+        if (!tokens[0].leadingComments) {
+          tokens[0].leadingComments = [];
+        }
+        tokens[0].leadingComments.push(comment);
+      } else {
+        if (!tokens[0].trailingComments) {
+          tokens[0].trailingComments = [];
+        }
+        tokens[0].trailingComments.push(comment);
+      }
+    });
     return tokens;
   }
 

--- a/packages/java-parser/src/index.js
+++ b/packages/java-parser/src/index.js
@@ -27,10 +27,32 @@ function parse(inputText, entryPoint = "compilationUnit") {
     );
   }
 
-  parser.input = attachComments(lexResult.tokens, lexResult.groups.comments);
+  const existToken = lexResult.tokens.length !== 0;
+  const tokenMock = [
+    {
+      image: "",
+      startOffset: 1,
+      endOffset: Infinity,
+      startLine: 1,
+      endLine: Infinity,
+      startColumn: 1,
+      endColumn: Infinity,
+      tokenTypeIdx: 91
+    }
+  ];
+
+  let cst;
+  if (existToken) {
+    parser.input = attachComments(lexResult.tokens, lexResult.groups.comments);
+    cst = parser[entryPoint]();
+  } else {
+    parser.input = tokenMock;
+    parser.input[0].trailingComments = [...lexResult.groups.comments];
+    cst = parser["emptyStatement"]();
+  }
 
   // Automatic CST created when parsing
-  const cst = parser[entryPoint]();
+
   if (parser.errors.length > 0) {
     const error = parser.errors[0];
     throw Error(

--- a/packages/java-parser/src/index.js
+++ b/packages/java-parser/src/index.js
@@ -2,14 +2,9 @@
 const JavaLexer = require("./lexer");
 const JavaParser = require("./parser");
 
-// const startTime = new Date().getTime();
 const parser = new JavaParser();
 const BaseJavaCstVisitor = parser.getBaseCstVisitorConstructor();
 const BaseJavaCstVisitorWithDefaults = parser.getBaseCstVisitorConstructorWithDefaults();
-
-// const endTime = new Date().getTime();
-// const totalTime = endTime - startTime;
-// console.log("parse start time (ms): " + totalTime);
 
 function parse(inputText, entryPoint = "compilationUnit") {
   // Lex

--- a/packages/java-parser/src/productions/packages-and-modules.js
+++ b/packages/java-parser/src/productions/packages-and-modules.js
@@ -1,5 +1,5 @@
 "use strict";
-const { isRecognitionException, tokenMatcher } = require("chevrotain");
+const { isRecognitionException, tokenMatcher, EOF } = require("chevrotain");
 
 function defineRules($, t) {
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#CompilationUnit
@@ -15,6 +15,8 @@ function defineRules($, t) {
         ALT: () => $.SUBRULE($.modularCompilationUnit)
       }
     ]);
+    // https://github.com/jhipster/prettier-java/pull/217
+    $.CONSUME(EOF);
   });
 
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-7.html#jls-OrdinaryCompilationUnit

--- a/packages/prettier-plugin-java/src/printers/packages-and-modules.js
+++ b/packages/prettier-plugin-java/src/printers/packages-and-modules.js
@@ -14,9 +14,9 @@ const {
 
 class PackagesAndModulesPrettierVisitor {
   compilationUnit(ctx) {
-    const EOF = ctx.EOF[0];
-    delete ctx.EOF;
-    return concat([this.visitSingle(ctx), EOF]);
+    const compilationUnit =
+      ctx.ordinaryCompilationUnit || ctx.modularCompilationUnit;
+    return concat([this.visit(compilationUnit), ctx.EOF[0]]);
   }
 
   ordinaryCompilationUnit(ctx) {

--- a/packages/prettier-plugin-java/src/printers/packages-and-modules.js
+++ b/packages/prettier-plugin-java/src/printers/packages-and-modules.js
@@ -14,7 +14,9 @@ const {
 
 class PackagesAndModulesPrettierVisitor {
   compilationUnit(ctx) {
-    return this.visitSingle(ctx);
+    const EOF = ctx.EOF[0];
+    delete ctx.EOF;
+    return concat([this.visitSingle(ctx), EOF]);
   }
 
   ordinaryCompilationUnit(ctx) {

--- a/packages/prettier-plugin-java/src/printers/prettier-builder.js
+++ b/packages/prettier-plugin-java/src/printers/prettier-builder.js
@@ -48,7 +48,7 @@ function getImageWithComments(token) {
 function formatComment(comment) {
   const res = [];
   comment.image.split("\n").forEach(l => {
-    res.push(l.trim());
+    res.push(l);
     res.push(prettier.hardline);
   });
   if (res[res.length - 1] === prettier.hardline) {

--- a/packages/prettier-plugin-java/src/printers/prettier-builder.js
+++ b/packages/prettier-plugin-java/src/printers/prettier-builder.js
@@ -62,7 +62,7 @@ function formatComment(comment) {
 }
 
 function isToken(doc) {
-  return doc && doc.image && doc.tokenType;
+  return doc && doc.hasOwnProperty("image") && doc.tokenType;
 }
 
 function processComments(docs) {

--- a/packages/prettier-plugin-java/src/printers/prettier-builder.js
+++ b/packages/prettier-plugin-java/src/printers/prettier-builder.js
@@ -48,7 +48,11 @@ function getImageWithComments(token) {
 function formatComment(comment) {
   const res = [];
   comment.image.split("\n").forEach(l => {
-    res.push(l);
+    if (l.match(/(\s+)(\*)(.*)/gm)) {
+      res.push(l.trim());
+    } else {
+      res.push(l);
+    }
     res.push(prettier.hardline);
   });
   if (res[res.length - 1] === prettier.hardline) {

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-only/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-only/_input.java
@@ -1,4 +1,3 @@
-
 /*
 * # Copyright 2013-2019 the original author or authors from the JHipster project.
 * #

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-only/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-only/_input.java
@@ -1,0 +1,70 @@
+
+/*
+* # Copyright 2013-2019 the original author or authors from the JHipster project.
+* #
+* # This file is part of the JHipster project, see https://www.jhipster.tech/
+* # for more information.
+* #
+* # Licensed under the Apache License, Version 2.0 (the "License");
+* # you may not use this file except in compliance with the License.
+* # You may obtain a copy of the License at
+* #
+* #      http://www.apache.org/licenses/LICENSE-2.0
+* #
+* # Unless required by applicable law or agreed to in writing, software
+* # distributed under the License is distributed on an "AS IS" BASIS,
+* # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* # See the License for the specific language governing permissions and
+* # limitations under the License.
+* #
+*/
+/*
+package io.github.jhipster.sample.repository;
+
+import io.github.jhipster.sample.domain.User;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.time.Instant;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    String USERS_BY_LOGIN_CACHE = "usersByLogin";
+
+    String USERS_BY_EMAIL_CACHE = "usersByEmail";
+
+    Optional<User> findOneByActivationKey(String activationKey);
+
+
+    List<User> findAllByActivatedIsFalseAndActivationKeyIsNotNullAndCreatedDateBefore(Instant dateTime);
+
+
+    Optional<User> findOneByResetKey(String resetKey);
+
+    Optional<User> findOneByEmailIgnoreCase(String email);
+
+    Optional<User> findOneByLogin(String login);
+
+    @EntityGraph(attributePaths = "authorities")
+    Optional<User> findOneWithAuthoritiesById(Long id);
+
+    @EntityGraph(attributePaths = "authorities")
+    @Cacheable(cacheNames = USERS_BY_LOGIN_CACHE)
+    Optional<User> findOneWithAuthoritiesByLogin(String login);
+
+    @EntityGraph(attributePaths = "authorities")
+    @Cacheable(cacheNames = USERS_BY_EMAIL_CACHE)
+    Optional<User> findOneWithAuthoritiesByEmail(String email);
+
+    Page<User> findAllByLoginNot(Pageable pageable, String login);
+}
+*/

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-only/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-only/_output.java
@@ -1,0 +1,70 @@
+
+/*
+* # Copyright 2013-2019 the original author or authors from the JHipster project.
+* #
+* # This file is part of the JHipster project, see https://www.jhipster.tech/
+* # for more information.
+* #
+* # Licensed under the Apache License, Version 2.0 (the "License");
+* # you may not use this file except in compliance with the License.
+* # You may obtain a copy of the License at
+* #
+* #      http://www.apache.org/licenses/LICENSE-2.0
+* #
+* # Unless required by applicable law or agreed to in writing, software
+* # distributed under the License is distributed on an "AS IS" BASIS,
+* # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* # See the License for the specific language governing permissions and
+* # limitations under the License.
+* #
+*/
+/*
+package io.github.jhipster.sample.repository;
+
+import io.github.jhipster.sample.domain.User;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.time.Instant;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    String USERS_BY_LOGIN_CACHE = "usersByLogin";
+
+    String USERS_BY_EMAIL_CACHE = "usersByEmail";
+
+    Optional<User> findOneByActivationKey(String activationKey);
+
+
+    List<User> findAllByActivatedIsFalseAndActivationKeyIsNotNullAndCreatedDateBefore(Instant dateTime);
+
+
+    Optional<User> findOneByResetKey(String resetKey);
+
+    Optional<User> findOneByEmailIgnoreCase(String email);
+
+    Optional<User> findOneByLogin(String login);
+
+    @EntityGraph(attributePaths = "authorities")
+    Optional<User> findOneWithAuthoritiesById(Long id);
+
+    @EntityGraph(attributePaths = "authorities")
+    @Cacheable(cacheNames = USERS_BY_LOGIN_CACHE)
+    Optional<User> findOneWithAuthoritiesByLogin(String login);
+
+    @EntityGraph(attributePaths = "authorities")
+    @Cacheable(cacheNames = USERS_BY_EMAIL_CACHE)
+    Optional<User> findOneWithAuthoritiesByEmail(String email);
+
+    Page<User> findAllByLoginNot(Pageable pageable, String login);
+}
+*/

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-spec.js
@@ -7,4 +7,5 @@ describe("prettier-java", () => {
   testSample(path.resolve(__dirname, "./interface"));
   testSample(path.resolve(__dirname, "./package"));
   testSample(path.resolve(__dirname, "./comments-blocks-and-statements"));
+  testSample(path.resolve(__dirname, "./comments-only"));
 });

--- a/packages/prettier-plugin-java/test/unit-test/comments/edge/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/edge/_output.java
@@ -1,206 +1,206 @@
 /*
 
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-1. Definitions.
+   1. Definitions.
 
-"License" shall mean the terms and conditions for use, reproduction,
-and distribution as defined by Sections 1 through 9 of this document.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-"Licensor" shall mean the copyright owner or entity authorized by
-the copyright owner that is granting the License.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-"Legal Entity" shall mean the union of the acting entity and all
-other entities that control, are controlled by, or are under common
-control with that entity. For the purposes of this definition,
-"control" means (i) the power, direct or indirect, to cause the
-direction or management of such entity, whether by contract or
-otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-"You" (or "Your") shall mean an individual or Legal Entity
-exercising permissions granted by this License.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-"Source" form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation
-source, and configuration files.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-"Object" form shall mean any form resulting from mechanical
-transformation or translation of a Source form, including but
-not limited to compiled object code, generated documentation,
-and conversions to other media types.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-"Work" shall mean the work of authorship, whether in Source or
-Object form, made available under the License, as indicated by a
-copyright notice that is included in or attached to the work
-(an example is provided in the Appendix below).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-"Derivative Works" shall mean any work, whether in Source or Object
-form, that is based on (or derived from) the Work and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship. For the purposes
-of this License, Derivative Works shall not include works that remain
-separable from, or merely link (or bind by name) to the interfaces of,
-the Work and Derivative Works thereof.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-"Contribution" shall mean any work of authorship, including
-the original version of the Work and any modifications or additions
-to that Work or Derivative Works thereof, that is intentionally
-submitted to Licensor for inclusion in the Work by the copyright owner
-or by an individual or Legal Entity authorized to submit on behalf of
-the copyright owner. For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, the
-Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise
-designated in writing by the copyright owner as "Not a Contribution."
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-"Contributor" shall mean Licensor and any individual or Legal Entity
-on behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-2. Grant of Copyright License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the
-Work and such Derivative Works in Source or Object form.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-3. Grant of Patent License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made,
-use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable
-by such Contributor that are necessarily infringed by their
-Contribution(s) alone or by combination of their Contribution(s)
-with the Work to which such Contribution(s) was submitted. If You
-institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work
-or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate
-as of the date such litigation is filed.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-4. Redistribution. You may reproduce and distribute copies of the
-Work or Derivative Works thereof in any medium, with or without
-modifications, and in Source or Object form, provided that You
-meet the following conditions:
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-(a) You must give any other recipients of the Work or
-Derivative Works a copy of this License; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-(b) You must cause any modified files to carry prominent notices
-stating that You changed the files; and
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-(c) You must retain, in the Source form of any Derivative Works
-that You distribute, all copyright, patent, trademark, and
-attribution notices from the Source form of the Work,
-excluding those notices that do not pertain to any part of
-the Derivative Works; and
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-(d) If the Work includes a "NOTICE" text file as part of its
-distribution, then any Derivative Works that You distribute must
-include a readable copy of the attribution notices contained
-within such NOTICE file, excluding those notices that do not
-pertain to any part of the Derivative Works, in at least one
-of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or
-documentation, if provided along with the Derivative Works; or,
-within a display generated by the Derivative Works, if and
-wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and
-do not modify the License. You may add Your own attribution
-notices within Derivative Works that You distribute, alongside
-or as an addendum to the NOTICE text from the Work, provided
-that such additional attribution notices cannot be construed
-as modifying the License.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-You may add Your own copyright statement to Your modifications and
-may provide additional or different license terms and conditions
-for use, reproduction, or distribution of Your modifications, or
-for any such Derivative Works as a whole, provided Your use,
-reproduction, and distribution of the Work otherwise complies with
-the conditions stated in this License.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-5. Submission of Contributions. Unless You explicitly state otherwise,
-any Contribution intentionally submitted for inclusion in the Work
-by You to the Licensor shall be under the terms and conditions of
-this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify
-the terms of any separate license agreement you may have executed
-with Licensor regarding such Contributions.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-6. Trademarks. This License does not grant permission to use the trade
-names, trademarks, service marks, or product names of the Licensor,
-except as required for reasonable and customary use in describing the
-origin of the Work and reproducing the content of the NOTICE file.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-7. Disclaimer of Warranty. Unless required by applicable law or
-agreed to in writing, Licensor provides the Work (and each
-Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied, including, without limitation, any warranties or conditions
-of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any
-risks associated with Your exercise of permissions under this License.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-8. Limitation of Liability. In no event and under no legal theory,
-whether in tort (including negligence), contract, or otherwise,
-unless required by applicable law (such as deliberate and grossly
-negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a
-result of this License or out of the use or inability to use the
-Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer,
-and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify,
-defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-END OF TERMS AND CONDITIONS
+   END OF TERMS AND CONDITIONS
 
-APPENDIX: How to apply the Apache License to your work.
+   APPENDIX: How to apply the Apache License to your work.
 
-To apply the Apache License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets "[]"
-replaced with your own identifying information. (Don't include
-the brackets!)  The text should be enclosed in the appropriate
-comment syntax for the file format. We also recommend that a
-file or class name and description of purpose be included on the
-same "printed page" as the copyright notice for easier
-identification within third-party archives.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+   Copyright [yyyy] [name of copyright owner]
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 // This is edge class
 public class Edge {}


### PR DESCRIPTION
The parser fails when given in input only commented code, this is due to the fact that we are attaching comments to token but since there is no token it breaks.
I tried a little "hack" by mocking a token where all comments will attach to it.