### PR TITLE
Fix expression print

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
@@ -130,9 +130,13 @@ class BlocksAndStatementPrettierVisitor {
     }
 
     return rejectAndConcat([
-      rejectAndJoin(" ", [ctx.If[0], ctx.LBrace[0]]),
-      expression,
-      concat([ctx.RBrace[0], ifSeparator]),
+      rejectAndJoin(" ", [
+        ctx.If[0],
+        concat([
+          putIntoBraces(expression, softline, ctx.LBrace[0], ctx.RBrace[0]),
+          ifSeparator
+        ])
+      ]),
       ifStatement,
       elsePart
     ]);
@@ -154,7 +158,7 @@ class BlocksAndStatementPrettierVisitor {
 
     return rejectAndJoin(" ", [
       ctx.Switch[0],
-      rejectAndConcat([ctx.LBrace[0], expression, ctx.RBrace[0]]),
+      putIntoBraces(expression, softline, ctx.LBrace[0], ctx.RBrace[0]),
       switchBlock
     ]);
   }
@@ -207,7 +211,7 @@ class BlocksAndStatementPrettierVisitor {
     return rejectAndJoin(" ", [
       ctx.While[0],
       rejectAndJoin(statementSeparator, [
-        rejectAndConcat([ctx.LBrace[0], expression, ctx.RBrace[0]]),
+        putIntoBraces(expression, softline, ctx.LBrace[0], ctx.RBrace[0]),
         statement
       ])
     ]);
@@ -228,9 +232,7 @@ class BlocksAndStatementPrettierVisitor {
       rejectAndJoin(statementSeparator, [ctx.Do[0], statement]),
       ctx.While[0],
       rejectAndConcat([
-        ctx.LBrace[0],
-        expression,
-        ctx.RBrace[0],
+        putIntoBraces(expression, softline, ctx.LBrace[0], ctx.RBrace[0]),
         ctx.Semicolon[0]
       ])
     ]);
@@ -363,9 +365,13 @@ class BlocksAndStatementPrettierVisitor {
     const block = this.visit(ctx.block);
 
     return rejectAndConcat([
-      join(" ", [ctx.Synchronized[0], ctx.LBrace[0]]),
-      expression,
-      concat([ctx.RBrace[0], " "]),
+      join(" ", [
+        ctx.Synchronized[0],
+        concat([
+          putIntoBraces(expression, softline, ctx.LBrace[0], ctx.RBrace[0]),
+          " "
+        ])
+      ]),
       block
     ]);
   }

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -213,8 +213,6 @@ class ExpressionsPrettierVisitor {
         let separator = " ";
         if (token.image === "&&" || token.image === "||") {
           separator = line;
-        } else {
-          separator = " ";
         }
         segment.push(
           rejectAndConcat([

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -226,7 +226,7 @@ class ExpressionsPrettierVisitor {
         );
       }
     }
-    return group(rejectAndJoin(" ", segment));
+    return group(concat([softline, rejectAndJoin(" ", segment), softline]));
   }
 
   unaryExpression(ctx) {

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -210,10 +210,16 @@ class ExpressionsPrettierVisitor {
         }
         i++;
       } else if (matchCategory(token, "'BinaryOperator'")) {
+        let separator = "";
+        if (token.image === "&&" || token.image === "||") {
+          separator = softline;
+        } else {
+          separator = " ";
+        }
         segment.push(
           indent(
             rejectAndConcat([
-              softline,
+              separator,
               rejectAndJoin(" ", [token, unaryExpression.shift()])
             ])
           )

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -217,16 +217,14 @@ class ExpressionsPrettierVisitor {
           separator = " ";
         }
         segment.push(
-          indent(
-            rejectAndConcat([
-              separator,
-              rejectAndJoin(" ", [token, unaryExpression.shift()])
-            ])
-          )
+          rejectAndConcat([
+            separator,
+            rejectAndJoin(" ", [token, unaryExpression.shift()])
+          ])
         );
       }
     }
-    return group(concat([softline, rejectAndJoin(" ", segment), softline]));
+    return group(rejectAndJoin(" ", segment));
   }
 
   unaryExpression(ctx) {

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -210,16 +210,16 @@ class ExpressionsPrettierVisitor {
         }
         i++;
       } else if (matchCategory(token, "'BinaryOperator'")) {
-        let separator = "";
+        let separator = " ";
         if (token.image === "&&" || token.image === "||") {
-          separator = softline;
+          separator = line;
         } else {
           separator = " ";
         }
         segment.push(
           rejectAndConcat([
-            separator,
-            rejectAndJoin(" ", [token, unaryExpression.shift()])
+            " ",
+            rejectAndJoin(separator, [token, unaryExpression.shift()])
           ])
         );
       }

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -163,7 +163,7 @@ class ExpressionsPrettierVisitor {
     let tmpSegment = [];
 
     groups.forEach(gp => {
-      tmpSegment = [];
+      tmpSegment = [unaryExpression.shift()];
       for (let i = 0; i < gp.length; i++) {
         const token = gp[i];
         const shiftOperator = isShiftOperator(gp, i);
@@ -172,7 +172,9 @@ class ExpressionsPrettierVisitor {
             rejectAndJoin(" ", [ctx.Instanceof[0], referenceType.shift()])
           );
         } else if (matchCategory(token, "'AssignmentOperator'")) {
-          tmpSegment.push(rejectAndJoin(line, [token, expression.shift()]));
+          tmpSegment.push(
+            indent(rejectAndJoin(line, [token, expression.shift()]))
+          );
         } else if (
           shiftOperator === "shiftLeft" ||
           shiftOperator === "shiftRight"
@@ -194,16 +196,21 @@ class ExpressionsPrettierVisitor {
           i += 2;
         } else if (matchCategory(token, "'BinaryOperator'")) {
           tmpSegment.push(
-            rejectAndConcat([
-              " ",
-              rejectAndJoin(line, [token, unaryExpression.shift()])
-            ])
+            indent(rejectAndJoin(line, [token, unaryExpression.shift()]))
           );
         }
       }
-      allSegment.push(group(concat(tmpSegment)));
+      allSegment.push(group(rejectAndJoin(" ", tmpSegment)));
     });
-    return group(rejectAndJoinSeps(sortedBinOps, allSegment));
+    if (groups.length === 0) {
+      return unaryExpression.shift();
+    }
+    return group(
+      rejectAndJoinSeps(
+        sortedBinOps.map(elt => concat([" ", elt, line])),
+        allSegment
+      )
+    );
 
     /*
     const segment = [unaryExpression.shift()];

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -295,8 +295,11 @@ function putIntoCurlyBraces(argument, separator, LBrace, RBrace) {
 }
 
 const andOrBinaryOperators = new Set(["&&", "||", "&", "|", "^"]);
-function sortGroupTokens(ctx) {
-  // separate tokens into groups by andOrBinaryOperators ("&&", "||", "&", "|", "^")
+function separateTokensIntoGroups(ctx) {
+  /**
+   * separate tokens into groups by andOrBinaryOperators ("&&", "||", "&", "|", "^")
+   * in order to break those operators in priority.
+   */
   const tokens = sortTokens(
     ctx.Instanceof,
     ctx.AssignmentOperator,
@@ -309,14 +312,13 @@ function sortGroupTokens(ctx) {
   const sortedBinOps = [];
   let tmpGroup = [];
   tokens.forEach(token => {
-    if (matchCategory(token, "'BinaryOperator'")) {
-      if (andOrBinaryOperators.has(token.image)) {
-        sortedBinOps.push(token);
-        groups.push(tmpGroup);
-        tmpGroup = [];
-      } else {
-        tmpGroup.push(token);
-      }
+    if (
+      matchCategory(token, "'BinaryOperator'") &&
+      andOrBinaryOperators.has(token.image)
+    ) {
+      sortedBinOps.push(token);
+      groups.push(tmpGroup);
+      tmpGroup = [];
     } else {
       tmpGroup.push(token);
     }
@@ -340,7 +342,7 @@ function isShiftOperator(tokens, index) {
     tokens[index + 1].image === "<" &&
     tokens[index].startOffset === tokens[index + 1].startOffset - 1
   ) {
-    return "shiftLeft";
+    return "leftShift";
   }
   if (
     tokens[index].image === ">" &&
@@ -352,9 +354,9 @@ function isShiftOperator(tokens, index) {
       tokens[index + 2].image === ">" &&
       tokens[index + 1].startOffset === tokens[index + 2].startOffset - 1
     ) {
-      return "doubleShiftRight";
+      return "doubleRightShift";
     }
-    return "shiftRight";
+    return "rightShift";
   }
 
   return "none";
@@ -382,6 +384,6 @@ module.exports = {
   handleClassBodyDeclaration,
   putIntoBraces,
   putIntoCurlyBraces,
-  sortGroupTokens,
+  separateTokensIntoGroups,
   isShiftOperator
 };

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -308,27 +308,27 @@ function separateTokensIntoGroups(ctx) {
     ctx.BinaryOperator
   );
 
-  const groups = [];
-  const sortedBinOps = [];
+  const groupsOfOperator = [];
+  const sortedBinaryOperators = [];
   let tmpGroup = [];
   tokens.forEach(token => {
     if (
       matchCategory(token, "'BinaryOperator'") &&
       andOrBinaryOperators.has(token.image)
     ) {
-      sortedBinOps.push(token);
-      groups.push(tmpGroup);
+      sortedBinaryOperators.push(token);
+      groupsOfOperator.push(tmpGroup);
       tmpGroup = [];
     } else {
       tmpGroup.push(token);
     }
   });
 
-  groups.push(tmpGroup);
+  groupsOfOperator.push(tmpGroup);
 
   return {
-    groups,
-    sortedBinOps
+    groupsOfOperator,
+    sortedBinaryOperators
   };
 }
 

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -322,6 +322,8 @@ function sortGroupTokens(ctx) {
     }
   });
 
+  groups.push(tmpGroup);
+
   return {
     groups,
     sortedBinOps
@@ -329,9 +331,10 @@ function sortGroupTokens(ctx) {
 }
 
 function isShiftOperator(tokens, index) {
-  if (tokens.length < index + 1) {
+  if (tokens.length <= index + 1) {
     return "none";
   }
+
   if (
     tokens[index].image === "<" &&
     tokens[index + 1].image === "<" &&

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -294,6 +294,69 @@ function putIntoCurlyBraces(argument, separator, LBrace, RBrace) {
   return concat([LBrace, RBrace]);
 }
 
+const andOrBinaryOperators = new Set(["&&", "||", "&", "|", "^"]);
+function sortGroupTokens(ctx) {
+  // separate tokens into groups by andOrBinaryOperators ("&&", "||", "&", "|", "^")
+  const tokens = sortTokens(
+    ctx.Instanceof,
+    ctx.AssignmentOperator,
+    ctx.Less,
+    ctx.Greater,
+    ctx.BinaryOperator
+  );
+
+  const groups = [];
+  const sortedBinOps = [];
+  let tmpGroup = [];
+  tokens.forEach(token => {
+    if (matchCategory(token, "'BinaryOperator'")) {
+      if (andOrBinaryOperators.has(token.image)) {
+        sortedBinOps.push(token);
+        groups.push(tmpGroup);
+        tmpGroup = [];
+      } else {
+        tmpGroup.push(token);
+      }
+    } else {
+      tmpGroup.push(token);
+    }
+  });
+
+  return {
+    groups,
+    sortedBinOps
+  };
+}
+
+function isShiftOperator(tokens, index) {
+  if (tokens.length < index + 1) {
+    return "none";
+  }
+  if (
+    tokens[index].image === "<" &&
+    tokens[index + 1].image === "<" &&
+    tokens[index].startOffset === tokens[index + 1].startOffset - 1
+  ) {
+    return "shiftLeft";
+  }
+  if (
+    tokens[index].image === ">" &&
+    tokens[index + 1].image === ">" &&
+    tokens[index].startOffset === tokens[index + 1].startOffset - 1
+  ) {
+    if (
+      tokens.length > index + 2 &&
+      tokens[index + 2].image === ">" &&
+      tokens[index + 1].startOffset === tokens[index + 2].startOffset - 1
+    ) {
+      return "doubleShiftRight";
+    }
+    return "shiftRight";
+  }
+
+  return "none";
+}
+
 module.exports = {
   buildFqn,
   reject,
@@ -315,5 +378,7 @@ module.exports = {
   rejectSeparators,
   handleClassBodyDeclaration,
   putIntoBraces,
-  putIntoCurlyBraces
+  putIntoCurlyBraces,
+  sortGroupTokens,
+  isShiftOperator
 };

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -2,8 +2,7 @@ public class BinaryOperations {
 
   public void binaryOperationThatShouldBreak() {
     System.out.println(
-      "This operation with two very long string should break"
-        + "in a very nice way"
+      "This operation with two very long string should break" + "in a very nice way"
     );
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -2,7 +2,8 @@ public class BinaryOperations {
 
   public void binaryOperationThatShouldBreak() {
     System.out.println(
-      "This operation with two very long string should break" + "in a very nice way"
+      "This operation with two very long string should break" +
+        "in a very nice way"
     );
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -148,7 +148,8 @@ public final class ArrayTable<R, C, V>
     * elements but rowKeySet() will be empty and containsRow() won't
     * acknolwedge them.
     */
-    rowKeyToIndex = Maps.indexMap(rowList);
+    rowKeyToIndex =
+      Maps.indexMap(rowList);
     columnKeyToIndex = Maps.indexMap(columnList);
 
     @SuppressWarnings(

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/_input.java
@@ -68,7 +68,7 @@ public class PrettierTest {
                 return/*dead code*/ ;
             }   /*at least one iteration !*/while (false);
         synchronized/*declares synchronizd statement*/ (this){
-        while/*infinite loop*/      (true)
+        while/*infinite*/ (true)
             /*stop the program*/throw new RuntimeException();
         }
         

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/_output.java
@@ -73,7 +73,7 @@ public class PrettierTest {
       return/*dead code*/;
     } /*at least one iteration !*/while (false);
     synchronized/*declares synchronizd statement*/ (this) {
-      while/*infinite loop*/ (true) /*stop the program*/throw new RuntimeException();
+      while/*infinite*/ (true) /*stop the program*/throw new RuntimeException();
     }
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
@@ -81,15 +81,80 @@ public class Expressions {
     }
   }
 
-  public void printLine() {
+  public void printIf() {
+    Object myObject = new PrettierObject().getSingleton().getAuthentication().getCredentials().getRights().getName();
+
     if(myValue == 42 || myValue == 42 && myValue == 42 && myValue == 42 || myValue == 42 && myValue == 42) {
+
+    }
+
+    if(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42 && myValue == 42) {
+      
+    }
+
+    if(myValue != 42) {
 
     }
   }
 
-  public void printLineMix() {
-    if(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42) {
+  public void printSwitch() {
+    switch(myValue == 42 || myValue == 42 && myValue == 42 && myValue == 42 || myValue == 42 && myValue == 42) {
+
+    }
+
+    switch(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42 && myValue == 42) {
       
+    }
+
+    switch(myValue != 42) {
+      
+    }
+  }
+
+  public void printWhile() {
+    while/*infinite*/ (true) /*stop the program*/throw new RuntimeException();
+    
+    while(myValue == 42 || myValue == 42 && myValue == 42 && myValue == 42 || myValue == 42 && myValue == 42) {
+
+    }
+
+    while(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42 && myValue == 42) {
+      
+    }
+
+    while(myValue != 42) {
+      
+    }
+  }
+
+  public void printDoWhile() {
+    do{
+      System.out.println("Prettier-java is cool !");
+    }
+    while(myValue == 42 || myValue == 42 && myValue == 42 && myValue == 42 || myValue == 42 && myValue == 42);
+
+    do {
+      System.out.println("Prettier-java is cool !");
+    }
+    while(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42 && myValue == 42);
+
+    do {
+      System.out.println("Prettier-java is cool !");
+    }
+    while(myValue != 42);
+  }
+
+  public void printSynchronized() {
+    synchronized(myValue == 42 || myValue == 42 && myValue == 42 && myValue == 42 || myValue == 42 && myValue == 42) {
+      System.out.println("Prettier-java is cool !");
+    }
+
+    synchronized(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42 && myValue == 42) {
+      System.out.println("Prettier-java is cool !");
+    }
+
+    synchronized(myValue == 42) {
+      System.out.println("Prettier-java is cool !");
     }
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
@@ -92,7 +92,7 @@ public class Expressions {
       
     }
 
-    if(myValue != 42) {
+    if(myValue != 42 && myValue == 42) {
 
     }
   }
@@ -109,6 +109,10 @@ public class Expressions {
     switch(myValue != 42) {
       
     }
+
+    switch(myValue != 42 && myValue == 42) {
+
+    }
   }
 
   public void printWhile() {
@@ -124,6 +128,10 @@ public class Expressions {
 
     while(myValue != 42) {
       
+    }
+
+    while(myValue != 42 && myValue == 42) {
+
     }
   }
 
@@ -142,6 +150,10 @@ public class Expressions {
       System.out.println("Prettier-java is cool !");
     }
     while(myValue != 42);
+
+    do {
+      System.out.println("Prettier-java is cool !");
+    }while(myValue != 42 && myValue == 42);
   }
 
   public void printSynchronized() {
@@ -154,6 +166,10 @@ public class Expressions {
     }
 
     synchronized(myValue == 42) {
+      System.out.println("Prettier-java is cool !");
+    }
+
+    synchronized(myValue != 42 && myValue == 42) {
       System.out.println("Prettier-java is cool !");
     }
   }

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
@@ -72,5 +72,26 @@ public class Expressions {
     }
   }
 
+  public void printSimple() {
+    if(myValue == 42) {
+    }
+
+    if(myValue != 42) {
+      System.out.println("Why not 42 !");
+    }
+  }
+
+  public void printLine() {
+    if(myValue == 42 || myValue == 42 && myValue == 42 && myValue == 42 || myValue == 42 && myValue == 42) {
+
+    }
+  }
+
+  public void printLineMix() {
+    if(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42) {
+      
+    }
+  }
+
 }
 

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -80,20 +80,134 @@ public class Expressions {
     }
   }
 
-  public void printLine() {
-    if (myValue == 42
-      || myValue == 42
-      && myValue == 42
-      && myValue == 42
-      || myValue == 42
-      && myValue == 42) {}
-  }
+  public void printIf() {
+    Object myObject = new PrettierObject()
+      .getSingleton()
+      .getAuthentication()
+      .getCredentials()
+      .getRights()
+      .getName();
 
-  public void printLineMix() {
-    if (myValue != 42
+    if (
+      myValue == 42
+      || myValue == 42
+      && myValue == 42
+      && myValue == 42
+      || myValue == 42
+      && myValue == 42
+    ) {}
+
+    if (
+      myValue != 42
       && 42 / 42
       || myValue & 42
       && myValue > 42
-      || myValue < 42) {}
+      || myValue < 42
+      && myValue == 42
+    ) {}
+
+    if (myValue != 42) {}
+  }
+
+  public void printSwitch() {
+    switch (
+      myValue == 42
+      || myValue == 42
+      && myValue == 42
+      && myValue == 42
+      || myValue == 42
+      && myValue == 42
+    ) {}
+
+    switch (
+      myValue != 42
+      && 42 / 42
+      || myValue & 42
+      && myValue > 42
+      || myValue < 42
+      && myValue == 42
+    ) {}
+
+    switch (myValue != 42) {}
+  }
+
+  public void printWhile() {
+    while/*infinite*/ (true) /*stop the program*/throw new RuntimeException();
+
+    while (
+      myValue == 42
+      || myValue == 42
+      && myValue == 42
+      && myValue == 42
+      || myValue == 42
+      && myValue == 42
+    ) {}
+
+    while (
+      myValue != 42
+      && 42 / 42
+      || myValue & 42
+      && myValue > 42
+      || myValue < 42
+      && myValue == 42
+    ) {}
+
+    while (myValue != 42) {}
+  }
+
+  public void printDoWhile() {
+    do {
+      System.out.println("Prettier-java is cool !");
+    } while (
+      myValue == 42
+      || myValue == 42
+      && myValue == 42
+      && myValue == 42
+      || myValue == 42
+      && myValue == 42
+    );
+
+    do {
+      System.out.println("Prettier-java is cool !");
+    } while (
+      myValue != 42
+      && 42 / 42
+      || myValue & 42
+      && myValue > 42
+      || myValue < 42
+      && myValue == 42
+    );
+
+    do {
+      System.out.println("Prettier-java is cool !");
+    } while (myValue != 42);
+  }
+
+  public void printSynchronized() {
+    synchronized (
+      myValue == 42
+      || myValue == 42
+      && myValue == 42
+      && myValue == 42
+      || myValue == 42
+      && myValue == 42
+    ) {
+      System.out.println("Prettier-java is cool !");
+    }
+
+    synchronized (
+      myValue != 42
+      && 42 / 42
+      || myValue & 42
+      && myValue > 42
+      || myValue < 42
+      && myValue == 42
+    ) {
+      System.out.println("Prettier-java is cool !");
+    }
+
+    synchronized (myValue == 42) {
+      System.out.println("Prettier-java is cool !");
+    }
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -106,7 +106,7 @@ public class Expressions {
       myValue == 42
     ) {}
 
-    if (myValue != 42) {}
+    if (myValue != 42 && myValue == 42) {}
   }
 
   public void printSwitch() {
@@ -129,6 +129,8 @@ public class Expressions {
     ) {}
 
     switch (myValue != 42) {}
+
+    switch (myValue != 42 && myValue == 42) {}
   }
 
   public void printWhile() {
@@ -153,6 +155,8 @@ public class Expressions {
     ) {}
 
     while (myValue != 42) {}
+
+    while (myValue != 42 && myValue == 42) {}
   }
 
   public void printDoWhile() {
@@ -181,6 +185,10 @@ public class Expressions {
     do {
       System.out.println("Prettier-java is cool !");
     } while (myValue != 42);
+
+    do {
+      System.out.println("Prettier-java is cool !");
+    } while (myValue != 42 && myValue == 42);
   }
 
   public void printSynchronized() {
@@ -207,6 +215,10 @@ public class Expressions {
     }
 
     synchronized (myValue == 42) {
+      System.out.println("Prettier-java is cool !");
+    }
+
+    synchronized (myValue != 42 && myValue == 42) {
       System.out.println("Prettier-java is cool !");
     }
   }

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -89,21 +89,21 @@ public class Expressions {
       .getName();
 
     if (
+      myValue == 42 ||
+      myValue == 42 &&
+      myValue == 42 &&
+      myValue == 42 ||
+      myValue == 42 &&
       myValue == 42
-      || myValue == 42
-      && myValue == 42
-      && myValue == 42
-      || myValue == 42
-      && myValue == 42
     ) {}
 
     if (
-      myValue != 42
-      && 42 / 42
-      || myValue & 42
-      && myValue > 42
-      || myValue < 42
-      && myValue == 42
+      myValue != 42 &&
+      42 / 42 ||
+      myValue & 42 &&
+      myValue > 42 ||
+      myValue < 42 &&
+      myValue == 42
     ) {}
 
     if (myValue != 42) {}
@@ -111,21 +111,21 @@ public class Expressions {
 
   public void printSwitch() {
     switch (
+      myValue == 42 ||
+      myValue == 42 &&
+      myValue == 42 &&
+      myValue == 42 ||
+      myValue == 42 &&
       myValue == 42
-      || myValue == 42
-      && myValue == 42
-      && myValue == 42
-      || myValue == 42
-      && myValue == 42
     ) {}
 
     switch (
-      myValue != 42
-      && 42 / 42
-      || myValue & 42
-      && myValue > 42
-      || myValue < 42
-      && myValue == 42
+      myValue != 42 &&
+      42 / 42 ||
+      myValue & 42 &&
+      myValue > 42 ||
+      myValue < 42 &&
+      myValue == 42
     ) {}
 
     switch (myValue != 42) {}
@@ -135,21 +135,21 @@ public class Expressions {
     while/*infinite*/ (true) /*stop the program*/throw new RuntimeException();
 
     while (
+      myValue == 42 ||
+      myValue == 42 &&
+      myValue == 42 &&
+      myValue == 42 ||
+      myValue == 42 &&
       myValue == 42
-      || myValue == 42
-      && myValue == 42
-      && myValue == 42
-      || myValue == 42
-      && myValue == 42
     ) {}
 
     while (
-      myValue != 42
-      && 42 / 42
-      || myValue & 42
-      && myValue > 42
-      || myValue < 42
-      && myValue == 42
+      myValue != 42 &&
+      42 / 42 ||
+      myValue & 42 &&
+      myValue > 42 ||
+      myValue < 42 &&
+      myValue == 42
     ) {}
 
     while (myValue != 42) {}
@@ -159,23 +159,23 @@ public class Expressions {
     do {
       System.out.println("Prettier-java is cool !");
     } while (
+      myValue == 42 ||
+      myValue == 42 &&
+      myValue == 42 &&
+      myValue == 42 ||
+      myValue == 42 &&
       myValue == 42
-      || myValue == 42
-      && myValue == 42
-      && myValue == 42
-      || myValue == 42
-      && myValue == 42
     );
 
     do {
       System.out.println("Prettier-java is cool !");
     } while (
-      myValue != 42
-      && 42 / 42
-      || myValue & 42
-      && myValue > 42
-      || myValue < 42
-      && myValue == 42
+      myValue != 42 &&
+      42 / 42 ||
+      myValue & 42 &&
+      myValue > 42 ||
+      myValue < 42 &&
+      myValue == 42
     );
 
     do {
@@ -185,23 +185,23 @@ public class Expressions {
 
   public void printSynchronized() {
     synchronized (
+      myValue == 42 ||
+      myValue == 42 &&
+      myValue == 42 &&
+      myValue == 42 ||
+      myValue == 42 &&
       myValue == 42
-      || myValue == 42
-      && myValue == 42
-      && myValue == 42
-      || myValue == 42
-      && myValue == 42
     ) {
       System.out.println("Prettier-java is cool !");
     }
 
     synchronized (
-      myValue != 42
-      && 42 / 42
-      || myValue & 42
-      && myValue > 42
-      || myValue < 42
-      && myValue == 42
+      myValue != 42 &&
+      42 / 42 ||
+      myValue & 42 &&
+      myValue > 42 ||
+      myValue < 42 &&
+      myValue == 42
     ) {
       System.out.println("Prettier-java is cool !");
     }

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -71,4 +71,29 @@ public class Expressions {
       System.out.println("instanceOf");
     }
   }
+
+  public void printSimple() {
+    if (myValue == 42) {}
+
+    if (myValue != 42) {
+      System.out.println("Why not 42 !");
+    }
+  }
+
+  public void printLine() {
+    if (myValue == 42
+      || myValue == 42
+      && myValue == 42
+      && myValue == 42
+      || myValue == 42
+      && myValue == 42) {}
+  }
+
+  public void printLineMix() {
+    if (myValue != 42
+      && 42 / 42
+      || myValue & 42
+      && myValue > 42
+      || myValue < 42) {}
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -100,7 +100,8 @@ public class Expressions {
     if (
       myValue != 42 &&
       42 / 42 ||
-      myValue & 42 &&
+      myValue &
+      42 &&
       myValue > 42 ||
       myValue < 42 &&
       myValue == 42
@@ -122,7 +123,8 @@ public class Expressions {
     switch (
       myValue != 42 &&
       42 / 42 ||
-      myValue & 42 &&
+      myValue &
+      42 &&
       myValue > 42 ||
       myValue < 42 &&
       myValue == 42
@@ -148,7 +150,8 @@ public class Expressions {
     while (
       myValue != 42 &&
       42 / 42 ||
-      myValue & 42 &&
+      myValue &
+      42 &&
       myValue > 42 ||
       myValue < 42 &&
       myValue == 42
@@ -176,7 +179,8 @@ public class Expressions {
     } while (
       myValue != 42 &&
       42 / 42 ||
-      myValue & 42 &&
+      myValue &
+      42 &&
       myValue > 42 ||
       myValue < 42 &&
       myValue == 42
@@ -206,7 +210,8 @@ public class Expressions {
     synchronized (
       myValue != 42 &&
       42 / 42 ||
-      myValue & 42 &&
+      myValue &
+      42 &&
       myValue > 42 ||
       myValue < 42 &&
       myValue == 42


### PR DESCRIPTION
Fix the breaking expression discussed [here](https://github.com/jhipster/prettier-java/issues/218)

Example:
input:
```java
public class Args {

  public static void main(String[] args) {
    if(test == 1 && test == 1 && test == 1 && test == 1 && test == 1 && test == 1 && test == 1 && test == 1) {

    }
}
}
```

output:
```java
public class Args {

  public static void main(String[] args) {
    if (
      test == 1 &&
      test == 1 &&
      test == 1 &&
      test == 1 &&
      test == 1 &&
      test == 1 &&
      test == 1 &&
      test == 1
    ) {}
  }
}

```

~~However, it will only breaks on && and ||.
if we have ```if(aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongVariable == aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongVariable2)```, it won't break on ```==```.
Is it bothersome ? I am not sure... It will be hard to tell how we should break each operator since we just have an array on all operators on the cstnode.~~
I am working with @clement26695 to make it work :+1: 