### PR TITLE
bitshifting operators must no include whitespace

### DIFF
--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -144,17 +144,20 @@ function defineRules($, t) {
           ALT: () => {
             $.OR2([
               {
+                GATE: () => $.LA(1).startOffset + 1 === $.LA(2).startOffset,
                 ALT: () => {
                   $.CONSUME(t.Less);
                   $.CONSUME2(t.Less);
                 }
               },
               {
+                GATE: () => $.LA(1).startOffset + 1 === $.LA(2).startOffset,
                 ALT: () => {
                   $.CONSUME(t.Greater);
                   $.CONSUME2(t.Greater);
-                  $.OPTION(() => {
-                    $.CONSUME3(t.Greater);
+                  $.OPTION({
+                    GATE: () => $.LA(0).startOffset + 1 === $.LA(1).startOffset,
+                    DEF: () => $.CONSUME3(t.Greater)
                   });
                 }
               }

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -39,3 +39,39 @@ describe("The Java Parser fixed bugs", () => {
     expect(() => javaParser.parse(input)).to.not.throw();
   });
 });
+
+describe("The Java Parser fixed bugs", () => {
+  it("issue #113 - Bit shifting operators must not include whitespace - >>", () => {
+    const input = "public class Foo{int hello = 1 >> 5;}";
+    expect(() => javaParser.parse(input)).to.not.throw();
+  });
+
+  it("issue #113 - Bit shifting operators must not include whitespace - >>>", () => {
+    const input = "public class Foo{int hello = 1 >>> 5;}";
+    expect(() => javaParser.parse(input)).to.not.throw();
+  });
+
+  it("issue #113 - Bit shifting operators must not include whitespace - <<", () => {
+    const input = "public class Foo{int hello = 1 << 5;}";
+    expect(() => javaParser.parse(input)).to.not.throw();
+  });
+
+  it("issue #113 - Bit shifting operators must not include whitespace - space after first >", () => {
+    const input = "public class Foo{int hello = 1 > >> 5;}";
+    expect(() => javaParser.parse(input)).to.throw();
+  });
+
+  it("issue #113 - Bit shifting operators must not include whitespace - space after second >", () => {
+    const input = "public class Foo{int hello = 1 >> > 5;}";
+    expect(() => javaParser.parse(input)).to.throw();
+  });
+  it("issue #113 - Bit shifting operators must not include whitespace - space on all >", () => {
+    const input = "public class Foo{int hello = 1 > > > 5;}";
+    expect(() => javaParser.parse(input)).to.throw();
+  });
+
+  it("issue #113 - Bit shifting operators must not include whitespace - space after first <", () => {
+    const input = "public class Foo{int hello = 1 < < 5;}";
+    expect(() => javaParser.parse(input)).to.throw();
+  });
+});


### PR DESCRIPTION
Fixing the first issue of #113 