### PR TITLE
fix breaking with multi-lines comments

### DIFF
--- a/packages/prettier-plugin-java/src/printers/prettier-builder.js
+++ b/packages/prettier-plugin-java/src/printers/prettier-builder.js
@@ -1,6 +1,8 @@
 "use strict";
 const prettier = require("prettier").doc.builders;
 
+const hardLineWithoutBreakParent = { type: "line", hard: true };
+
 function getImageWithComments(token) {
   const arr = [];
   if (token.hasOwnProperty("leadingComments")) {
@@ -8,7 +10,7 @@ function getImageWithComments(token) {
       if (element.startLine !== token.startLine) {
         arr.push(prettier.lineSuffixBoundary);
         arr.push(concat(formatComment(element)));
-        arr.push(prettier.hardline);
+        arr.push(hardLineWithoutBreakParent);
       } else {
         arr.push(concat(formatComment(element)));
       }
@@ -17,12 +19,12 @@ function getImageWithComments(token) {
   arr.push(token.image);
   if (token.hasOwnProperty("trailingComments")) {
     if (token.trailingComments[0].startLine !== token.startLine) {
-      arr.push(prettier.hardline);
+      arr.push(hardLineWithoutBreakParent);
     }
     token.trailingComments.forEach(element => {
       if (element.startLine !== token.startLine) {
         arr.push(concat(formatComment(element)));
-        arr.push(prettier.hardline);
+        arr.push(hardLineWithoutBreakParent);
       } else if (element.tokenType.tokenName === "LineComment") {
         // Do not add extra space in case of empty statement
         const separator = token.image === "" ? "" : " ";
@@ -53,9 +55,9 @@ function formatComment(comment) {
     } else {
       res.push(l);
     }
-    res.push(prettier.hardline);
+    res.push(hardLineWithoutBreakParent);
   });
-  if (res[res.length - 1] === prettier.hardline) {
+  if (res[res.length - 1] === hardLineWithoutBreakParent) {
     res.pop();
   }
   return res;
@@ -120,5 +122,6 @@ module.exports = {
   fill,
   indent,
   dedent,
-  getImageWithComments
+  getImageWithComments,
+  hardLineWithoutBreakParent
 };

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -148,8 +148,7 @@ public final class ArrayTable<R, C, V>
     * elements but rowKeySet() will be empty and containsRow() won't
     * acknolwedge them.
     */
-    rowKeyToIndex =
-      Maps.indexMap(rowList);
+    rowKeyToIndex = Maps.indexMap(rowList);
     columnKeyToIndex = Maps.indexMap(columnList);
 
     @SuppressWarnings(

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/_output.java
@@ -81,6 +81,5 @@ public class PrettierTest {
 //Additionnal enumeration
 enum Cards {
   //The Heart and the Spade
-  HEART/*the heart*/,
-  SPADES/*and the spade*/;
+  HEART/*the heart*/, SPADES/*and the spade*/;
 }


### PR DESCRIPTION
Add a custom line for comments that will always break but will not force parent groups to break.