### PR TITLE
Attach comments to the next token instead of closest

### DIFF
--- a/packages/java-parser/src/comments.js
+++ b/packages/java-parser/src/comments.js
@@ -64,17 +64,18 @@ function attachComments(tokens, comments) {
       currentToken++;
     }
 
-    // attach comment to the closest token
+    // attach comment to the next token by default,
+    // it attaches to the current one when the comment and token is on the same line
     if (
-      element.startOffset - tokens[currentToken].endOffset <
-      tokens[currentToken + 1].startOffset - element.endOffset
+      element.startLine === tokens[currentToken].endLine &&
+      element.startLine !== tokens[currentToken + 1].startLine
     ) {
-      if (!tokens[currentToken].hasOwnProperty("trailingComments")) {
+      if (!tokens[currentToken].trailingComments) {
         tokens[currentToken].trailingComments = [];
       }
       tokens[currentToken].trailingComments.push(element);
     } else {
-      if (!tokens[currentToken + 1].hasOwnProperty("leadingComments")) {
+      if (!tokens[currentToken + 1].leadingComments) {
         tokens[currentToken + 1].leadingComments = [];
       }
       tokens[currentToken + 1].leadingComments.push(element);

--- a/packages/prettier-plugin-java/scripts/single-printer-run/_output.java
+++ b/packages/prettier-plugin-java/scripts/single-printer-run/_output.java
@@ -1,9 +1,11 @@
 public enum Enum {
   SOME_ENUM, ANOTHER_ENUM, LAST_ENUM;
 }
+
 public enum Enum {
-  THIS_IS_GOOD ("abc"), THIS_IS_FINE ("abc");
+  THIS_IS_GOOD("abc"), THIS_IS_FINE("abc");
   public static final String thisWillBeDeleted = "DELETED";
+
   private final String value;
 
   public Enum(String value) {
@@ -14,8 +16,10 @@ public enum Enum {
     return "STRING";
   }
 }
+
 class CLassWithEnum {
+
   public static enum VALID_THINGS {
-    FIRST, SECOND
+    FIRST, SECOND;
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_input.java
@@ -774,4 +774,14 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
   }
 
   private static final long serialVersionUID = 0;
+
+
+  @Override
+  public Optional<String> getCurrentAuditor() {
+    // There is currently no reactive AuditorAware implementation so we can't
+    // extract the currently logged-in user from the Reactor Context.
+    // Therefore createdBy and lastModifiedBy will have to be set explicitly.
+    // See https://jira.spring.io/browse/DATACMNS-1231
+    return Optional.of(Constants.SYSTEM_ACCOUNT);
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -816,4 +816,13 @@ public final class ArrayTable<R, C, V>
   }
 
   private static final long serialVersionUID = 0;
+
+  @Override
+  public Optional<String> getCurrentAuditor() {
+    // There is currently no reactive AuditorAware implementation so we can't
+    // extract the currently logged-in user from the Reactor Context.
+    // Therefore createdBy and lastModifiedBy will have to be set explicitly.
+    // See https://jira.spring.io/browse/DATACMNS-1231
+    return Optional.of(Constants.SYSTEM_ACCOUNT);
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -96,13 +96,13 @@ public final class ArrayTable<R, C, V>
   ) {
     return new ArrayTable<>(rowKeys, columnKeys);
   }
+
   /*
   * TODO(jlevy): Add factory methods taking an Enum class, instead of an
   * iterable, to specify the allowed row keys and/or column keys. Note that
   * custom serialization logic is needed to support different enum sizes during
   * serialization and deserialization.
   */
-
   /**
   * Creates an {@code ArrayTable} with the mappings in the provided table.
   *
@@ -476,11 +476,11 @@ public final class ArrayTable<R, C, V>
     );
     return set(rowIndex, columnIndex, value);
   }
+
   /*
   * TODO(jlevy): Consider creating a merge() method, similar to putAll() but
   * copying non-null values only.
   */
-
   /**
   * {@inheritDoc}
   *

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/_output.java
@@ -7,9 +7,9 @@ public class PrettierTest {
     } /*catch*/catch (EmptyStackException e) {
       throw new RuntimeException(e);
     } /*multi-catch*/catch (
-      /*1*/FirstException | /*2*/SecondException |/*3*/ ThirdException e2
+      /*1*/FirstException | /*2*/SecondException | /*3*/ThirdException e2
     ) {
-      throw/*throw an exception*/ new/*don't forget new when throwing exceptions*/ RuntimeException(
+      throw /*throw an exception*/new /*don't forget new when throwing exceptions*/RuntimeException(
         e2
       );
     } /*is always executed no matter what*/finally {
@@ -17,8 +17,8 @@ public class PrettierTest {
     }
   }
 
-  private void myFunction(/* axis x */
-    int arg1,
+  private void myFunction(
+    /* axis x */int arg1,
     /* axis y */int arg2,
     /* axis z */int arg3
   ) {
@@ -27,9 +27,9 @@ public class PrettierTest {
     );
 
     int /*variable name is of value var */var = arg1 + arg2 + arg3;
-    if/*true*/ (var == 0) {
+    if /*true*/(var == 0) {
       System.out.println("The value is 0");
-    } else/*false*/ {
+    } else /*false*/{
       int[] arr = {
         /*One*/1,
         /*Two */2,
@@ -56,7 +56,7 @@ public class PrettierTest {
           case 0:
             System.out.println("Zero ");
 
-            continue/*labeled continued*/ loop;
+            continue /*labeled continued*/loop;
           default/*def*/:
             /*labeled break*/break loop;
         }
@@ -65,15 +65,15 @@ public class PrettierTest {
   }
 
   private synchronized void myFunction(int arg1, int arg2/*overloading*/) {
-    for (int i = 0; i < /*=*/arg1; i++) do/*dodododo*/ { //do whiles
+    for (int i = 0; i < /*=*/arg1; i++) do /*dodododo*/{ //do whiles
       //asserting
-      assert/*true*/ true == true;
+      assert /*true*/true == true;
       continue;
       break/*dead code*/;
       return/*dead code*/;
     } /*at least one iteration !*/while (false);
-    synchronized/*declares synchronizd statement*/ (this) {
-      while/*infinite*/ (true) /*stop the program*/throw new RuntimeException();
+    synchronized /*declares synchronizd statement*/(this) {
+      while /*infinite*/(true) /*stop the program*/throw new RuntimeException();
     }
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/comments/interface/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/interface/_output.java
@@ -4,9 +4,9 @@ import com.other.interfaces.RequiredI;
 /**
 * This is the comment describing the interface
 */
-public /*a*/interface/*b*/ MyInterface
-  /*a*/extends/*b*/ /*a*/OfferedI/*b*//*a*/,/*b*/ /*a*/RequiredI/*b*/ {
-// comment
+public /*a*/interface /*b*/MyInterface
+  /*a*/extends /*b*//*a*/OfferedI/*b*//*a*/, /*b*//*a*/RequiredI /*b*/{
+  // comment
   /**
   * Javadoc
   * @param p1 parameter 1
@@ -15,9 +15,9 @@ public /*a*/interface/*b*/ MyInterface
   * @throws RuntimeException RuntimeException comment
   */
   public void myMethodInterface(
-    Param1 /*a*/p1/*b*//*a*/,/*b*/
-    /*a*/Param2/*b*/ /*a*/p2/*b*/,
+    Param1 /*a*/p1/*b*//*a*/,
+    /*b*//*a*/Param2 /*b*//*a*/p2/*b*/,
     Param3 p3
   )
-    /*a*/throws/*b*/ Exception/*a*/,/*b*/ RuntimeException/*a*/;/*b*/
+    /*a*/throws /*b*/Exception/*a*/, /*b*/RuntimeException/*a*/;/*b*/
 }

--- a/packages/prettier-plugin-java/test/unit-test/comments/package/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/package/_input.java
@@ -2,12 +2,10 @@
     /*a*/requires/*a*/ java.desktopa /*a*/;/*b*/
     requires soat.vending.machine.model;
     requires /*a*/transitive/*b*/ soat.core;
-    /*a*/ exports /*b*/ fr.soat.vending.machine.model /*a*/to/*b*/  
-    another /*a*/,/*b*/ again /*c*/,/*d*/ ano /*a*/;/*b*/
+    /*a*/ exports /*b*/ fr.soat.vending.machine.model /*a*/to/*b*/ another /*a*/,/*b*/ again /*c*/,/*d*/ ano /*a*/;/*b*/
 
     // opens
-    /*a*/ opens /*b*/ fr.soat.vending.machine.model /*a*/to/*b*/  
-    another /*a*/,/*b*/ again /*c*/,/*d*/ ano /*a*/;/*b*/
+    /*a*/ opens /*b*/ fr.soat.vending.machine.model /*a*/to/*b*/ another /*a*/,/*b*/ again /*c*/,/*d*/ ano /*a*/;/*b*/
 
 
     // uses

--- a/packages/prettier-plugin-java/test/unit-test/comments/package/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/package/_output.java
@@ -1,10 +1,10 @@
-/*a*/open/*b*/ /*a*/module/*b*/ soat/*a*/./*b*/vending.machine.gui {
-  /*a*/requires/*a*/ java.desktopa/*a*/;/*b*/
+/*a*/open /*b*//*a*/module /*b*/soat/*a*/./*b*/vending.machine.gui {
+  /*a*/requires /*a*/java.desktopa/*a*/;/*b*/
   requires soat.vending.machine.model;
-  requires /*a*/transitive/*b*/ soat.core;
-  /*a*/exports /*b*/fr.soat.vending.machine.model /*a*/to/*b*/ another/*a*/,/*b*/ again/*c*/,/*d*/ ano/*a*/;/*b*/
+  requires /*a*/transitive /*b*/soat.core;
+  /*a*/exports /*b*/fr.soat.vending.machine.model /*a*/to /*b*/another/*a*/, /*b*/again/*c*/, /*d*/ano/*a*/;/*b*/
   // opens
-  /*a*/opens /*b*/fr.soat.vending.machine.model /*a*/to/*b*/ another/*a*/,/*b*/ again/*c*/,/*d*/ ano/*a*/;/*b*/
+  /*a*/opens /*b*/fr.soat.vending.machine.model /*a*/to /*b*/another/*a*/, /*b*/again/*c*/, /*d*/ano/*a*/;/*b*/
   // uses
-  /*a*/uses/*b*/ fr.soat.vendinga/*a*/./*b*/machine.services.DrinksService/*a*/;/*b*/
+  /*a*/uses /*b*/fr.soat.vendinga/*a*/./*b*/machine.services.DrinksService/*a*/;/*b*/
 }

--- a/packages/prettier-plugin-java/test/unit-test/empty_statement/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/empty_statement/_output.java
@@ -53,7 +53,7 @@ public class EmptyStament {
       System.out.println("one");
     }
 
-    if (test);/*test*/ else {
+    if (test); /*test*/else {
       System.out.println("one");
     }
 
@@ -65,7 +65,7 @@ public class EmptyStament {
       System.out.println("two");
     } else;/*test*/
 
-    if (test);/*test*/ else;/*test*/
+    if (test); /*test*/else;/*test*/
 
     if (test) /*test*/; else /*test*/;
   }
@@ -81,6 +81,6 @@ public class EmptyStament {
   public void doWhileWithEmptyStatement(boolean one) {
     do; while (one);
     do /*test*/; while (one);
-    do;/*test*/ while (one);
+    do; /*test*/while (one);
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -136,7 +136,7 @@ public class Expressions {
   }
 
   public void printWhile() {
-    while/*infinite*/ (true) /*stop the program*/throw new RuntimeException();
+    while /*infinite*/(true) /*stop the program*/throw new RuntimeException();
 
     while (
       myValue == 42 ||


### PR DESCRIPTION
This PR modify the comment attachment rule, the issue is we probably have case like #219 and because the way we handle the comment we cannot fix the indent cases or it would be a pain.
So instead of attaching to the closest token it always attach as a leadingComments of the token except when the previous token and the comment is on the same line. This is the most common cases, people (IMO) tend to always put their comments above what they want to comment.
If this attachment rule is problematic, we can easily revert it since this is just a simple piece of the code.

Fix #219