### PR TITLE
Delete 'fs' import because that is not used

### DIFF
--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-vars */
 "use strict";
 const { createToken: createTokenOrg, Lexer } = require("chevrotain");
-const fs = require("fs");
 let chars;
 // A little mini DSL for easier lexer definition.
 const fragments = {};


### PR DESCRIPTION
Our project that uses `java-parser` was failed to build.
And we found `java-parser` imports unused `fs` library, which was the cause of the problem.

