### PR TITLE
Fix multi-lines comments

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
@@ -17,7 +17,8 @@ const {
   getBlankLinesSeparator,
   rejectSeparators,
   putIntoBraces,
-  putIntoCurlyBraces
+  putIntoCurlyBraces,
+  isStatementEmptyStatement
 } = require("./printer-utils");
 
 class BlocksAndStatementPrettierVisitor {
@@ -106,22 +107,14 @@ class BlocksAndStatementPrettierVisitor {
     const ifStatement = this.visit(ctx.statement[0], {
       allowEmptyStatement: true
     });
-    const ifSeparator =
-      ifStatement.contents !== undefined &&
-      ifStatement.contents.parts[0] === ";"
-        ? ""
-        : " ";
+    const ifSeparator = isStatementEmptyStatement(ifStatement) ? "" : " ";
 
     let elsePart = "";
     if (ctx.Else !== undefined) {
       const elseStatement = this.visit(ctx.statement[1], {
         allowEmptyStatement: true
       });
-      const elseSeparator =
-        elseStatement.contents !== undefined &&
-        elseStatement.contents.parts[0] === ";"
-          ? ""
-          : " ";
+      const elseSeparator = isStatementEmptyStatement(elseStatement) ? "" : " ";
 
       elsePart = rejectAndJoin(elseSeparator, [
         concat([" ", ctx.Else[0]]),
@@ -203,10 +196,7 @@ class BlocksAndStatementPrettierVisitor {
     const statement = this.visit(ctx.statement[0], {
       allowEmptyStatement: true
     });
-    const statementSeparator =
-      statement.contents !== undefined && statement.contents.parts[0] === ";"
-        ? ""
-        : " ";
+    const statementSeparator = isStatementEmptyStatement(statement) ? "" : " ";
 
     return rejectAndJoin(" ", [
       ctx.While[0],
@@ -221,10 +211,7 @@ class BlocksAndStatementPrettierVisitor {
     const statement = this.visit(ctx.statement[0], {
       allowEmptyStatement: true
     });
-    const statementSeparator =
-      statement.contents !== undefined && statement.contents.parts[0] === ";"
-        ? ""
-        : " ";
+    const statementSeparator = isStatementEmptyStatement(statement) ? "" : " ";
 
     const expression = this.visit(ctx.expression);
 
@@ -249,10 +236,7 @@ class BlocksAndStatementPrettierVisitor {
     const statement = this.visit(ctx.statement[0], {
       allowEmptyStatement: true
     });
-    const statementSeparator =
-      statement.contents !== undefined && statement.contents.parts[0] === ";"
-        ? ""
-        : " ";
+    const statementSeparator = isStatementEmptyStatement(statement) ? "" : " ";
 
     return rejectAndConcat([
       rejectAndJoin(" ", [ctx.For[0], ctx.LBrace[0]]),
@@ -290,10 +274,7 @@ class BlocksAndStatementPrettierVisitor {
     const statement = this.visit(ctx.statement[0], {
       allowEmptyStatement: true
     });
-    const statementSeparator =
-      statement.contents !== undefined && statement.contents.parts[0] === ";"
-        ? ""
-        : " ";
+    const statementSeparator = isStatementEmptyStatement(statement) ? "" : " ";
 
     return rejectAndConcat([
       rejectAndJoin(" ", [ctx.For[0], ctx.LBrace[0]]),

--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -286,10 +286,10 @@ class ClassesPrettierVisitor {
     const header = this.visit(ctx.methodHeader);
     const body = this.visit(ctx.methodBody);
     const headerBodySeparator =
-      body &&
-      body.contents &&
-      body.contents.parts &&
-      body.contents.parts.includes(";")
+      body !== undefined &&
+      body.type === "concat" &&
+      body.parts &&
+      body.parts.includes(";")
         ? ""
         : " ";
 

--- a/packages/prettier-plugin-java/src/printers/interfaces.js
+++ b/packages/prettier-plugin-java/src/printers/interfaces.js
@@ -143,10 +143,10 @@ class InterfacesPrettierVisitor {
     const methodHeader = this.visit(ctx.methodHeader);
     const methodBody = this.visit(ctx.methodBody);
     const separator =
-      methodBody &&
-      methodBody.contents &&
-      methodBody.contents.parts &&
-      methodBody.contents.parts.includes(";")
+      methodBody !== undefined &&
+      methodBody.type === "concat" &&
+      methodBody.parts &&
+      methodBody.parts.includes(";")
         ? ""
         : " ";
 

--- a/packages/prettier-plugin-java/src/printers/prettier-builder.js
+++ b/packages/prettier-plugin-java/src/printers/prettier-builder.js
@@ -44,7 +44,7 @@ function getImageWithComments(token) {
       arr.pop();
     }
   }
-  return group(concat(arr));
+  return concat(arr);
 }
 
 function formatComment(comment) {

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -523,6 +523,10 @@ function getCSTNodeStartEndToken(ctx) {
   return startEndTokens;
 }
 
+function isStatementEmptyStatement(statement) {
+  return statement.type === "concat" && statement.parts[0] === ";";
+}
+
 module.exports = {
   buildFqn,
   reject,
@@ -547,5 +551,6 @@ module.exports = {
   isShiftOperator,
   retrieveNodesToken,
   buildOriginalText,
-  getCSTNodeStartEndToken
+  getCSTNodeStartEndToken,
+  isStatementEmptyStatement
 };

--- a/packages/prettier-plugin-java/test/unit-test/comments/package/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/package/_output.java
@@ -6,7 +6,10 @@
     /*a*/to /*b*/another/*a*/, /*b*/again/*c*/, /*d*/ano/*a*/;/*b*/
 
   // opens
-    /*a*/opens /*b*/fr.soat.vending.machine.model /*a*/to /*b*/another/*a*/, /*b*/again/*c*/, /*d*/ano/*a*/;/*b*/
+    /*a*/opens /*b*/fr.soat.vending.machine.model /*a*/to
+      /*b*/another/*a*/,
+      /*b*/again/*c*/,
+      /*d*/ano/*a*/;/*b*/
 
   // uses
   /*a*/uses /*b*/fr.soat.vendinga/*a*/./*b*/machine.services.DrinksService/*a*/;/*b*/


### PR DESCRIPTION
Fixes multi-lines comments as:

```
public class Test<TEST, RZE>
    extends Go
    implements Alpha, Beta, Alpha, Alpha, Alpha, Alpha, Alpha, Alpha {

    /*
    comment
     */
    @Pointcut("within(@org.springframework.stereotype.Repository *)" +
        " || within(@org.springframework.stereotype.Service *)" +
        " || within(@org.springframework.web.bind.annotation.RestController *)")
    public void springBeanPointcut() {
        // Method is empty as this is just a Pointcut, the implementations are in the advices.
    }
}
```

The annotation was previously printed on one line. 

It was the last "major" bug I had in mind