### PR TITLE
Better display of localVariableDeclarationStatement modifiers

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
@@ -18,7 +18,8 @@ const {
   rejectSeparators,
   putIntoBraces,
   putIntoCurlyBraces,
-  isStatementEmptyStatement
+  isStatementEmptyStatement,
+  sortModifiers
 } = require("./printer-utils");
 
 class BlocksAndStatementPrettierVisitor {
@@ -54,15 +55,20 @@ class BlocksAndStatementPrettierVisitor {
   }
 
   localVariableDeclaration(ctx) {
-    const variableModifiers = this.mapVisit(ctx.variableModifier);
+    const modifiers = sortModifiers(ctx.variableModifier);
+    const firstAnnotations = this.mapVisit(modifiers[0]);
+    const finalModifiers = this.mapVisit(modifiers[1]);
+
     const localVariableType = this.visit(ctx.localVariableType);
     const variableDeclaratorList = this.visit(ctx.variableDeclaratorList);
-    return group(
-      rejectAndJoin(line, [
-        rejectAndJoin(" ", variableModifiers),
-        rejectAndJoin(" ", [localVariableType, variableDeclaratorList])
+    return rejectAndJoin(hardline, [
+      rejectAndJoin(hardline, firstAnnotations),
+      rejectAndJoin(" ", [
+        rejectAndJoin(" ", finalModifiers),
+        localVariableType,
+        variableDeclaratorList
       ])
-    );
+    ]);
   }
 
   localVariableType(ctx) {

--- a/packages/prettier-plugin-java/test/unit-test/variables/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_input.java
@@ -52,4 +52,25 @@ public class Variables {
     Map<String, String> map = new HashMap<>();
   }
 
+  public boolean localVariableDeclarationWhichBreak() {
+    @Nullable final BackupStatus lastStatus = BackupStatus.fromDbValue(backupRepository.getLastStatus());
+
+    final BackupStatus lastStatus = BackupStatus.fromDbValue(backupRepository.getLastStatus());
+
+    @Nullable
+    BackupStatus lastStatus = BackupStatus.fromDbValue(backupRepository.getLastStatus());
+
+    BackupStatus lastStatus = BackupStatus.fromDbValue(backupRepository.getLastStatus());
+  }
+
+  public boolean localVariableDeclarationWhichDoNotBreak() {
+    @Nullable final BackupStatus lastStatus = value;
+
+    final BackupStatus lastStatus = value;
+
+    @Nullable BackupStatus lastStatus = value;
+
+    BackupStatus lastStatus = value;
+  }
+
 }

--- a/packages/prettier-plugin-java/test/unit-test/variables/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_output.java
@@ -65,4 +65,36 @@ public class Variables {
     String str = new String();
     Map<String, String> map = new HashMap<>();
   }
+
+  public boolean localVariableDeclarationWhichBreak() {
+    @Nullable
+    final BackupStatus lastStatus = BackupStatus.fromDbValue(
+      backupRepository.getLastStatus()
+    );
+
+    final BackupStatus lastStatus = BackupStatus.fromDbValue(
+      backupRepository.getLastStatus()
+    );
+
+    @Nullable
+    BackupStatus lastStatus = BackupStatus.fromDbValue(
+      backupRepository.getLastStatus()
+    );
+
+    BackupStatus lastStatus = BackupStatus.fromDbValue(
+      backupRepository.getLastStatus()
+    );
+  }
+
+  public boolean localVariableDeclarationWhichDoNotBreak() {
+    @Nullable
+    final BackupStatus lastStatus = value;
+
+    final BackupStatus lastStatus = value;
+
+    @Nullable
+    BackupStatus lastStatus = value;
+
+    BackupStatus lastStatus = value;
+  }
 }


### PR DESCRIPTION
Fix #282 

@lppedd, this would now be formatted like this:

```java
public boolean localVariableDeclarationWhichBreak() {
    @Nullable
    final BackupStatus lastStatus = BackupStatus.fromDbValue(
      backupRepository.getLastStatus()
    );

    final BackupStatus lastStatus = BackupStatus.fromDbValue(
      backupRepository.getLastStatus()
    );

    @Nullable
    BackupStatus lastStatus = BackupStatus.fromDbValue(
      backupRepository.getLastStatus()
    );

    BackupStatus lastStatus = BackupStatus.fromDbValue(
      backupRepository.getLastStatus()
    );
  }

  public boolean localVariableDeclarationWhichDoNotBreak() {
    @Nullable
    final BackupStatus lastStatus = value;

    final BackupStatus lastStatus = value;

    @Nullable
    BackupStatus lastStatus = value;

    BackupStatus lastStatus = value;
  }
```