### PR TITLE
fix: fix stable reformating when wrapping return statements

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -229,9 +229,11 @@ class ExpressionsPrettierVisitor {
           indent(
             concat([
               softline,
-              rejectAndJoinSeps(
-                sortedBinaryOperators.map(elt => concat([" ", elt, line])),
-                segmentsSplittedByBinaryOperator
+              group(
+                rejectAndJoinSeps(
+                  sortedBinaryOperators.map(elt => concat([" ", elt, line])),
+                  segmentsSplittedByBinaryOperator
+                )
               )
             ])
           ),

--- a/packages/prettier-plugin-java/test/unit-test/return/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/return/_input.java
@@ -36,4 +36,8 @@ public abstract class Return {
     );
   }
 
+  // Bug fix #290
+  public boolean shouldBreakInOneLine(Example that) {
+    return oneVeryLongPrimaryExpression && andYetAnotherVeryVeryLongPrimaryExpression;
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/return/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/return/_output.java
@@ -43,4 +43,11 @@ public abstract class Return {
       seventhVariable
     );
   }
+
+  // Bug fix #290
+  public boolean shouldBreakInOneLine(Example that) {
+    return (
+      oneVeryLongPrimaryExpression && andYetAnotherVeryVeryLongPrimaryExpression
+    );
+  }
 }


### PR DESCRIPTION
Fix #290 