### PR TITLE
performance(parser) - Optimize Parser Init

### DIFF
--- a/packages/java-parser/.mocharc.js
+++ b/packages/java-parser/.mocharc.js
@@ -1,0 +1,4 @@
+// Enabled Additional validation flows during Parser / Lexer Initialization.
+process.env["prettier-java-development-mode"] = "enabled";
+
+module.exports = {};

--- a/packages/java-parser/src/index.js
+++ b/packages/java-parser/src/index.js
@@ -8,6 +8,7 @@ const {
 } = require("./comments");
 
 const parser = new JavaParser();
+
 const BaseJavaCstVisitor = parser.getBaseCstVisitorConstructor();
 const BaseJavaCstVisitorWithDefaults = parser.getBaseCstVisitorConstructorWithDefaults();
 

--- a/packages/java-parser/src/lexer.js
+++ b/packages/java-parser/src/lexer.js
@@ -1,9 +1,12 @@
 "use strict";
 const chevrotain = require("chevrotain");
 const { allTokens } = require("./tokens");
+const { getSkipValidations } = require("./utils");
 
 const Lexer = chevrotain.Lexer;
-
-const JavaLexer = new Lexer(allTokens, { ensureOptimizations: true });
+const JavaLexer = new Lexer(allTokens, {
+  ensureOptimizations: true,
+  skipValidations: getSkipValidations()
+});
 
 module.exports = JavaLexer;

--- a/packages/java-parser/src/parser.js
+++ b/packages/java-parser/src/parser.js
@@ -11,6 +11,7 @@ const arrays = require("./productions/arrays");
 const blocksStatements = require("./productions/blocks-and-statements");
 const expressions = require("./productions/expressions");
 const { shouldIgnore } = require("./comments");
+const { getSkipValidations } = require("./utils");
 
 /**
  * This parser attempts to strongly align with the specs style at:
@@ -38,10 +39,12 @@ const { shouldIgnore } = require("./comments");
 class JavaParser extends Parser {
   constructor() {
     super(allTokens, {
-      // TODO: performance: maxLookahead = 1 may be faster, but could we refactor the grammar to it?
-      //       and more importantly, do we want to?
+      // TODO: Try to Specify max lookahead 2 only where needed
+      //       and use `1` by default
       maxLookahead: 2,
-      nodeLocationTracking: "full"
+      nodeLocationTracking: "full",
+      // traceInitPerf: 2,
+      skipValidations: getSkipValidations()
     });
 
     const $ = this;

--- a/packages/java-parser/src/utils.js
+++ b/packages/java-parser/src/utils.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/**
+ * Should Parser / Lexer Validations be skipped?
+ *
+ * By default (productive mode) the validations would be skipped to reduce parser initialization time.
+ * But during development flows (e.g testing/CI) they should be enabled to detect possible issues.
+ *
+ * @returns {boolean}
+ */
+function getSkipValidations() {
+  return (
+    (process && // (not every runtime has a global `process` object
+      process.env &&
+      process.env["prettier-java-development-mode"] === "enabled") === false
+  );
+}
+
+module.exports = {
+  getSkipValidations
+};


### PR DESCRIPTION
Optimize Parser (And Lexer) initialization performance by skipping validation
during productive flows.
The validations are still executed during testing flows using
a mocha configuration file that adds an env variable.

On my Machine the Parser's init time went from 160ms->90ms
And the Lexer's init time went from 30ms->20ms.

Fixes #269