### PR TITLE
fix(lexer): "transitive" keyword as Identifier in module requires.

### DIFF
--- a/packages/java-parser/src/productions/packages-and-modules.js
+++ b/packages/java-parser/src/productions/packages-and-modules.js
@@ -147,8 +147,22 @@ function defineRules($, t) {
   $.RULE("requiresModuleDirective", () => {
     // Spec Deviation: extracted from "moduleDirective"
     $.CONSUME(t.Requires);
-    $.MANY(() => {
-      $.SUBRULE($.requiresModifier);
+    $.MANY({
+      GATE: () => {
+        /**
+         * https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.9 -
+         *   There is one exception: immediately to the right of the character sequence `requires` in the ModuleDirective production,
+         *   the character sequence `transitive` is tokenized as a keyword unless it is followed by a separator,
+         *   in which case it is tokenized as an identifier.
+         */
+        return (
+          (tokenMatcher($.LA(1).tokenType, t.Transitive) &&
+            tokenMatcher($.LA(2).tokenType, t.Separators)) === false
+        );
+      },
+      DEF: () => {
+        $.SUBRULE($.requiresModifier);
+      }
     });
     $.SUBRULE($.moduleName);
     $.CONSUME(t.Semicolon);

--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -168,6 +168,12 @@ const UnarySuffixOperator = createToken({
   pattern: Lexer.NA
 });
 
+// https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.11
+const Separators = createToken({
+  name: "Separators",
+  pattern: Lexer.NA
+});
+
 // https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.6
 // Note [\\x09\\x20\\x0C] is equivalent to [\\t\\x20\\f] and that \\x20 represents
 // space character
@@ -342,21 +348,21 @@ createKeywordLikeToken({ name: "False", pattern: "false" });
 createKeywordLikeToken({ name: "Null", pattern: "null" });
 
 // punctuation and symbols
-createToken({ name: "At", pattern: "@" });
+createToken({ name: "At", pattern: "@", categories: [Separators] });
 createToken({ name: "Arrow", pattern: "->" });
-createToken({ name: "DotDotDot", pattern: "..." });
-createToken({ name: "Dot", pattern: "." });
-createToken({ name: "Comma", pattern: "," });
-createToken({ name: "Semicolon", pattern: ";" });
-createToken({ name: "ColonColon", pattern: "::" });
+createToken({ name: "DotDotDot", pattern: "...", categories: [Separators] });
+createToken({ name: "Dot", pattern: ".", categories: [Separators] });
+createToken({ name: "Comma", pattern: ",", categories: [Separators] });
+createToken({ name: "Semicolon", pattern: ";", categories: [Separators] });
+createToken({ name: "ColonColon", pattern: "::", categories: [Separators] });
 createToken({ name: "Colon", pattern: ":" });
 createToken({ name: "QuestionMark", pattern: "?" });
-createToken({ name: "LBrace", pattern: "(" });
-createToken({ name: "RBrace", pattern: ")" });
-createToken({ name: "LCurly", pattern: "{" });
-createToken({ name: "RCurly", pattern: "}" });
-createToken({ name: "LSquare", pattern: "[" });
-createToken({ name: "RSquare", pattern: "]" });
+createToken({ name: "LBrace", pattern: "(", categories: [Separators] });
+createToken({ name: "RBrace", pattern: ")", categories: [Separators] });
+createToken({ name: "LCurly", pattern: "{", categories: [Separators] });
+createToken({ name: "RCurly", pattern: "}", categories: [Separators] });
+createToken({ name: "LSquare", pattern: "[", categories: [Separators] });
+createToken({ name: "RSquare", pattern: "]", categories: [Separators] });
 
 // prefix and suffix operators
 // must be defined before "-"

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -3,10 +3,25 @@
 const { expect } = require("chai");
 const javaParser = require("../src/index");
 
+// TODO: we don't need to copy the describe section so many times in this file...
+//   `IT` should be nested under describe...
 describe("The Java Parser fixed bugs", () => {
   it("issue #129 - this.<bar>.baz()", () => {
     const input = "this.<Number>anyIterableType()";
     expect(() => javaParser.parse(input, "expression")).to.not.throw();
+  });
+
+  it("issue #112 - Special handling of transitive keyword in module requires statement", () => {
+    const input = `module foo {
+      // Regular requires statement (without modifier)
+      requires java.base;
+      // "transitive" as keyword
+      requires transitive java.compiler;
+      // "transitive" as Identifier
+      requires transitive.foo;
+    }
+    `;
+    expect(() => javaParser.parse(input)).to.not.throw();
   });
 });
 


### PR DESCRIPTION
The Special rule states that: a "transitive" keyword followed by a separator
in the context of a module requires would be parsed as an identifier
which is part of the moduleName instead of as a modifier.

This is handled by:
- Creating Separators token category.
- Adding a GATE before the "module requires" optional modifiers
  that inspects the next two tokens.

Fixes #112