### PR TITLE
Sort modifiers

### DIFF
--- a/packages/prettier-plugin-java/docs/modifiers.md
+++ b/packages/prettier-plugin-java/docs/modifiers.md
@@ -39,7 +39,7 @@ private static final String S = "abc";
 Input:
 
 ```java
-protected abstract class C {}
+abstract protected class C {}
 ```
 
 Output:

--- a/packages/prettier-plugin-java/docs/modifiers.md
+++ b/packages/prettier-plugin-java/docs/modifiers.md
@@ -1,0 +1,100 @@
+# Modifier formatting
+
+### Modifier sorting
+
+Class, method, and field modifiers will be sorted according to the order in the JLS (sections [8.1.1](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.1.1), [8.3.1](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.3.1), [8.4.3](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.4.3), and [9.4](https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html#jls-9.4)).
+The overall ordering is:
+
+- public
+- protected
+- private
+- abstract
+- default
+- static
+- final
+- transient
+- volatile
+- synchronized
+- native
+- strictfp
+
+#### Examples
+
+Input:
+
+```java
+final private static String S = "abc";
+```
+
+Output:
+
+```java
+private static final String S = "abc";
+```
+
+Input:
+
+```java
+protected abstract class C {}
+```
+
+Output:
+
+```java
+protected abstract class C {}
+```
+
+Input:
+
+```java
+static private void foo() {}
+```
+
+Output:
+
+```java
+private static void foo() {}
+```
+
+### Interaction with annotations
+
+If an annotation precedes all modifiers, it will be formatted ahead of the modifiers on its own line. Otherwise, it will be formatted after the modifiers, on the same line.
+
+#### Examples
+
+Input:
+
+```java
+@Annotation final private static String S = "abc";
+```
+
+Output:
+
+```java
+@Annotation
+private static final String S = "abc";
+```
+
+Input:
+
+```java
+final @Annotation private static String S = "abc";
+```
+
+Output:
+
+```java
+private static final @Annotation String S = "abc";
+```
+
+Input:
+
+```java
+final private static @Annotation String S = "abc";
+```
+
+Output:
+
+```java
+private static final @Annotation String S = "abc";
+```

--- a/packages/prettier-plugin-java/docs/modifiers.md
+++ b/packages/prettier-plugin-java/docs/modifiers.md
@@ -39,13 +39,13 @@ private static final String S = "abc";
 Input:
 
 ```java
-abstract protected class C {}
+final public class C {...}
 ```
 
 Output:
 
 ```java
-protected abstract class C {}
+public final class C {...}
 ```
 
 Input:

--- a/packages/prettier-plugin-java/docs/modifiers.md
+++ b/packages/prettier-plugin-java/docs/modifiers.md
@@ -2,7 +2,11 @@
 
 ### Modifier sorting
 
-Class, method, and field modifiers will be sorted according to the order in the JLS (sections [8.1.1](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.1.1), [8.3.1](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.3.1), [8.4.3](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.4.3), and [9.4](https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html#jls-9.4)).
+Class, method, and field modifiers will be sorted according to the order in the
+JLS (sections [8.1.1](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.1.1),
+[8.3.1](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.3.1),
+[8.4.3](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.4.3),
+and [9.4](https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html#jls-9.4)).
 The overall ordering is:
 
 - public
@@ -58,7 +62,11 @@ private static void foo() {}
 
 ### Interaction with annotations
 
-If an annotation precedes all modifiers, it will be formatted ahead of the modifiers on its own line. Otherwise, it will be formatted after the modifiers, on the same line.
+Class, field, and method annotations will be moved ahead of modifier keywords
+and placed on a separate line. The exception is method annotations that come
+after all modifier keywords, in which case the annotation will maintain the
+same position. This is to support annotations whose intent is to qualify the
+method's return type, rather than the method itself (for example: `public @Nullable String myMethod()`).
 
 #### Examples
 
@@ -78,23 +86,37 @@ private static final String S = "abc";
 Input:
 
 ```java
-final @Annotation private static String S = "abc";
-```
-
-Output:
-
-```java
-private static final @Annotation String S = "abc";
-```
-
-Input:
-
-```java
 final private static @Annotation String S = "abc";
 ```
 
 Output:
 
 ```java
-private static final @Annotation String S = "abc";
+@Annotation
+private static final String S = "abc";
+```
+
+Input:
+
+```java
+final public @Nullable String myMethod {}
+```
+
+Output:
+
+```java
+public final @Nullable String myMethod {}
+```
+
+Input:
+
+```java
+final @Override public String myMethod {}
+```
+
+Output:
+
+```java
+@Override
+public final String myMethod {}
 ```

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -4,6 +4,21 @@ const { join, concat, group } = require("./prettier-builder");
 const { printTokenWithComments } = require("./comments");
 const { indent, hardline } = require("prettier").doc.builders;
 
+const orderedModifiers = [
+  "Public",
+  "Protected",
+  "Private",
+  "Abstract",
+  "Default",
+  "Static",
+  "Final",
+  "Transient",
+  "Volatile",
+  "Synchronized",
+  "Native",
+  "Strictfp",
+];
+
 function buildFqn(tokens, dots) {
   return rejectAndJoinSeps(dots ? dots : [], tokens);
 }
@@ -142,6 +157,15 @@ function sortModifiers(modifiers) {
       otherModifiers.push(modifier);
       hasOtherModifier = true;
     }
+  });
+
+  otherModifiers.sort((a, b) => {
+    const modifierIndexA =
+        orderedModifiers.indexOf(Object.keys(a.children)[0]);
+    const modifierIndexB =
+        orderedModifiers.indexOf(Object.keys(b.children)[0]);
+
+    return modifierIndexA - modifierIndexB;
   });
 
   return [firstAnnotations, otherModifiers];

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -160,6 +160,15 @@ function sortModifiers(modifiers) {
   });
 
   otherModifiers.sort((a, b) => {
+    // sort annotations after modifiers
+    if (a.children.annotation && b.children.annotation) {
+      return 0;
+    } else if (a.children.annotation) {
+      return 1;
+    } else if (b.children.annotation) {
+      return -1;
+    }
+
     const modifierIndexA = orderedModifiers.indexOf(Object.keys(a.children)[0]);
     const modifierIndexB = orderedModifiers.indexOf(Object.keys(b.children)[0]);
 

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -16,7 +16,7 @@ const orderedModifiers = [
   "Volatile",
   "Synchronized",
   "Native",
-  "Strictfp",
+  "Strictfp"
 ];
 
 function buildFqn(tokens, dots) {
@@ -160,10 +160,8 @@ function sortModifiers(modifiers) {
   });
 
   otherModifiers.sort((a, b) => {
-    const modifierIndexA =
-        orderedModifiers.indexOf(Object.keys(a.children)[0]);
-    const modifierIndexB =
-        orderedModifiers.indexOf(Object.keys(b.children)[0]);
+    const modifierIndexA = orderedModifiers.indexOf(Object.keys(a.children)[0]);
+    const modifierIndexB = orderedModifiers.indexOf(Object.keys(b.children)[0]);
 
     return modifierIndexA - modifierIndexB;
   });

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -666,7 +666,8 @@ public final class ArrayTable<R, C, V>
     return columnKeyToIndex.keySet();
   }
 
-  private transient @MonotonicNonNull ColumnMap columnMap;
+  @MonotonicNonNull
+  private transient ColumnMap columnMap;
 
   @Override
   public Map<C, Map<R, V>> columnMap() {
@@ -755,7 +756,8 @@ public final class ArrayTable<R, C, V>
     return rowKeyToIndex.keySet();
   }
 
-  private transient @MonotonicNonNull RowMap rowMap;
+  @MonotonicNonNull
+  private transient RowMap rowMap;
 
   @Override
   public Map<R, Map<C, V>> rowMap() {

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
@@ -1,0 +1,25 @@
+static public interface InterfaceWithModifiers {
+  static final public String INTERFACE_CONSTANT = "abc";
+
+  default public String interfaceDefaultMethod() {
+    return INTERFACE_CONSTANT;
+  }
+
+  static public String interfaceStaticMethod() {
+    return INTERFACE_CONSTANT;
+  }
+}
+
+abstract public class AbstractClassWithModifiers {
+  volatile private static String field;
+
+  abstract synchronized protected String method();
+}
+
+final static public class ClassWithModifiers {
+  transient final private static String CONSTANT = "abc";
+
+  final static synchronized protected String method() {
+    return CONSTANT;
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
@@ -4,15 +4,17 @@
   static final @AnnotationOne public String INTERFACE_CONSTANT = "abc";
 
     @AnnotationOne
-  @AnnotationTwo default public @AnnotationThree String interfaceDefaultMethod() {
+  @AnnotationTwo default public @AnnotationThree String defaultMethod() {
     return INTERFACE_CONSTANT;
   }
 
-  static @AnnotationOne public @AnnotationTwo String interfaceStaticMethod() {
+  static @AnnotationOne public @AnnotationTwo String staticMethod() {
     return INTERFACE_CONSTANT;
   }
 
-  @AnnotationOne void interfaceMethodOnlyAnnotations();
+  public @AnnotationOne @AnnotationTwo void twoTrailingAnnotations();
+
+  @AnnotationOne void onlyAnnotations();
 }
 
 @AnnotationOne abstract public @AnnotationTwo class AbstractClassWithModifiers {
@@ -20,6 +22,8 @@
 
   @AnnotationOne
   @AnnotationTwo abstract synchronized protected @AnnotationThree String method();
+
+  public @AnnotationOne @AnnotationTwo void twoTrailingAnnotations() {}
 
   @AnnotationOne void onlyAnnotations() {}
 }
@@ -30,6 +34,8 @@ final @AnnotationOne static public @AnnotationTwo class ClassWithModifiers {
   final @AnnotationOne static @AnnotationTwo synchronized protected @AnnotationThree String method() {
     return CONSTANT;
   }
+
+  public @AnnotationOne @AnnotationTwo void twoTrailingAnnotations() {}
 
   @AnnotationOne void onlyAnnotations() {}
 }

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
@@ -1,25 +1,25 @@
-static public interface InterfaceWithModifiers {
-  static final public String INTERFACE_CONSTANT = "abc";
+@Annotation(annotationAttribute = CONSTANT_STRING) static public interface InterfaceWithModifiers {
+  static final @Annotation(annotationAttribute = CONSTANT_STRING) public String INTERFACE_CONSTANT = "abc";
 
-  default public String interfaceDefaultMethod() {
+  @Annotation(annotationAttribute = CONSTANT_STRING) default public String interfaceDefaultMethod() {
     return INTERFACE_CONSTANT;
   }
 
-  static public String interfaceStaticMethod() {
+  static @Annotation(annotationAttribute = CONSTANT_STRING) public String interfaceStaticMethod() {
     return INTERFACE_CONSTANT;
   }
 }
 
-abstract public class AbstractClassWithModifiers {
-  volatile private static String field;
+@Annotation(annotationAttribute = CONSTANT_STRING) abstract public class AbstractClassWithModifiers {
+  volatile private @Annotation(annotationAttribute = CONSTANT_STRING) static String field;
 
-  abstract synchronized protected String method();
+  @Annotation(annotationAttribute = CONSTANT_STRING) abstract synchronized protected String method();
 }
 
-final static public class ClassWithModifiers {
-  transient final private static String CONSTANT = "abc";
+final static public @Annotation(annotationAttribute = CONSTANT_STRING) class ClassWithModifiers {
+  transient @Annotation(annotationAttribute = CONSTANT_STRING) final private static String CONSTANT = "abc";
 
-  final static synchronized protected String method() {
+  final static synchronized protected @Annotation(annotationAttribute = CONSTANT_STRING) String method() {
     return CONSTANT;
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
@@ -1,25 +1,35 @@
-@Annotation(annotationAttribute = CONSTANT_STRING) static public interface InterfaceWithModifiers {
-  static final @Annotation(annotationAttribute = CONSTANT_STRING) public String INTERFACE_CONSTANT = "abc";
+  @AnnotationOne
 
-  @Annotation(annotationAttribute = CONSTANT_STRING) default public String interfaceDefaultMethod() {
+@AnnotationTwo static public @AnnotationThree interface InterfaceWithModifiers {
+  static final @AnnotationOne public String INTERFACE_CONSTANT = "abc";
+
+    @AnnotationOne
+  @AnnotationTwo default public @AnnotationThree String interfaceDefaultMethod() {
     return INTERFACE_CONSTANT;
   }
 
-  static @Annotation(annotationAttribute = CONSTANT_STRING) public String interfaceStaticMethod() {
+  static @AnnotationOne public @AnnotationTwo String interfaceStaticMethod() {
     return INTERFACE_CONSTANT;
   }
+
+  @AnnotationOne void interfaceMethodOnlyAnnotations();
 }
 
-@Annotation(annotationAttribute = CONSTANT_STRING) abstract public class AbstractClassWithModifiers {
-  volatile private @Annotation(annotationAttribute = CONSTANT_STRING) static String field;
+@AnnotationOne abstract public @AnnotationTwo class AbstractClassWithModifiers {
+  volatile private @Annotation static String field;
 
-  @Annotation(annotationAttribute = CONSTANT_STRING) abstract synchronized protected String method();
+  @AnnotationOne
+  @AnnotationTwo abstract synchronized protected @AnnotationThree String method();
+
+  @AnnotationOne void onlyAnnotations() {}
 }
 
-final static public @Annotation(annotationAttribute = CONSTANT_STRING) class ClassWithModifiers {
-  transient @Annotation(annotationAttribute = CONSTANT_STRING) final private static String CONSTANT = "abc";
+final @AnnotationOne static public @AnnotationTwo class ClassWithModifiers {
+  transient @AnnotationOne final private @AnnotationTwo static String CONSTANT = "abc";
 
-  final static synchronized protected @Annotation(annotationAttribute = CONSTANT_STRING) String method() {
+  final @AnnotationOne static @AnnotationTwo synchronized protected @AnnotationThree String method() {
     return CONSTANT;
   }
+
+  @AnnotationOne void onlyAnnotations() {}
 }

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
@@ -1,25 +1,41 @@
+@Annotation(annotationAttribute = CONSTANT_STRING)
 public static interface InterfaceWithModifiers {
-  public static final String INTERFACE_CONSTANT = "abc";
+  public static final @Annotation(
+    annotationAttribute = CONSTANT_STRING
+  ) String INTERFACE_CONSTANT = "abc";
 
+  @Annotation(annotationAttribute = CONSTANT_STRING)
   public default String interfaceDefaultMethod() {
     return INTERFACE_CONSTANT;
   }
 
-  public static String interfaceStaticMethod() {
+  public static @Annotation(
+    annotationAttribute = CONSTANT_STRING
+  ) String interfaceStaticMethod() {
     return INTERFACE_CONSTANT;
   }
 }
 
+@Annotation(annotationAttribute = CONSTANT_STRING)
 public abstract class AbstractClassWithModifiers {
-  private static volatile String field;
+  private static volatile @Annotation(
+    annotationAttribute = CONSTANT_STRING
+  ) String field;
 
+  @Annotation(annotationAttribute = CONSTANT_STRING)
   protected abstract synchronized String method();
 }
 
-public static final class ClassWithModifiers {
-  private static final transient String CONSTANT = "abc";
+public static final @Annotation(
+  annotationAttribute = CONSTANT_STRING
+) class ClassWithModifiers {
+  private static final transient @Annotation(
+    annotationAttribute = CONSTANT_STRING
+  ) String CONSTANT = "abc";
 
-  protected static final synchronized String method() {
+  protected static final synchronized @Annotation(
+    annotationAttribute = CONSTANT_STRING
+  ) String method() {
     return CONSTANT;
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
@@ -1,41 +1,52 @@
-@Annotation(annotationAttribute = CONSTANT_STRING)
+@AnnotationOne
+@AnnotationTwo
+@AnnotationThree
 public static interface InterfaceWithModifiers {
-  public static final @Annotation(
-    annotationAttribute = CONSTANT_STRING
-  ) String INTERFACE_CONSTANT = "abc";
+  @AnnotationOne
+  public static final String INTERFACE_CONSTANT = "abc";
 
-  @Annotation(annotationAttribute = CONSTANT_STRING)
-  public default String interfaceDefaultMethod() {
+  @AnnotationOne
+  @AnnotationTwo
+  public default @AnnotationThree String interfaceDefaultMethod() {
     return INTERFACE_CONSTANT;
   }
 
-  public static @Annotation(
-    annotationAttribute = CONSTANT_STRING
-  ) String interfaceStaticMethod() {
+  @AnnotationOne
+  public static @AnnotationTwo String interfaceStaticMethod() {
     return INTERFACE_CONSTANT;
   }
+
+  @AnnotationOne
+  void interfaceMethodOnlyAnnotations();
 }
 
-@Annotation(annotationAttribute = CONSTANT_STRING)
+@AnnotationOne
+@AnnotationTwo
 public abstract class AbstractClassWithModifiers {
-  private static volatile @Annotation(
-    annotationAttribute = CONSTANT_STRING
-  ) String field;
+  @Annotation
+  private static volatile String field;
 
-  @Annotation(annotationAttribute = CONSTANT_STRING)
-  protected abstract synchronized String method();
+  @AnnotationOne
+  @AnnotationTwo
+  protected abstract synchronized @AnnotationThree String method();
+
+  @AnnotationOne
+  void onlyAnnotations() {}
 }
 
-public static final @Annotation(
-  annotationAttribute = CONSTANT_STRING
-) class ClassWithModifiers {
-  private static final transient @Annotation(
-    annotationAttribute = CONSTANT_STRING
-  ) String CONSTANT = "abc";
+@AnnotationOne
+@AnnotationTwo
+public static final class ClassWithModifiers {
+  @AnnotationOne
+  @AnnotationTwo
+  private static final transient String CONSTANT = "abc";
 
-  protected static final synchronized @Annotation(
-    annotationAttribute = CONSTANT_STRING
-  ) String method() {
+  @AnnotationOne
+  @AnnotationTwo
+  protected static final synchronized @AnnotationThree String method() {
     return CONSTANT;
   }
+
+  @AnnotationOne
+  void onlyAnnotations() {}
 }

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
@@ -7,17 +7,19 @@ public static interface InterfaceWithModifiers {
 
   @AnnotationOne
   @AnnotationTwo
-  public default @AnnotationThree String interfaceDefaultMethod() {
+  public default @AnnotationThree String defaultMethod() {
     return INTERFACE_CONSTANT;
   }
 
   @AnnotationOne
-  public static @AnnotationTwo String interfaceStaticMethod() {
+  public static @AnnotationTwo String staticMethod() {
     return INTERFACE_CONSTANT;
   }
 
+  public @AnnotationOne @AnnotationTwo void twoTrailingAnnotations();
+
   @AnnotationOne
-  void interfaceMethodOnlyAnnotations();
+  void onlyAnnotations();
 }
 
 @AnnotationOne
@@ -29,6 +31,8 @@ public abstract class AbstractClassWithModifiers {
   @AnnotationOne
   @AnnotationTwo
   protected abstract synchronized @AnnotationThree String method();
+
+  public @AnnotationOne @AnnotationTwo void twoTrailingAnnotations() {}
 
   @AnnotationOne
   void onlyAnnotations() {}
@@ -46,6 +50,8 @@ public static final class ClassWithModifiers {
   protected static final synchronized @AnnotationThree String method() {
     return CONSTANT;
   }
+
+  public @AnnotationOne @AnnotationTwo void twoTrailingAnnotations() {}
 
   @AnnotationOne
   void onlyAnnotations() {}

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
@@ -1,0 +1,25 @@
+public static interface InterfaceWithModifiers {
+  public static final String INTERFACE_CONSTANT = "abc";
+
+  public default String interfaceDefaultMethod() {
+    return INTERFACE_CONSTANT;
+  }
+
+  public static String interfaceStaticMethod() {
+    return INTERFACE_CONSTANT;
+  }
+}
+
+public abstract class AbstractClassWithModifiers {
+  private static volatile String field;
+
+  protected abstract synchronized String method();
+}
+
+public static final class ClassWithModifiers {
+  private static final transient String CONSTANT = "abc";
+
+  protected static final synchronized String method() {
+    return CONSTANT;
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/modifiers-spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/modifiers-spec.js
@@ -1,0 +1,3 @@
+describe("prettier-java", () => {
+    require("../../test-utils").testSample(__dirname);
+});

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/modifiers-spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/modifiers-spec.js
@@ -1,3 +1,3 @@
 describe("prettier-java", () => {
-    require("../../test-utils").testSample(__dirname);
+  require("../../test-utils").testSample(__dirname);
 });


### PR DESCRIPTION
Related to #291 

I had some trouble getting access to the actual modifier name ("public", "static", "private", etc.) and I don't write much javascript so any feedback on the code is welcome. 

There is an existing `sortModifiers` function that everything goes through, however it seems to just separate leading annotations from all other annotations/modifiers. I tried to preserve the behavior of this function, however it conflicts a bit with the new modifier sorting behavior. 

For example, if you have this code:
`final @Annotation private String field;`

Currently, prettier-java leaves this code alone. However, we want to swap the order of the `final` and `private` modifiers, but it's not clear what should happen to `@Annotation` when we do this. As currently written, this PR moves all such annotations to the end, and would output:
`private final @Annotation String field;`

Some other options that come to mind:
- unconditionally move annotations ahead of modifiers, which means you can't write a method signature like `public @Nullable String myMethod()`
- move annotations to the front unless they come after all modifiers, which still allows method signatures like `public @Nullable String myMethod()`