### PR TITLE
fix: fix formating for variable arity parameters with variable modifier

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -461,14 +461,22 @@ class ClassesPrettierVisitor {
   variableArityParameter(ctx) {
     const variableModifier = this.mapVisit(ctx.variableModifier);
     const unannType = this.visit(ctx.unannType);
-    const annotation = this.mapVisit(ctx.annotation);
+    const annotations = this.mapVisit(ctx.annotation);
     const identifier = ctx.Identifier[0];
 
-    return rejectAndConcat([
+    const unannTypePrinted =
+      ctx.annotation === undefined
+        ? concat([unannType, ctx.DotDotDot[0]])
+        : unannType;
+    const annotationsPrinted =
+      ctx.annotation === undefined
+        ? annotations
+        : concat([rejectAndJoin(" ", annotations), ctx.DotDotDot[0]]);
+
+    return rejectAndJoin(" ", [
       join(" ", variableModifier),
-      unannType,
-      join(" ", annotation),
-      concat([ctx.DotDotDot[0], " "]),
+      unannTypePrinted,
+      annotationsPrinted,
       identifier
     ]);
   }

--- a/packages/prettier-plugin-java/test/unit-test/args/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/args/_input.java
@@ -13,4 +13,12 @@ public class Args {
 
   void lastParameterDotDotDot(String str1, String... str2) {
   }
+
+  // TODO: uncomment when the parser variable arity bug is fixed (see #139)
+  // void variableArityParameters(Object @Nullable... errorMessageArgs) {}
+
+  void variableArityParameters(final String... strings) {
+
+  }
+
 }

--- a/packages/prettier-plugin-java/test/unit-test/args/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/args/_output.java
@@ -18,4 +18,8 @@ public class Args {
   ) {}
 
   void lastParameterDotDotDot(String str1, String... str2) {}
+
+  // TODO: uncomment when the parser variable arity bug is fixed (see #139)
+  // void variableArityParameters(Object @Nullable... errorMessageArgs) {}
+  void variableArityParameters(final String... strings) {}
 }


### PR DESCRIPTION
Fix #303 

Related to #139: I ignored one test case as there is a known bug in the parser we didn't solve yet about variableArityParameters. This test case should be uncommented when this bug is solved.