### PR TITLE
fix: ternary expression should break before `?` and `:`

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -131,20 +131,16 @@ class ExpressionsPrettierVisitor {
       const expression1 = this.visit(ctx.expression[0]);
       const expression2 = this.visit(ctx.expression[1]);
 
-      return group(
-        rejectAndConcat([
-          group(
-            rejectAndConcat([
+      return indent(
+        group(
+          rejectAndConcat([
+            rejectAndJoin(line, [
               binaryExpression,
-              indent(line),
-              concat([ctx.QuestionMark[0], " "]),
-              expression1
+              rejectAndJoin(" ", [ctx.QuestionMark[0], expression1]),
+              rejectAndJoin(" ", [ctx.Colon[0], expression2])
             ])
-          ),
-          indent(line),
-          concat([ctx.Colon[0], " "]),
-          expression2
-        ])
+          ])
+        )
       );
     }
     return binaryExpression;

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
@@ -10,6 +10,7 @@ public class BinaryOperations {
 
   public void ternaryOperationThatShouldBreak() {
     int shortInteger = thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne ? thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne : thisIsAShortInteger;
+    int shortInteger2 = thisIsAVeryLongInteger ? thisIsAnotherVeryLongOne : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
   }
 
   public void ternaryOperationThatShouldNotBreak() {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -15,6 +15,9 @@ public class BinaryOperations {
     int shortInteger = thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne
       ? thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne
       : thisIsAShortInteger;
+    int shortInteger2 = thisIsAVeryLongInteger
+      ? thisIsAnotherVeryLongOne
+      : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
   }
 
   public void ternaryOperationThatShouldNotBreak() {

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -452,7 +452,8 @@ public final class ArrayTable<R, C, V>
   public V get(@Nullable Object rowKey, @Nullable Object columnKey) {
     Integer rowIndex = rowKeyToIndex.get(rowKey);
     Integer columnIndex = columnKeyToIndex.get(columnKey);
-    return (rowIndex == null || columnIndex == null) ? null
+    return (rowIndex == null || columnIndex == null)
+      ? null
       : at(rowIndex, columnIndex);
   }
 
@@ -627,7 +628,8 @@ public final class ArrayTable<R, C, V>
   public Map<R, V> column(C columnKey) {
     checkNotNull(columnKey);
     Integer columnIndex = columnKeyToIndex.get(columnKey);
-    return (columnIndex == null) ? ImmutableMap.<R, V>of()
+    return (columnIndex == null)
+      ? ImmutableMap.<R, V>of()
       : new Column(columnIndex);
   }
 


### PR DESCRIPTION
Fix #312 