### PR TITLE
Feature/enums improvements

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -674,7 +674,9 @@ class ClassesPrettierVisitor {
 
   enumConstantList(ctx) {
     const enumConstants = this.mapVisit(ctx.enumConstant);
-    const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, line])) : [];
+    const commas = ctx.Comma
+      ? ctx.Comma.map(elt => concat([elt, hardline]))
+      : [];
 
     return group(rejectAndJoinSeps(commas, enumConstants));
   }

--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -16,11 +16,7 @@ const {
   isStatementEmptyStatement
 } = require("./printer-utils");
 const { concat, join, group, indent } = require("./prettier-builder");
-const {
-  printTokenWithComments,
-  getTokenLeadingComments,
-  getTokenTrailingComments
-} = require("./comments");
+const { printTokenWithComments } = require("./comments");
 
 class ClassesPrettierVisitor {
   classDeclaration(ctx) {
@@ -657,15 +653,10 @@ class ClassesPrettierVisitor {
     const enumConstantList = this.visit(ctx.enumConstantList);
     const enumBodyDeclarations = this.visit(ctx.enumBodyDeclarations);
 
-    const optionnalComma = ctx.Comma
-      ? ctx.Comma.map(elt => concat([elt, " "]))
-      : [];
+    const optionalComma = ctx.Comma ? { ...ctx.Comma[0], image: "" } : "";
 
     return putIntoCurlyBraces(
-      rejectAndJoinSeps(optionnalComma, [
-        enumConstantList,
-        enumBodyDeclarations
-      ]),
+      rejectAndConcat([enumConstantList, optionalComma, enumBodyDeclarations]),
       hardline,
       ctx.LCurly[0],
       ctx.RCurly[0]
@@ -722,11 +713,7 @@ class ClassesPrettierVisitor {
       ]);
     }
 
-    return concat([
-      ...getTokenLeadingComments(ctx.Semicolon[0]),
-      "",
-      ...getTokenTrailingComments(ctx.Semicolon[0])
-    ]);
+    return { ...ctx.Semicolon[0], image: "" };
   }
 
   isClassDeclaration(ctx) {

--- a/packages/prettier-plugin-java/src/printers/comments.js
+++ b/packages/prettier-plugin-java/src/printers/comments.js
@@ -207,7 +207,5 @@ function processComments(docs) {
 module.exports = {
   processComments,
   printTokenWithComments,
-  getTokenLeadingComments,
-  getTokenTrailingComments,
   printNodeWithComments
 };

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/complex/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/complex/_output.java
@@ -81,5 +81,6 @@ public class PrettierTest {
 //Additionnal enumeration
 enum Cards {
   //The Heart and the Spade
-  HEART/*the heart*/, SPADES/*and the spade*/
+  HEART/*the heart*/,
+  SPADES/*and the spade*/
 }

--- a/packages/prettier-plugin-java/test/unit-test/enum/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_input.java
@@ -1,10 +1,10 @@
-public enum EnumWhichNotBreak {
+public enum Enum {
 
   SOME_ENUM, ANOTHER_ENUM, LAST_ENUM
 
 }
 
-public enum EnumWhichNotBreakWithExtraSemicolon {
+public enum EnumWithExtraSemicolon {
 
   SOME_ENUM, ANOTHER_ENUM, LAST_ENUM;
 

--- a/packages/prettier-plugin-java/test/unit-test/enum/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_input.java
@@ -10,17 +10,63 @@ public enum EnumWithExtraSemicolon {
 
 }
 
-public enum EnumWhichBreak {
+public enum EnumWithExtraComma {
+
+  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM,
+
+}
+
+public enum EnumWithExtraCommaAndExtraSemicolon {
+
+  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM,;
+
+}
+
+public enum EnumWithExtraCommaAndComment {
+
+  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM/* comment */,
+
+}
+
+public enum EnumWithExtraSemicolonAndComment {
+
+  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM/* comment */;
+
+}
+
+public enum EnumWithManyValues {
 
   ONE_VALUE, TWO_VALUE, THREE_VALUE, FOUR_VALUE, FIVE_VALUE, SIX_VALUE, SEVEN_VALUE, EIGTH_VALUE, NINE_VALUE,
   TEN_VALUE
 
 }
 
-public enum EnumWhichBreakWithExtraSemicolon {
+public enum EnumWithManyValuesWithExtraSemicolon {
 
   ONE_VALUE, TWO_VALUE, THREE_VALUE, FOUR_VALUE, FIVE_VALUE, SIX_VALUE, SEVEN_VALUE, EIGTH_VALUE, NINE_VALUE,
   TEN_VALUE;
+
+}
+
+public enum EnumWithManyValuesWithExtraComma {
+
+  ONE_VALUE, TWO_VALUE, THREE_VALUE, FOUR_VALUE, FIVE_VALUE, SIX_VALUE, SEVEN_VALUE, EIGTH_VALUE, NINE_VALUE,
+  TEN_VALUE,
+
+}
+
+public enum EnumWithManyValuesWithExtraCommaAndExtraSemicolon {
+
+  ONE_VALUE, TWO_VALUE, THREE_VALUE, FOUR_VALUE, FIVE_VALUE, SIX_VALUE, SEVEN_VALUE, EIGTH_VALUE, NINE_VALUE,
+  TEN_VALUE,;
+
+}
+
+public enum EnumWithExtraCommaAndEnumBodyDeclarations {
+
+  THIS_IS_GOOD("abc"), THIS_IS_FINE("abc"), ;
+
+  public static final String thisWillBeDeleted = "DELETED";
 
 }
 

--- a/packages/prettier-plugin-java/test/unit-test/enum/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_output.java
@@ -10,7 +10,31 @@ public enum EnumWithExtraSemicolon {
   LAST_ENUM
 }
 
-public enum EnumWhichBreak {
+public enum EnumWithExtraComma {
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM
+}
+
+public enum EnumWithExtraCommaAndExtraSemicolon {
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM
+}
+
+public enum EnumWithExtraCommaAndComment {
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM/* comment */
+}
+
+public enum EnumWithExtraSemicolonAndComment {
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM/* comment */
+}
+
+public enum EnumWithManyValues {
   ONE_VALUE,
   TWO_VALUE,
   THREE_VALUE,
@@ -23,7 +47,7 @@ public enum EnumWhichBreak {
   TEN_VALUE
 }
 
-public enum EnumWhichBreakWithExtraSemicolon {
+public enum EnumWithManyValuesWithExtraSemicolon {
   ONE_VALUE,
   TWO_VALUE,
   THREE_VALUE,
@@ -34,6 +58,38 @@ public enum EnumWhichBreakWithExtraSemicolon {
   EIGTH_VALUE,
   NINE_VALUE,
   TEN_VALUE
+}
+
+public enum EnumWithManyValuesWithExtraComma {
+  ONE_VALUE,
+  TWO_VALUE,
+  THREE_VALUE,
+  FOUR_VALUE,
+  FIVE_VALUE,
+  SIX_VALUE,
+  SEVEN_VALUE,
+  EIGTH_VALUE,
+  NINE_VALUE,
+  TEN_VALUE
+}
+
+public enum EnumWithManyValuesWithExtraCommaAndExtraSemicolon {
+  ONE_VALUE,
+  TWO_VALUE,
+  THREE_VALUE,
+  FOUR_VALUE,
+  FIVE_VALUE,
+  SIX_VALUE,
+  SEVEN_VALUE,
+  EIGTH_VALUE,
+  NINE_VALUE,
+  TEN_VALUE
+}
+
+public enum EnumWithExtraCommaAndEnumBodyDeclarations {
+  THIS_IS_GOOD("abc"),
+  THIS_IS_FINE("abc");
+  public static final String thisWillBeDeleted = "DELETED";
 }
 
 public enum Enum {

--- a/packages/prettier-plugin-java/test/unit-test/enum/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_output.java
@@ -1,9 +1,13 @@
-public enum EnumWhichNotBreak {
-  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM
+public enum Enum {
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM
 }
 
-public enum EnumWhichNotBreakWithExtraSemicolon {
-  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM
+public enum EnumWithExtraSemicolon {
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM
 }
 
 public enum EnumWhichBreak {
@@ -33,7 +37,8 @@ public enum EnumWhichBreakWithExtraSemicolon {
 }
 
 public enum Enum {
-  THIS_IS_GOOD("abc"), THIS_IS_FINE("abc");
+  THIS_IS_GOOD("abc"),
+  THIS_IS_FINE("abc");
   public static final String thisWillBeDeleted = "DELETED";
 
   private final String value;
@@ -50,6 +55,7 @@ public enum Enum {
 class CLassWithEnum {
 
   public static enum VALID_THINGS {
-    FIRST, SECOND
+    FIRST,
+    SECOND
   }
 }


### PR DESCRIPTION
Fix #314 and fix #313 

I didn't implement a `--trailing-comma` comma for the moment. It could be added in the feature, but I don't think it is a top priority for the moment