### PR TITLE
Don't indent binary operators

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
@@ -363,8 +363,7 @@ class BlocksAndStatementPrettierVisitor {
   returnStatement(ctx) {
     if (ctx.expression) {
       const expression = this.visit(ctx.expression, {
-        addParenthesisToWrapStatement: true,
-        shouldIndentBinaryOperationInExpression: false
+        addParenthesisToWrapStatement: true
       });
 
       return rejectAndConcat([

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -195,18 +195,9 @@ class ExpressionsPrettierVisitor {
           );
           i += 2;
         } else if (matchCategory(token, "'BinaryOperator'")) {
-          const binaryOperation = rejectAndJoin(line, [
-            token,
-            unaryExpression.shift()
-          ]);
-          if (
-            params !== undefined &&
-            !params.shouldIndentBinaryOperationInExpression
-          ) {
-            currentSegment.push(binaryOperation);
-          } else {
-            currentSegment.push(indent(binaryOperation));
-          }
+          currentSegment.push(
+            rejectAndJoin(line, [token, unaryExpression.shift()])
+          );
         }
       }
       segmentsSplittedByBinaryOperator.push(
@@ -419,9 +410,7 @@ class ExpressionsPrettierVisitor {
   }
 
   parenthesisExpression(ctx) {
-    const expression = this.visit(ctx.expression, {
-      shouldIndentBinaryOperationInExpression: false
-    });
+    const expression = this.visit(ctx.expression);
     return putIntoBraces(expression, softline, ctx.LBrace[0], ctx.RBrace[0]);
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
@@ -1,19 +1,29 @@
 public class BinaryOperations {
 
-  public void binaryOperationThatShouldBreak() {
+  @Annotation("This operation with two very long string should break" + "in a very nice way")
+  public String binaryOperationThatShouldBreak() {
     System.out.println("This operation with two very long string should break" + "in a very nice way");
+    return "This operation with two very long string should break" + "in a very nice way";
   }
 
-  public void binaryOperationThatShouldNotBreak() {
+  @Annotation("This operation should" + "not break")
+  public String binaryOperationThatShouldNotBreak() {
     System.out.println("This operation should" + "not break");
+    return "This operation should" + "not break";
   }
 
-  public void ternaryOperationThatShouldBreak() {
+  public int ternaryOperationThatShouldBreak() {
     int shortInteger = thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne ? thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne : thisIsAShortInteger;
-    int shortInteger2 = thisIsAVeryLongInteger ? thisIsAnotherVeryLongOne : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
+    return thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne ? thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne : thisIsAShortInteger;
   }
 
-  public void ternaryOperationThatShouldNotBreak() {
+  public int ternaryOperationThatShouldBreak2() {
+    int shortInteger = thisIsAVeryLongInteger ? thisIsAnotherVeryLongOne : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
+    return thisIsAVeryLongInteger ? thisIsAnotherVeryLongOne : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
+  }
+
+  public int ternaryOperationThatShouldNotBreak() {
     int a = b ? b : c;
+    return b ? b : c;
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -1,26 +1,46 @@
 public class BinaryOperations {
 
-  public void binaryOperationThatShouldBreak() {
+  @Annotation(
+    "This operation with two very long string should break" +
+    "in a very nice way"
+  )
+  public String binaryOperationThatShouldBreak() {
     System.out.println(
       "This operation with two very long string should break" +
-        "in a very nice way"
+      "in a very nice way"
+    );
+    return (
+      "This operation with two very long string should break" +
+      "in a very nice way"
     );
   }
 
-  public void binaryOperationThatShouldNotBreak() {
+  @Annotation("This operation should" + "not break")
+  public String binaryOperationThatShouldNotBreak() {
     System.out.println("This operation should" + "not break");
+    return "This operation should" + "not break";
   }
 
-  public void ternaryOperationThatShouldBreak() {
+  public int ternaryOperationThatShouldBreak() {
     int shortInteger = thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne
       ? thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne
       : thisIsAShortInteger;
-    int shortInteger2 = thisIsAVeryLongInteger
+    return thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne
+      ? thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne
+      : thisIsAShortInteger;
+  }
+
+  public int ternaryOperationThatShouldBreak2() {
+    int shortInteger = thisIsAVeryLongInteger
+      ? thisIsAnotherVeryLongOne
+      : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
+    return thisIsAVeryLongInteger
       ? thisIsAnotherVeryLongOne
       : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
   }
 
-  public void ternaryOperationThatShouldNotBreak() {
+  public int ternaryOperationThatShouldNotBreak() {
     int a = b ? b : c;
+    return b ? b : c;
   }
 }


### PR DESCRIPTION
Fixes #306 

I was wondering whether this indentation is desirable for other binary operators, for example `>`, however I think it's better not to start creating heuristics for different binary operators. This also appears to match prettier-js behavior (example below)

Input:
```javascript
function example() {
  const greater = someReallyLongExceptionallyUnbelievablyLongIntegerName > anotherReallyLongExceptionallyUnbelievablyLongIntegerName;
  const blah = "asldjoewimqwioemwqoiewoiqjeoiamdoimwqioejwqoimdasoidmoqwie" + "qweinaoidnoiqwneoiwqjeoiwqjoiasndoisamdoiqwmeiowqjoieoi" + "qwewhqenwoniosadjoienrmnmziojqoirjqwoeiqowewq";
}
```

Output:
```javascript
function example() {
  const greater =
    someReallyLongExceptionallyUnbelievablyLongIntegerName >
    anotherReallyLongExceptionallyUnbelievablyLongIntegerName;
  const blah =
    "asldjoewimqwioemwqoiewoiqjeoiamdoimwqioejwqoimdasoidmoqwie" +
    "qweinaoidnoiqwneoiwqjeoiwqjoiasndoisamdoiqwmeiowqjoieoi" +
    "qwewhqenwoniosadjoienrmnmziojqoirjqwoeiqowewq";
}
```