### PR TITLE
Sort imports naively

### DIFF
--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -579,11 +579,10 @@ function compareFqn(packageOrTypeNameFirst, packageOrTypeNameSecond) {
 
   const minParts = Math.min(identifiersFirst.length, identifiersSecond.length);
   for (let i = 0; i < minParts; i++) {
-    const identifierComparison = identifiersFirst[i].image.localeCompare(
-      identifiersSecond[i].image
-    );
-    if (identifierComparison !== 0) {
-      return identifierComparison;
+    if (identifiersFirst[i].image < identifiersSecond[i].image) {
+      return -1;
+    } else if (identifiersFirst[i].image > identifiersSecond[i].image) {
+      return 1;
     }
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_input.java
@@ -1,6 +1,8 @@
 import java.util.ArrayList;
 import java.util.function.Consumer;
+import java.util.function.ConsumerTwo;
 import java.util.List;
+import java.util.concurrent.*;
 import java.util.Map;
 
 public class PackageAndImports {}

--- a/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_input.java
@@ -1,7 +1,9 @@
 import java.util.ArrayList;
 import java.util.function.Consumer;
+import java.util.functioN.Consumer;
 import java.util.function.ConsumerTwo;
 import java.util.List;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.*;
 import java.util.Map;
 

--- a/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_input.java
@@ -1,0 +1,6 @@
+import java.util.ArrayList;
+import java.util.function.Consumer;
+import java.util.List;
+import java.util.Map;
+
+public class PackageAndImports {}

--- a/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_output.java
@@ -1,0 +1,6 @@
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class PackageAndImports {}

--- a/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_output.java
@@ -1,6 +1,8 @@
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.*;
 import java.util.function.Consumer;
+import java.util.function.ConsumerTwo;
 
 public class PackageAndImports {}

--- a/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/package_and_imports/classWithMixedCaseImports/_output.java
@@ -2,6 +2,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
+import java.util.concurrent.Semaphore;
+import java.util.functioN.Consumer;
 import java.util.function.Consumer;
 import java.util.function.ConsumerTwo;
 

--- a/packages/prettier-plugin-java/test/unit-test/package_and_imports/package_and_imports-spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/package_and_imports/package_and_imports-spec.js
@@ -2,6 +2,7 @@ const { testSample } = require("../../test-utils");
 const path = require("path");
 
 describe("prettier-java", () => {
+  testSample(path.resolve(__dirname, "./classWithMixedCaseImports"));
   testSample(path.resolve(__dirname, "./classWithMixedImports"));
   testSample(path.resolve(__dirname, "./classWithNoImports"));
   testSample(path.resolve(__dirname, "./classWithOnlyStaticImports"));


### PR DESCRIPTION
Fixes #324 

I believe this matches the Google import sort order
https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing
> Within each block the imported names appear in ASCII sort order. (Note: this is not the same as the import statements being in ASCII sort order, since '.' sorts before ';'.)

This also appears to better conform to the way IntelliJ/Eclipse sort imports. I looked through the tests for Google's import sorter and tried to cover the same edge cases in the tests I added:
https://github.com/google/google-java-format/blob/master/core/src/test/java/com/google/googlejavaformat/java/ImportOrdererTest.java