### PR TITLE
Improve formatting of variable initialization

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -239,11 +239,18 @@ class ClassesPrettierVisitor {
         }
 
         // Method Invocation
-        if (
+        const isMethodInvocation =
           firstPrimary.children.primarySuffix !== undefined &&
           firstPrimary.children.primarySuffix[0].children
-            .methodInvocationSuffix !== undefined
-        ) {
+            .methodInvocationSuffix !== undefined;
+        const isUniqueUnaryExpression =
+          ctx.variableInitializer[0].children.expression[0].children
+            .ternaryExpression[0].children.binaryExpression[0].children
+            .unaryExpression.length === 1;
+
+        const isUniqueMethodInvocation =
+          isMethodInvocation && isUniqueUnaryExpression;
+        if (isUniqueMethodInvocation) {
           return rejectAndJoin(" ", [
             variableDeclaratorId,
             ctx.Equals[0],

--- a/packages/prettier-plugin-java/test/unit-test/variables/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_input.java
@@ -92,4 +92,11 @@ public class Variables {
     Object.test.creation thisObject6 = classWithName.invocationOne(argument1, argument2,
         argument3).attributeOne.attributeTwo.invocationTwo(argument1, argument2).attributeThree.invocationThree();
   }
+
+  public void breakMultipleMethods() {
+    boolean willDrop = predictDropResponse.getSendResult().isIgnorableFailure() || predictDropResponse.getSendResult().isFatalError();
+    boolean willDrop = predictDropResponse.getSendResult().isIgnorableFailure || predictDropResponse.getSendResult().isFatalError;
+    boolean willDrop = predictDropResponsegetSendResultisIgnorableFailure || predictDropResponsegetSendResultisFatalError;
+    boolean willDrop = predictDropResponse.getSendResult().isIgnorableFailure() || predictDropResponsegetSendResultisFatalError;
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/variables/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_output.java
@@ -146,4 +146,19 @@ public class Variables {
       .attributeOne.attributeTwo.invocationTwo(argument1, argument2)
       .attributeThree.invocationThree();
   }
+
+  public void breakMultipleMethods() {
+    boolean willDrop =
+      predictDropResponse.getSendResult().isIgnorableFailure() ||
+      predictDropResponse.getSendResult().isFatalError();
+    boolean willDrop =
+      predictDropResponse.getSendResult().isIgnorableFailure ||
+      predictDropResponse.getSendResult().isFatalError;
+    boolean willDrop =
+      predictDropResponsegetSendResultisIgnorableFailure ||
+      predictDropResponsegetSendResultisFatalError;
+    boolean willDrop =
+      predictDropResponse.getSendResult().isIgnorableFailure() ||
+      predictDropResponsegetSendResultisFatalError;
+  }
 }


### PR DESCRIPTION
Fix #311

Break between equals and method if the content is too long and there are multiple expressions/method calls. It should be consistent with the Prettier style:

```js
const alpha = oaoa().zzazazkzkakzkzkakzkaoaozoaozoaozoaozoazoazooazoazoa() || kzkakzkzkakzkaoaozoaozoaozoaozoazoazooazoazoa()
const alpha = oaoazzaz.ooazoazazkzkakzkzkakzkaoaozoaozaaaaaaaopdahpdjpajaoaozoaozoazoazooazoazoa()

```

is transformed in:

```js
const alpha =
  oaoa().zzazazkzkakzkzkakzkaoaozoaozoaozoaozoazoazooazoazoa() ||
  kzkakzkzkakzkaoaozoaozoaozoaozoazoazooazoazoa();
const alpha = oaoazzaz.ooazoazazkzkakzkzkakzkaoaozoaozaaaaaaaopdahpdjpajaoaozoaozoazoazooazoazoa();

```