### PR TITLE
Improve formatting of lambda expressions

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -32,7 +32,19 @@ class ExpressionsPrettierVisitor {
     const lambdaParameters = this.visit(ctx.lambdaParameters);
     const lambdaBody = this.visit(ctx.lambdaBody);
 
-    return rejectAndJoin(" ", [lambdaParameters, ctx.Arrow[0], lambdaBody]);
+    const isLambdaBodyABlock = ctx.lambdaBody[0].children.block !== undefined;
+    if (isLambdaBodyABlock) {
+      return rejectAndJoin(" ", [lambdaParameters, ctx.Arrow[0], lambdaBody]);
+    }
+
+    return group(
+      indent(
+        rejectAndJoin(line, [
+          rejectAndJoin(" ", [lambdaParameters, ctx.Arrow[0]]),
+          lambdaBody
+        ])
+      )
+    );
   }
 
   lambdaParameters(ctx) {

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
@@ -6,7 +6,7 @@ public class Lambda {
       System.out.println(x);
     });
   }
-  
+
   public void singleArgumentWithoutParens() {
     call(x -> {
       System.out.println(x);
@@ -43,6 +43,11 @@ public class Lambda {
 
   public void onlyOneMethodInBody() {
     call(x -> System.out.println(x));
+  }
+
+  public void lambdaWithoutBracesWhichBreak() {
+    call(x -> foo.isVeryVeryVeryLongConditionTrue() &&
+    foo.isAnotherVeryVeryLongConditionTrue());
   }
 
 }

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
@@ -56,4 +56,12 @@ public class Lambda {
   public void onlyOneMethodInBody() {
     call(x -> System.out.println(x));
   }
+
+  public void lambdaWithoutBracesWhichBreak() {
+    call(
+      x ->
+        foo.isVeryVeryVeryLongConditionTrue() &&
+        foo.isAnotherVeryVeryLongConditionTrue()
+    );
+  }
 }


### PR DESCRIPTION
Related to https://github.com/jhipster/prettier-java/issues/311#issuecomment-565098219

Break after arrow when the content is too long and there are no curly braces

cc @andybergon