### PR TITLE
feature: allow blank lines in enumConstant lists

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -2,6 +2,7 @@
 const _ = require("lodash");
 const { line, softline, hardline } = require("prettier").doc.builders;
 const {
+  getBlankLinesSeparator,
   hasLeadingLineComments,
   reject,
   rejectAndConcat,
@@ -685,8 +686,10 @@ class ClassesPrettierVisitor {
 
   enumConstantList(ctx) {
     const enumConstants = this.mapVisit(ctx.enumConstant);
+
+    const blankLineSeparators = getBlankLinesSeparator(ctx.enumConstant);
     const commas = ctx.Comma
-      ? ctx.Comma.map(elt => concat([elt, hardline]))
+      ? ctx.Comma.map((elt, index) => concat([elt, blankLineSeparators[index]]))
       : [];
 
     return group(rejectAndJoinSeps(commas, enumConstants));

--- a/packages/prettier-plugin-java/test/unit-test/enum/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_input.java
@@ -97,3 +97,21 @@ class CLassWithEnum {
   }
 
 }
+
+public enum OtherEnum {
+  ONE, TWO,
+
+  THREE,
+
+
+
+  FOUR,
+  /* Five */
+  FIVE,
+
+  /* Six */
+  SIX
+
+
+}
+

--- a/packages/prettier-plugin-java/test/unit-test/enum/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_output.java
@@ -115,3 +115,17 @@ class CLassWithEnum {
     SECOND
   }
 }
+
+public enum OtherEnum {
+  ONE,
+  TWO,
+
+  THREE,
+
+  FOUR,
+  /* Five */
+  FIVE,
+
+  /* Six */
+  SIX
+}


### PR DESCRIPTION
Fix #259 

## What changed with this PR: 
- blank lines are not completely removed in enumConstant lists: we allow one blank line between two enum constants

## Example
```java
// Input
public enum OtherEnum {
  ONE, TWO,

  THREE,



  FOUR,
  /* Five */
  FIVE,

  /* Six */
  SIX


}

// Output
public enum OtherEnum {
  ONE, 
  TWO,

  THREE,

  FOUR,
  /* Five */
  FIVE,

  /* Six */
  SIX
}
```