### PR TITLE
feature: add blank line in enums between constants & declarations

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -727,7 +727,7 @@ class ClassesPrettierVisitor {
         ctx.classBodyDeclaration
       );
 
-      return rejectAndJoin(line, [
+      return rejectAndJoin(concat([hardline, hardline]), [
         ctx.Semicolon[0],
         rejectAndJoinSeps(separators, classBodyDeclaration)
       ]);

--- a/packages/prettier-plugin-java/test/unit-test/enum/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_output.java
@@ -89,12 +89,14 @@ public enum EnumWithManyValuesWithExtraCommaAndExtraSemicolon {
 public enum EnumWithExtraCommaAndEnumBodyDeclarations {
   THIS_IS_GOOD("abc"),
   THIS_IS_FINE("abc");
+
   public static final String thisWillBeDeleted = "DELETED";
 }
 
 public enum Enum {
   THIS_IS_GOOD("abc"),
   THIS_IS_FINE("abc");
+
   public static final String thisWillBeDeleted = "DELETED";
 
   private final String value;


### PR DESCRIPTION
Fix #309

In this PR, I always add a blank line before enumBodyDeclarations.

So we would get this formatting
```java
// This input
public enum EnumWithExtraCommaAndEnumBodyDeclarations {
  THIS_IS_GOOD("abc"),
  THIS_IS_FINE("abc");
  public static final String thisWillBeDeleted = "DELETED";
}

// or this input
public enum EnumWithExtraCommaAndEnumBodyDeclarations {
  THIS_IS_GOOD("abc"),
  THIS_IS_FINE("abc");
  public static final String thisWillBeDeleted = "DELETED";
}

// will be formatted to this output
public enum EnumWithExtraCommaAndEnumBodyDeclarations {
  THIS_IS_GOOD("abc"),
  THIS_IS_FINE("abc");

  public static final String thisWillBeDeleted = "DELETED";
}
```