### PR TITLE
fix: move comments in binaryExpression

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -15,7 +15,8 @@ const {
   putIntoBraces,
   separateTokensIntoGroups,
   isShiftOperator,
-  isUniqueMethodInvocation
+  isUniqueMethodInvocation,
+  handleComments
 } = require("./printer-utils");
 
 class ExpressionsPrettierVisitor {
@@ -158,6 +159,8 @@ class ExpressionsPrettierVisitor {
   }
 
   binaryExpression(ctx, params) {
+    handleComments(ctx);
+
     const referenceType = this.mapVisit(ctx.referenceType);
     const expression = this.mapVisit(ctx.expression);
     const unaryExpression = this.mapVisit(ctx.unaryExpression);

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -634,6 +634,27 @@ function isUniqueMethodInvocation(primarySuffixes) {
   return count;
 }
 
+function handleComments(ctx) {
+  let unaryExpressionIndex = 1;
+  ctx.BinaryOperator.forEach(binaryOperator => {
+    if (hasLeadingComments(binaryOperator)) {
+      while (
+        ctx.unaryExpression[unaryExpressionIndex].location.startOffset <
+        binaryOperator.endOffset
+      ) {
+        unaryExpressionIndex++;
+      }
+
+      ctx.unaryExpression[unaryExpressionIndex].leadingComments =
+        ctx.unaryExpression[unaryExpressionIndex].leadingComments || [];
+      ctx.unaryExpression[unaryExpressionIndex].leadingComments.unshift(
+        ...binaryOperator.leadingComments
+      );
+      delete binaryOperator.leadingComments;
+    }
+  });
+}
+
 module.exports = {
   buildFqn,
   reject,
@@ -660,5 +681,6 @@ module.exports = {
   retrieveNodesToken,
   isStatementEmptyStatement,
   sortImports,
-  isUniqueMethodInvocation
+  isUniqueMethodInvocation,
+  handleComments
 };

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -636,23 +636,45 @@ function isUniqueMethodInvocation(primarySuffixes) {
 
 function handleComments(ctx) {
   let unaryExpressionIndex = 1;
-  ctx.BinaryOperator.forEach(binaryOperator => {
-    if (hasLeadingComments(binaryOperator)) {
-      while (
-        ctx.unaryExpression[unaryExpressionIndex].location.startOffset <
-        binaryOperator.endOffset
-      ) {
-        unaryExpressionIndex++;
-      }
+  if (ctx.BinaryOperator !== undefined) {
+    ctx.BinaryOperator.forEach(binaryOperator => {
+      if (hasLeadingComments(binaryOperator)) {
+        while (
+          ctx.unaryExpression[unaryExpressionIndex].location.startOffset <
+          binaryOperator.endOffset
+        ) {
+          unaryExpressionIndex++;
+        }
 
-      ctx.unaryExpression[unaryExpressionIndex].leadingComments =
-        ctx.unaryExpression[unaryExpressionIndex].leadingComments || [];
-      ctx.unaryExpression[unaryExpressionIndex].leadingComments.unshift(
-        ...binaryOperator.leadingComments
-      );
-      delete binaryOperator.leadingComments;
-    }
-  });
+        // Adapt the position of the operator and its leading comments
+        const shiftUp =
+          binaryOperator.leadingComments[0].startLine -
+          1 -
+          ctx.BinaryOperator.startLine;
+
+        if (
+          binaryOperator.startLine !==
+          ctx.unaryExpression[unaryExpressionIndex].location.startLine
+        ) {
+          binaryOperator.leadingComments.forEach(comment => {
+            comment.startLine += 1;
+            comment.endLine += 1;
+          });
+        }
+        binaryOperator.startLine += shiftUp;
+        binaryOperator.endLine += shiftUp;
+
+        // Assign the leading comments & trailing comments of the binaryOperator
+        // to the following unaryExpression as leading comments
+        ctx.unaryExpression[unaryExpressionIndex].leadingComments =
+          ctx.unaryExpression[unaryExpressionIndex].leadingComments || [];
+        ctx.unaryExpression[unaryExpressionIndex].leadingComments.unshift(
+          ...binaryOperator.leadingComments
+        );
+        delete binaryOperator.leadingComments;
+      }
+    });
+  }
 }
 
 module.exports = {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
@@ -31,4 +31,26 @@ public class BinaryOperations {
     int a = b ? b : c;
     return b ? b : c;
   }
+
+  public boolean binaryOperationWithComments() {
+    boolean a = one || two >> 1 // one
+      // two
+      // three
+      || // five
+      // four
+      three;
+
+    boolean b = one || two >> 1 // one
+      // two
+      // three
+      ||
+      three;
+
+    boolean c = one || two >> 1 // one
+      // two
+      // three
+      || three;
+
+    return a || b || c;
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -48,4 +48,31 @@ public class BinaryOperations {
     int a = b ? b : c;
     return b ? b : c;
   }
+
+  public boolean binaryOperationWithComments() {
+    boolean a =
+      one ||
+      two >> 1 || // one
+      // five
+      // two
+      // three
+      // four
+      three;
+
+    boolean b =
+      one ||
+      two >> 1 || // one
+      // two
+      // three
+      three;
+
+    boolean c =
+      one ||
+      two >> 1 || // one
+      // two
+      // three
+      three;
+
+    return a || b || c;
+  }
 }


### PR DESCRIPTION
Move comments before binaryOperator to the following unaryExpression

Fix #352

By comparison, what is done in Prettier for TS:

```sh
--parser typescript
```

**Input:**
```tsx
a = one || two >> 1 // one
        // two
        // three
        || //four
        // five
        three;
```

**Output:**
```tsx
a =
  one ||
  two >> 1 || // one //four
  // two
  // three
  // five
  three;

```