### PR TITLE
Add option support for trailing comma in enums

### DIFF
--- a/packages/prettier-plugin-java/src/cst-printer.js
+++ b/packages/prettier-plugin-java/src/cst-printer.js
@@ -88,7 +88,10 @@ class CstPrettierPrinter extends BaseJavaCstVisitor {
                   .endOffset
               : node.location.endOffset;
 
-          return this.originalText.substring(startOffset, endOffset + 1);
+          return this.prettierOptions.originalText.substring(
+            startOffset,
+            endOffset + 1
+          );
         } catch (e) {
           throw Error(
             e +
@@ -131,8 +134,8 @@ const prettyPrinter = new CstPrettierPrinter();
 
 // TODO: do we need the "path" and "print" arguments passed by prettier
 // see https://github.com/prettier/prettier/issues/5747
-function createPrettierDoc(cstNode, originalText) {
-  prettyPrinter.originalText = originalText;
+function createPrettierDoc(cstNode, options) {
+  prettyPrinter.prettierOptions = options;
   return prettyPrinter.visit(cstNode);
 }
 

--- a/packages/prettier-plugin-java/src/printer.js
+++ b/packages/prettier-plugin-java/src/printer.js
@@ -26,7 +26,7 @@ function genericPrint(path, options, print) {
   //   }
   // ];
 
-  return createPrettierDoc(node, options.originalText);
+  return createPrettierDoc(node, options);
 }
 
 module.exports = genericPrint;

--- a/packages/prettier-plugin-java/src/printers/arrays.js
+++ b/packages/prettier-plugin-java/src/printers/arrays.js
@@ -1,10 +1,9 @@
 "use strict";
 const { line } = require("prettier").doc.builders;
-const { ifBreak } = require("./prettier-builder");
 const {
   rejectAndConcat,
   rejectAndJoinSeps,
-  putIntoBraces
+  printArrayList
 } = require("./printer-utils");
 
 class ArraysPrettierVisitor {
@@ -13,21 +12,13 @@ class ArraysPrettierVisitor {
       ctx.variableInitializerList
     );
 
-    let optionalComma;
-    if (this.prettierOptions.trailingComma !== "none") {
-      optionalComma = ctx.Comma
-        ? ifBreak(ctx.Comma[0], { ...ctx.Comma[0], image: "" })
-        : ifBreak(",", "");
-    } else {
-      optionalComma = ctx.Comma ? { ...ctx.Comma[0], image: "" } : "";
-    }
-
-    return putIntoBraces(
-      rejectAndConcat([optionalVariableInitializerList, optionalComma]),
-      line,
-      ctx.LCurly[0],
-      ctx.RCurly[0]
-    );
+    return printArrayList({
+      list: optionalVariableInitializerList,
+      extraComma: ctx.Comma,
+      LCurly: ctx.LCurly[0],
+      RCurly: ctx.RCurly[0],
+      trailingComma: this.prettierOptions.trailingComma
+    });
   }
 
   variableInitializerList(ctx) {

--- a/packages/prettier-plugin-java/src/printers/arrays.js
+++ b/packages/prettier-plugin-java/src/printers/arrays.js
@@ -1,5 +1,6 @@
 "use strict";
 const { line } = require("prettier").doc.builders;
+const { ifBreak } = require("./prettier-builder");
 const {
   rejectAndConcat,
   rejectAndJoinSeps,
@@ -11,7 +12,15 @@ class ArraysPrettierVisitor {
     const optionalVariableInitializerList = this.visit(
       ctx.variableInitializerList
     );
-    const optionalComma = ctx.Comma ? ctx.Comma[0] : "";
+
+    let optionalComma;
+    if (this.prettierOptions.trailingComma !== "none") {
+      optionalComma = ctx.Comma
+        ? ifBreak(ctx.Comma[0], { ...ctx.Comma[0], image: "" })
+        : ifBreak(",", "");
+    } else {
+      optionalComma = ctx.Comma ? { ...ctx.Comma[0], image: "" } : "";
+    }
 
     return putIntoBraces(
       rejectAndConcat([optionalVariableInitializerList, optionalComma]),

--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -674,7 +674,12 @@ class ClassesPrettierVisitor {
     const enumConstantList = this.visit(ctx.enumConstantList);
     const enumBodyDeclarations = this.visit(ctx.enumBodyDeclarations);
 
-    const optionalComma = ctx.Comma ? { ...ctx.Comma[0], image: "" } : "";
+    let optionalComma;
+    if (this.prettierOptions.trailingComma !== "none") {
+      optionalComma = ctx.Comma ? ctx.Comma[0] : ",";
+    } else {
+      optionalComma = ctx.Comma ? { ...ctx.Comma[0], image: "" } : "";
+    }
 
     return putIntoBraces(
       rejectAndConcat([enumConstantList, optionalComma, enumBodyDeclarations]),

--- a/packages/prettier-plugin-java/src/printers/interfaces.js
+++ b/packages/prettier-plugin-java/src/printers/interfaces.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { line, softline, hardline } = require("prettier").doc.builders;
-const { concat, group, ifBreak, indent } = require("./prettier-builder");
+const { concat, group, indent } = require("./prettier-builder");
 const { printTokenWithComments } = require("./comments/format-comments");
 const {
   rejectAndConcat,
@@ -11,7 +11,8 @@ const {
   getInterfaceBodyDeclarationsSeparator,
   putIntoBraces,
   displaySemicolon,
-  isStatementEmptyStatement
+  isStatementEmptyStatement,
+  printArrayList
 } = require("./printer-utils");
 
 class InterfacesPrettierVisitor {
@@ -276,21 +277,13 @@ class InterfacesPrettierVisitor {
   elementValueArrayInitializer(ctx) {
     const elementValueList = this.visit(ctx.elementValueList);
 
-    let optionalComma;
-    if (this.prettierOptions.trailingComma !== "none") {
-      optionalComma = ctx.Comma
-        ? ifBreak(ctx.Comma[0], { ...ctx.Comma[0], image: "" })
-        : ifBreak(",", "");
-    } else {
-      optionalComma = ctx.Comma ? { ...ctx.Comma[0], image: "" } : "";
-    }
-
-    return putIntoBraces(
-      rejectAndConcat([elementValueList, optionalComma]),
-      line,
-      ctx.LCurly[0],
-      ctx.RCurly[0]
-    );
+    return printArrayList({
+      list: elementValueList,
+      extraComma: ctx.Comma,
+      LCurly: ctx.LCurly[0],
+      RCurly: ctx.RCurly[0],
+      trailingComma: this.prettierOptions.trailingComma
+    });
   }
 
   elementValueList(ctx) {

--- a/packages/prettier-plugin-java/src/printers/interfaces.js
+++ b/packages/prettier-plugin-java/src/printers/interfaces.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { line, softline, hardline } = require("prettier").doc.builders;
-const { concat, group, indent } = require("./prettier-builder");
+const { concat, group, ifBreak, indent } = require("./prettier-builder");
 const { printTokenWithComments } = require("./comments/format-comments");
 const {
   rejectAndConcat,
@@ -275,15 +275,21 @@ class InterfacesPrettierVisitor {
 
   elementValueArrayInitializer(ctx) {
     const elementValueList = this.visit(ctx.elementValueList);
-    const comma = ctx.Comma ? ctx.Comma[0] : "";
 
-    return group(
-      rejectAndConcat([
-        ctx.LCurly[0],
-        indent(rejectAndConcat([line, elementValueList, comma])),
-        line,
-        ctx.RCurly[0]
-      ])
+    let optionalComma;
+    if (this.prettierOptions.trailingComma !== "none") {
+      optionalComma = ctx.Comma
+        ? ifBreak(ctx.Comma[0], { ...ctx.Comma[0], image: "" })
+        : ifBreak(",", "");
+    } else {
+      optionalComma = ctx.Comma ? { ...ctx.Comma[0], image: "" } : "";
+    }
+
+    return putIntoBraces(
+      rejectAndConcat([elementValueList, optionalComma]),
+      line,
+      ctx.LCurly[0],
+      ctx.RCurly[0]
     );
   }
 

--- a/packages/prettier-plugin-java/src/printers/prettier-builder.js
+++ b/packages/prettier-plugin-java/src/printers/prettier-builder.js
@@ -42,11 +42,19 @@ function dedent(doc) {
   return indentedDoc.contents.length === 0 ? "" : indentedDoc;
 }
 
+function ifBreak(breakContents, flatContents) {
+  return prettier.ifBreak(
+    processComments(breakContents),
+    processComments(flatContents)
+  );
+}
+
 module.exports = {
   concat,
   join,
   group,
   fill,
   indent,
-  dedent
+  dedent,
+  ifBreak
 };

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -1,12 +1,12 @@
 "use strict";
 const _ = require("lodash");
-const { join, concat, group } = require("./prettier-builder");
+const { ifBreak, join, concat, group } = require("./prettier-builder");
 const {
   getTokenLeadingComments,
   printTokenWithComments
 } = require("./comments/format-comments");
 const { hasComments } = require("./comments/comments-utils");
-const { indent, hardline } = require("prettier").doc.builders;
+const { indent, hardline, line } = require("prettier").doc.builders;
 
 const orderedModifiers = [
   "Public",
@@ -605,6 +605,24 @@ function isUniqueMethodInvocation(primarySuffixes) {
   return count;
 }
 
+function printArrayList({ list, extraComma, LCurly, RCurly, trailingComma }) {
+  let optionalComma;
+  if (trailingComma !== "none") {
+    optionalComma = extraComma
+      ? ifBreak(extraComma[0], { ...extraComma[0], image: "" })
+      : ifBreak(",", "");
+  } else {
+    optionalComma = extraComma ? { ...extraComma[0], image: "" } : "";
+  }
+
+  return putIntoBraces(
+    rejectAndConcat([list, optionalComma]),
+    line,
+    LCurly,
+    RCurly
+  );
+}
+
 module.exports = {
   buildFqn,
   reject,
@@ -629,5 +647,6 @@ module.exports = {
   retrieveNodesToken,
   isStatementEmptyStatement,
   sortImports,
-  isUniqueMethodInvocation
+  isUniqueMethodInvocation,
+  printArrayList
 };

--- a/packages/prettier-plugin-java/test/test-utils.js
+++ b/packages/prettier-plugin-java/test/test-utils.js
@@ -105,6 +105,7 @@ function formatJavaSnippet({ snippet, entryPoint, prettierOptions = {} }) {
   const options = {
     printWidth: 80,
     tabWidth: 2,
+    trailingComma: "none",
     ...prettierOptions
   };
   const doc = createPrettierDoc(node, options);

--- a/packages/prettier-plugin-java/test/test-utils.js
+++ b/packages/prettier-plugin-java/test/test-utils.js
@@ -100,19 +100,29 @@ function testRepositorySample(testFolder, command, args) {
   });
 }
 
-function formatJavaSnippet(snippet, entryPoint) {
+function formatJavaSnippet({ snippet, entryPoint, prettierOptions = {} }) {
   const node = javaParser.parse(snippet, entryPoint);
-  const doc = createPrettierDoc(node);
-
-  return printDocToString(doc, {
+  const options = {
     printWidth: 80,
-    tabWidth: 2
-  }).formatted;
+    tabWidth: 2,
+    ...prettierOptions
+  };
+  const doc = createPrettierDoc(node, options);
+  return printDocToString(doc, options).formatted;
 }
 
-function expectSnippetToBeFormatted({ input, expectedOutput, entryPoint }) {
-  const onePass = formatJavaSnippet(input, entryPoint);
-  const secondPass = formatJavaSnippet(onePass, entryPoint);
+function expectSnippetToBeFormatted({
+  snippet,
+  expectedOutput,
+  entryPoint,
+  prettierOptions = {}
+}) {
+  const onePass = formatJavaSnippet({ snippet, entryPoint, prettierOptions });
+  const secondPass = formatJavaSnippet({
+    snippet: onePass,
+    entryPoint,
+    prettierOptions
+  });
 
   expect(onePass).to.equal(expectedOutput);
   expect(secondPass).to.equal(expectedOutput);

--- a/packages/prettier-plugin-java/test/unit-test/snippets/arrays/array-initializer.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/arrays/array-initializer.spec.js
@@ -1,0 +1,108 @@
+"use strict";
+
+const { expectSnippetToBeFormatted } = require("../../../test-utils");
+
+describe("Arrays Initializer", () => {
+  it("can format an empty arrayInitializer", () => {
+    expectSnippetToBeFormatted({
+      snippet: "{ }",
+      expectedOutput: "{}",
+      entryPoint: "arrayInitializer"
+    });
+  });
+
+  it("can format a arrayInitializer", () => {
+    expectSnippetToBeFormatted({
+      snippet: "{alpha}",
+      expectedOutput: "{ alpha }",
+      entryPoint: "arrayInitializer"
+    });
+  });
+
+  context("Trailing Commas", () => {
+    it("should remove extra comma in arrayInitializer by default", () => {
+      expectSnippetToBeFormatted({
+        snippet: "{alpha,}",
+        expectedOutput: "{ alpha }",
+        entryPoint: "arrayInitializer"
+      });
+    });
+
+    it("should remove extra comma in arrayInitializer by default", () => {
+      const snippet = "{oneVeryLongArrayValue,}";
+      const prettierOptions = {
+        printWidth: 15
+      };
+      // prettier-ignore
+      const expectedOutput =
+        "{\n" +
+        "  oneVeryLongArrayValue\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet,
+        expectedOutput,
+        entryPoint: "arrayInitializer",
+        prettierOptions
+      });
+    });
+
+    it("should remove extra comma in arrayInitializer if it fit in one line and --trailing-comma='all'", () => {
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue,}",
+        expectedOutput: "{ oneVeryLongArrayValue }",
+        entryPoint: "arrayInitializer",
+        prettierOptions: {
+          trailingComma: "all"
+        }
+      });
+    });
+
+    it("should not add extra comma in arrayInitializer if it fit in one line and --trailing-comma='all'", () => {
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue}",
+        expectedOutput: "{ oneVeryLongArrayValue }",
+        entryPoint: "arrayInitializer",
+        prettierOptions: {
+          trailingComma: "all"
+        }
+      });
+    });
+
+    it("should keep extra comma in arrayInitializer if it does not fit in one line and --trailing-comma='all'", () => {
+      // prettier-ignore
+      const expectedOutput =
+        "{\n" +
+        "  oneVeryLongArrayValue/* COMMA */,\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue /* COMMA */,}",
+        expectedOutput,
+        entryPoint: "arrayInitializer",
+        prettierOptions: {
+          printWidth: 15,
+          trailingComma: "all"
+        }
+      });
+    });
+
+    it("should add extra comma in arrayInitializer if it does not fit in one line and --trailing-comma='all'", () => {
+      // prettier-ignore
+      const expectedOutput =
+        "{\n" +
+        "  oneVeryLongArrayValue,\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue}",
+        expectedOutput,
+        entryPoint: "arrayInitializer",
+        prettierOptions: {
+          printWidth: 15,
+          trailingComma: "all"
+        }
+      });
+    });
+  });
+});

--- a/packages/prettier-plugin-java/test/unit-test/snippets/arrays/variable-initializer-list.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/arrays/variable-initializer-list.spec.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const { expectSnippetToBeFormatted } = require("../../../test-utils");
+
+describe("VariableInitializerList", () => {
+  it("format variableInitializerList with one variableInitializer", () => {
+    expectSnippetToBeFormatted({
+      snippet: "alpha ",
+      expectedOutput: "alpha",
+      entryPoint: "variableInitializerList"
+    });
+  });
+
+  it("format variableInitializerList with multiple variableInitializer", () => {
+    expectSnippetToBeFormatted({
+      snippet: "alpha,beta, gamma",
+      expectedOutput: "alpha,\nbeta,\ngamma",
+      entryPoint: "variableInitializerList"
+    });
+  });
+});

--- a/packages/prettier-plugin-java/test/unit-test/snippets/classes/enum-body.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/classes/enum-body.spec.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const { expectSnippetToBeFormatted } = require("../../../test-utils");
+
+describe("Enum Body", () => {
+  it("Remove trailing comma by default", () => {
+    const snippet = "{ONE,TWO,THREE,}";
+    // prettier-ignore
+    const expectedOutput =
+      "{\n" +
+      "  ONE,\n" +
+      "  TWO,\n" +
+      "  THREE\n" +
+      "}";
+    expectSnippetToBeFormatted({
+      snippet,
+      expectedOutput,
+      entryPoint: "enumBody"
+    });
+  });
+
+  it("Add trailing comma when specified", () => {
+    const snippet = "{ONE,TWO,THREE}";
+    // prettier-ignore
+    const expectedOutput =
+      "{\n" +
+      "  ONE,\n" +
+      "  TWO,\n" +
+      "  THREE,\n" +
+      "}";
+    const prettierOptions = {
+      trailingComma: "all"
+    };
+    expectSnippetToBeFormatted({
+      snippet,
+      expectedOutput,
+      entryPoint: "enumBody",
+      prettierOptions
+    });
+  });
+
+  it("Keep one trailing comma if there is already one", () => {
+    const snippet = "{" + "\n  ONE," + "\n  TWO," + "\n  THREE," + "\n}";
+    // prettier-ignore
+    const expectedOutput =
+      "{\n" +
+      "  ONE,\n" +
+      "  TWO,\n" +
+      "  THREE,\n" +
+      "}";
+    const prettierOptions = {
+      trailingComma: "all"
+    };
+    expectSnippetToBeFormatted({
+      snippet,
+      expectedOutput,
+      entryPoint: "enumBody",
+      prettierOptions
+    });
+  });
+
+  it("Remove trailing comma in enum constant list with semicolon by default", () => {
+    const snippet = "{ONE,TWO,THREE,;}";
+    // prettier-ignore
+    const expectedOutput =
+      "{\n" +
+      "  ONE,\n" +
+      "  TWO,\n" +
+      "  THREE\n" +
+      "}";
+    expectSnippetToBeFormatted({
+      snippet,
+      expectedOutput,
+      entryPoint: "enumBody"
+    });
+  });
+
+  it("Add trailing comma in enum constant list with semicolon when specified", () => {
+    const snippet = "{ONE,TWO,THREE;}";
+    // prettier-ignore
+    const expectedOutput =
+      "{\n" +
+      "  ONE,\n" +
+      "  TWO,\n" +
+      "  THREE,\n" +
+      "}";
+    const prettierOptions = {
+      trailingComma: "all"
+    };
+    expectSnippetToBeFormatted({
+      snippet,
+      expectedOutput,
+      entryPoint: "enumBody",
+      prettierOptions
+    });
+  });
+});

--- a/packages/prettier-plugin-java/test/unit-test/snippets/classes/variableDeclarator/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/classes/variableDeclarator/test.spec.js
@@ -8,7 +8,7 @@ describe("VariableDeclarator", () => {
     const snippet = "i=1";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents = "i = 1";
     expect(formattedText).to.equal(expectedContents);
   });
@@ -17,7 +17,7 @@ describe("VariableDeclarator", () => {
     const snippet = "i={alpha}";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents = "i = { alpha }";
     expect(formattedText).to.equal(expectedContents);
   });
@@ -27,7 +27,7 @@ describe("VariableDeclarator", () => {
       "i={alpha, beta, gamma, delta, epsilon, zeta, eta, theta, iota, kappa, lambda, mu, nu, xi}";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents =
       "i = {\n  alpha,\n  beta,\n  gamma,\n  delta,\n  epsilon,\n  zeta,\n  eta,\n  theta,\n  iota,\n  kappa,\n  lambda,\n  mu,\n  nu,\n  xi\n}";
     expect(formattedText).to.equal(expectedContents);
@@ -37,7 +37,7 @@ describe("VariableDeclarator", () => {
     const snippet = "lambda= test -> {}";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents = "lambda = test -> {}";
     expect(formattedText).to.equal(expectedContents);
   });
@@ -46,7 +46,7 @@ describe("VariableDeclarator", () => {
     const snippet = "lambda= test -> {int i;}";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents = "lambda = test -> {\n  int i;\n}";
     expect(formattedText).to.equal(expectedContents);
   });
@@ -55,7 +55,7 @@ describe("VariableDeclarator", () => {
     const snippet = "value= bool ? one : two";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents = "value = bool ? one : two";
     expect(formattedText).to.equal(expectedContents);
   });
@@ -65,7 +65,7 @@ describe("VariableDeclarator", () => {
       "value = thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne ? thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne : thisIsAShortInteger";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents =
       "value = thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne\n  ? thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne\n  : thisIsAShortInteger";
     expect(formattedText).to.equal(expectedContents);
@@ -74,7 +74,7 @@ describe("VariableDeclarator", () => {
     const snippet = "value = \n// comment2\n 1";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents = "value =\n  // comment2\n  1";
     expect(formattedText).to.equal(expectedContents);
   });
@@ -83,7 +83,7 @@ describe("VariableDeclarator", () => {
     const snippet = "value = // comment1\n// comment2\n 1";
     const entryPoint = "variableDeclarator";
 
-    const formattedText = formatJavaSnippet(snippet, entryPoint);
+    const formattedText = formatJavaSnippet({ snippet, entryPoint });
     const expectedContents = "value = // comment1\n  // comment2\n  1";
     expect(formattedText).to.equal(expectedContents);
   });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/interfaces/element-value-array-initializer.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/interfaces/element-value-array-initializer.spec.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const { expectSnippetToBeFormatted } = require("../../../test-utils");
+
+describe("element Value Array Initializer", () => {
+  it("can format a elementValueArrayInitializer", () => {
+    expectSnippetToBeFormatted({
+      snippet: "{alpha}",
+      expectedOutput: "{ alpha }",
+      entryPoint: "elementValueArrayInitializer"
+    });
+  });
+
+  context("Trailing Commas", () => {
+    it("should remove extra comma in elementValueArrayInitializer by default", () => {
+      expectSnippetToBeFormatted({
+        snippet: "{alpha,}",
+        expectedOutput: "{ alpha }",
+        entryPoint: "elementValueArrayInitializer"
+      });
+    });
+
+    it("should remove extra comma in elementValueArrayInitializer by default", () => {
+      // prettier-ignore
+      const expectedOutput =
+        "{\n" +
+        "  oneVeryLongArrayValue\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue,}",
+        expectedOutput,
+        entryPoint: "elementValueArrayInitializer",
+        prettierOptions: {
+          printWidth: 15
+        }
+      });
+    });
+
+    it("should remove extra comma in elementValueArrayInitializer if it fit in one line and --trailing-comma='all'", () => {
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue,}",
+        expectedOutput: "{ oneVeryLongArrayValue }",
+        entryPoint: "elementValueArrayInitializer",
+        prettierOptions: {
+          trailingComma: "all"
+        }
+      });
+    });
+
+    it("should not add extra comma in elementValueArrayInitializer if it fit in one line and --trailing-comma='all'", () => {
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue}",
+        expectedOutput: "{ oneVeryLongArrayValue }",
+        entryPoint: "elementValueArrayInitializer",
+        prettierOptions: {
+          trailingComma: "all"
+        }
+      });
+    });
+
+    it("should keep extra comma in elementValueArrayInitializer if it does not fit in one line and --trailing-comma='all'", () => {
+      // prettier-ignore
+      const expectedOutput =
+        "{\n" +
+        "  oneVeryLongArrayValue/* COMMA */,\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue /* COMMA */,}",
+        expectedOutput,
+        entryPoint: "elementValueArrayInitializer",
+        prettierOptions: {
+          printWidth: 15,
+          trailingComma: "all"
+        }
+      });
+    });
+
+    it("should add extra comma in elementValueArrayInitializer if it does not fit in one line and --trailing-comma='all'", () => {
+      // prettier-ignore
+      const expectedOutput =
+        "{\n" +
+        "  oneVeryLongArrayValue,\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet: "{oneVeryLongArrayValue}",
+        expectedOutput,
+        entryPoint: "elementValueArrayInitializer",
+        prettierOptions: {
+          printWidth: 15,
+          trailingComma: "all"
+        }
+      });
+    });
+  });
+});

--- a/packages/prettier-plugin-java/test/unit-test/snippets/names/ambiguousName/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/names/ambiguousName/test.spec.js
@@ -5,7 +5,7 @@ const { expectSnippetToBeFormatted } = require("../../../../test-utils");
 describe("AmbiguousName", () => {
   it("can format a AmbiguousName without dots", () => {
     expectSnippetToBeFormatted({
-      input: "myAmbiguousName",
+      snippet: "myAmbiguousName",
       expectedOutput: "myAmbiguousName",
       entryPoint: "ambiguousName"
     });
@@ -13,7 +13,7 @@ describe("AmbiguousName", () => {
 
   it("can format a AmbiguousName with dots", () => {
     expectSnippetToBeFormatted({
-      input: "myAmbiguousName.with.lot.of.dots",
+      snippet: "myAmbiguousName.with.lot.of.dots",
       expectedOutput: "myAmbiguousName.with.lot.of.dots",
       entryPoint: "ambiguousName"
     });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/names/expressionName/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/names/expressionName/test.spec.js
@@ -5,7 +5,7 @@ const { expectSnippetToBeFormatted } = require("../../../../test-utils");
 describe("expressionName", () => {
   it("can format a ExpressionName without dots", () => {
     expectSnippetToBeFormatted({
-      input: "myExpression",
+      snippet: "myExpression",
       expectedOutput: "myExpression",
       entryPoint: "expressionName"
     });
@@ -13,7 +13,7 @@ describe("expressionName", () => {
 
   it("can format a ExpressionName with dots", () => {
     expectSnippetToBeFormatted({
-      input: "myExpression.with.lot.of.dots",
+      snippet: "myExpression.with.lot.of.dots",
       expectedOutput: "myExpression.with.lot.of.dots",
       entryPoint: "expressionName"
     });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/names/methodName/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/names/methodName/test.spec.js
@@ -5,7 +5,7 @@ const { expectSnippetToBeFormatted } = require("../../../../test-utils");
 describe("MethodName", () => {
   it("can format a MethodName", () => {
     expectSnippetToBeFormatted({
-      input: "test",
+      snippet: "test",
       expectedOutput: "test",
       entryPoint: "methodName"
     });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/names/packageOrTypeName/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/names/packageOrTypeName/test.spec.js
@@ -5,7 +5,7 @@ const { expectSnippetToBeFormatted } = require("../../../../test-utils");
 describe("PackageOrTypeName", () => {
   it("can format a PackageOrTypeName without dots", () => {
     expectSnippetToBeFormatted({
-      input: "com",
+      snippet: "com",
       expectedOutput: "com",
       entryPoint: "packageOrTypeName"
     });
@@ -13,7 +13,7 @@ describe("PackageOrTypeName", () => {
 
   it("can format a PackageOrTypeName with dots", () => {
     expectSnippetToBeFormatted({
-      input: "com.iluwatar.abstractdocument",
+      snippet: "com.iluwatar.abstractdocument",
       expectedOutput: "com.iluwatar.abstractdocument",
       entryPoint: "packageOrTypeName"
     });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/floatingPointType/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/floatingPointType/test.spec.js
@@ -5,7 +5,7 @@ const { expectSnippetToBeFormatted } = require("../../../../test-utils");
 describe("floatingPointType", () => {
   it("can format float keyword", () => {
     expectSnippetToBeFormatted({
-      input: "float",
+      snippet: "float",
       expectedOutput: "float",
       entryPoint: "floatingPointType"
     });
@@ -13,7 +13,7 @@ describe("floatingPointType", () => {
 
   it("can format double keyword", () => {
     expectSnippetToBeFormatted({
-      input: "double",
+      snippet: "double",
       expectedOutput: "double",
       entryPoint: "floatingPointType"
     });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/integralType/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/integralType/test.spec.js
@@ -5,7 +5,7 @@ const { expectSnippetToBeFormatted } = require("../../../../test-utils");
 describe("integralType", () => {
   it("can format byte keyword", () => {
     expectSnippetToBeFormatted({
-      input: "byte",
+      snippet: "byte",
       expectedOutput: "byte",
       entryPoint: "integralType"
     });
@@ -13,7 +13,7 @@ describe("integralType", () => {
 
   it("can format short keyword", () => {
     expectSnippetToBeFormatted({
-      input: "short",
+      snippet: "short",
       expectedOutput: "short",
       entryPoint: "integralType"
     });
@@ -21,7 +21,7 @@ describe("integralType", () => {
 
   it("can format int keyword", () => {
     expectSnippetToBeFormatted({
-      input: "int",
+      snippet: "int",
       expectedOutput: "int",
       entryPoint: "integralType"
     });
@@ -29,7 +29,7 @@ describe("integralType", () => {
 
   it("can format long keyword", () => {
     expectSnippetToBeFormatted({
-      input: "long",
+      snippet: "long",
       expectedOutput: "long",
       entryPoint: "integralType"
     });
@@ -37,7 +37,7 @@ describe("integralType", () => {
 
   it("can format char keyword", () => {
     expectSnippetToBeFormatted({
-      input: "char",
+      snippet: "char",
       expectedOutput: "char",
       entryPoint: "integralType"
     });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/numericType/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/numericType/test.spec.js
@@ -26,19 +26,19 @@ describe("numericType", () => {
   });
 
   it("can format byte keyword", () => {
-    const input = "byte";
+    const snippet = "byte";
     const entryPoint = "numericType";
 
-    formatJavaSnippet(input, entryPoint);
+    formatJavaSnippet({ snippet, entryPoint });
     assert.callCount(integralTypeSpy, 1);
     assert.callCount(floatingPointTypeSpy, 0);
   });
 
   it("can format double keyword", () => {
-    const input = "double";
+    const snippet = "double";
     const entryPoint = "numericType";
 
-    formatJavaSnippet(input, entryPoint);
+    formatJavaSnippet({ snippet, entryPoint });
     assert.callCount(integralTypeSpy, 0);
     assert.callCount(floatingPointTypeSpy, 1);
   });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/wildcard/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/wildcard/test.spec.js
@@ -17,7 +17,7 @@ describe("Wildcard", () => {
 
   it("can format a wildcard", () => {
     expectSnippetToBeFormatted({
-      input: "?",
+      snippet: "?",
       expectedOutput: "?",
       entryPoint: "wildcard"
     });
@@ -25,20 +25,20 @@ describe("Wildcard", () => {
 
   it("can format a wildcard with one annotations", () => {
     expectSnippetToBeFormatted({
-      input: "@Anno ?",
+      snippet: "@Anno ?",
       expectedOutput: "@Anno ?",
       entryPoint: "wildcard"
     });
   });
 
   it("can format a wildcard with annotations that exceed printWidth ", () => {
-    const input =
+    const snippet =
       "@Annotation1 @Annotation2 @Annotation3 @Annotation4 @Annotation5 @Annotation6 @Annotation7 ?";
     const expectedOutput =
       "@Annotation1 @Annotation2 @Annotation3 @Annotation4 @Annotation5 @Annotation6 @Annotation7 ?";
 
     expectSnippetToBeFormatted({
-      input,
+      snippet,
       expectedOutput,
       entryPoint: "wildcard"
     });
@@ -46,7 +46,7 @@ describe("Wildcard", () => {
 
   it("can format a wildcard with wildcardBound", () => {
     expectSnippetToBeFormatted({
-      input: "? extends int[]",
+      snippet: "? extends int[]",
       expectedOutput: "? extends int[]",
       entryPoint: "wildcard"
     });

--- a/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/wildcardBounds/test.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/types-values-and-variables/wildcardBounds/test.spec.js
@@ -17,7 +17,7 @@ describe("Wildcard Bounds", () => {
 
   it("can format a wildcardBounds with extends", () => {
     expectSnippetToBeFormatted({
-      input: "extends int[]",
+      snippet: "extends int[]",
       expectedOutput: "extends int[]",
       entryPoint: "wildcardBounds"
     });
@@ -26,7 +26,7 @@ describe("Wildcard Bounds", () => {
 
   it("can format a wildcardBounds with super", () => {
     expectSnippetToBeFormatted({
-      input: "super int[]",
+      snippet: "super int[]",
       expectedOutput: "super int[]",
       entryPoint: "wildcardBounds"
     });


### PR DESCRIPTION
## What changed with this PR: 
- Add options support for trailing commas in enum and arrays

## Example
**options:**
```sh
--trailing-comma all
```
```java
// Input
public enum Enum {
  ONE, TWO, THREE
}

// Output
public enum Enum {
  ONE, 
  TWO,
  THREE,
}
```

```java
// Input
public class T {
  void t() {
    int[] ints = { 1, 2, 3, };
    int[] ints = { aVeryLongArrayValue, anotherVeryLongArrayValue, andYetAnotherVeryLongArrayValue };
  }
}

// Output
public class T {
  void t() {
    int[] ints = { 1, 2, 3 };
    int[] ints = {
      aVeryLongArrayValue,
      anotherVeryLongArrayValue,
      andYetAnotherVeryLongArrayValue,
    };
  }
}
```

**Relative issues or prs:**
Relative to #313, #314 and #319 

cc @natdempk and @jhaber 