### PR TITLE
fix: line wrapping in switch statements

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
@@ -196,8 +196,8 @@ class BlocksAndStatementPrettierVisitor {
     const switchCases = this.mapVisit(ctx.switchCase);
 
     return putIntoBraces(
-      rejectAndJoin(line, switchCases),
-      line,
+      rejectAndJoin(hardline, switchCases),
+      hardline,
       ctx.LCurly[0],
       ctx.RCurly[0]
     );
@@ -207,7 +207,7 @@ class BlocksAndStatementPrettierVisitor {
     const switchLabel = this.visit(ctx.switchLabel);
     const blockStatements = this.visit(ctx.blockStatements);
 
-    return indent(rejectAndJoin(line, [switchLabel, blockStatements]));
+    return indent(rejectAndJoin(hardline, [switchLabel, blockStatements]));
   }
 
   switchLabel(ctx) {

--- a/packages/prettier-plugin-java/test/unit-test/snippets/blocks-and-statements/switch.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/blocks-and-statements/switch.spec.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const { expectSnippetToBeFormatted } = require("../../../test-utils");
+
+describe("Switches", () => {
+  context("Switch Statement", () => {
+    it("should format switch statement", () => {
+      const snippet =
+        "switch (answer) {\n" +
+        "  case YES:\n" +
+        '    return "Yes";\n' +
+        "  default:\n" +
+        '    return "NO";\n' +
+        "}";
+
+      const expectedOutput =
+        "switch (answer) {\n" +
+        "  case YES:\n" +
+        '    return "Yes";\n' +
+        "  default:\n" +
+        '    return "NO";\n' +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet,
+        expectedOutput,
+        entryPoint: "switchStatement"
+      });
+    });
+  });
+});

--- a/packages/prettier-plugin-java/test/unit-test/switch/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/switch/_input.java
@@ -43,4 +43,9 @@ class Switch {
       }
   }
 
+  // Bug fix: #357
+  public String shouldWrapEvenForSmallSwitchCases() {
+    switch (answer) { case "YES": return "YES"; default: return "NO"; }
+  }
+
 }

--- a/packages/prettier-plugin-java/test/unit-test/switch/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/switch/_output.java
@@ -42,4 +42,14 @@ class Switch {
         return 3;
     }
   }
+
+  // Bug fix: #357
+  public String shouldWrapEvenForSmallSwitchCases() {
+    switch (answer) {
+      case "YES":
+        return "YES";
+      default:
+        return "NO";
+    }
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->
Fix line wrapping of switch statements: do not try to print the switch statement in one line

## Example

```java
// Input
public String shouldWrapEvenForSmallSwitchCases() {
  switch (answer) { case "YES": return "YES"; default: return "NO"; }
}
// Output (v0.6.0)
public String shouldWrapEvenForSmallSwitchCases() {
  switch (answer) { case "YES": return "YES"; default: return "NO"; }
}

// Output after PR:
public String shouldWrapEvenForSmallSwitchCases() {
  switch (answer) {
    case "YES":
      return "YES";
    default:
      return "NO";
  }
}
```

## Relative issues or prs:
Fix #357 