### PR TITLE
fix: blank lines with empty statements

### DIFF
--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -275,29 +275,47 @@ function getDeclarationsSeparator(
   needLineDeclaration,
   isSemicolon
 ) {
+  const declarationsWithoutEmptyStatements = declarations.filter(
+    declaration => !isSemicolon(declaration)
+  );
+
+  const userBlankLinesSeparators = getBlankLinesSeparator(
+    declarationsWithoutEmptyStatements
+  );
+  const additionalBlankLines = declarationsWithoutEmptyStatements.map(
+    needLineDeclaration
+  );
+
   const separators = [];
-  const additionalBlankLines = [];
-
-  declarations.forEach(declaration => {
-    if (needLineDeclaration(declaration)) {
-      additionalBlankLines.push(hardline);
-    } else {
-      additionalBlankLines.push("");
-    }
-  });
-
-  const userBlankLinesSeparators = getBlankLinesSeparator(declarations);
-
+  let indexNextNotEmptyDeclaration = 0;
   for (let i = 0; i < declarations.length - 1; i++) {
-    if (!isSemicolon(declarations[i])) {
+    // if the empty statement has comments
+    // we want to print them on their own line
+    if (isSemicolon(declarations[i])) {
+      if (hasComments(declarations[i])) {
+        separators.push(hardline);
+      }
+    } else if (
+      indexNextNotEmptyDeclaration <
+      declarationsWithoutEmptyStatements.length - 1
+    ) {
       const isTwoHardLines =
-        userBlankLinesSeparators[i].parts[0].type === "concat";
+        userBlankLinesSeparators[indexNextNotEmptyDeclaration].parts[0].type ===
+        "concat";
       const additionalSep =
         !isTwoHardLines &&
-        (additionalBlankLines[i + 1] !== "" || additionalBlankLines[i] !== "")
+        (additionalBlankLines[indexNextNotEmptyDeclaration + 1] ||
+          additionalBlankLines[indexNextNotEmptyDeclaration])
           ? hardline
           : "";
-      separators.push(concat([userBlankLinesSeparators[i], additionalSep]));
+      separators.push(
+        concat([
+          userBlankLinesSeparators[indexNextNotEmptyDeclaration],
+          additionalSep
+        ])
+      );
+
+      indexNextNotEmptyDeclaration += 1;
     }
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/empty_statement/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/empty_statement/_input.java
@@ -89,3 +89,11 @@ public class EmptyStament {
   }
 
 }
+
+// Bug Fix: #356
+public class Test {
+  public TestField testField;;
+
+  @Override
+  public void someMethod() {}
+}

--- a/packages/prettier-plugin-java/test/unit-test/empty_statement/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/empty_statement/_output.java
@@ -84,3 +84,11 @@ public class EmptyStament {
     do; /*test*/while (one);
   }
 }
+
+// Bug Fix: #356
+public class Test {
+  public TestField testField;
+
+  @Override
+  public void someMethod() {}
+}

--- a/packages/prettier-plugin-java/test/unit-test/snippets/classes/class-body.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/classes/class-body.spec.js
@@ -1,0 +1,217 @@
+"use strict";
+
+const { expectSnippetToBeFormatted } = require("../../../test-utils");
+
+describe("Class Body", () => {
+  it("should handle an empty class body", () => {
+    expectSnippetToBeFormatted({
+      snippet: "{ }",
+      expectedOutput: "{}",
+      entryPoint: "classBody"
+    });
+  });
+
+  it("should handle a class body with one field declaration", () => {
+    // prettier-ignore
+    const expectedOutput =
+      "{\n" +
+      "  int i;\n" +
+      "}";
+
+    expectSnippetToBeFormatted({
+      snippet: "{int i;}",
+      expectedOutput,
+      entryPoint: "classBody"
+    });
+  });
+
+  it("should handle blank lines between field declarations", () => {
+    // prettier-ignore
+    const snippet =
+      "{\n" +
+      "  int i;\n" +
+      "  int j;\n" +
+      "  \n" +
+      "  int k;\n" +
+      "}";
+
+    // prettier-ignore
+    const expectedOutput =
+      "{\n" +
+      "  int i;\n" +
+      "  int j;\n" +
+      "\n" +
+      "  int k;\n" +
+      "}";
+
+    expectSnippetToBeFormatted({
+      snippet,
+      expectedOutput,
+      entryPoint: "classBody"
+    });
+  });
+
+  it("should add exactly one blank lines between field declarations", () => {
+    // prettier-ignore
+    const snippet =
+      "{\n" +
+      "  int i;\n" +
+      "\n" +
+      "\n" +
+      "  \n" +
+      "  int j;\n" +
+      "}";
+
+    // prettier-ignore
+    const expectedOutput =
+      "{\n" +
+      "  int i;\n" +
+      "\n" +
+      "  int j;\n" +
+      "}";
+
+    expectSnippetToBeFormatted({
+      snippet,
+      expectedOutput,
+      entryPoint: "classBody"
+    });
+  });
+
+  it("should add exactly one blank lines before method declarations", () => {
+    const snippet =
+      "{\n" +
+      "  int i;\n" +
+      "  void t() {}" +
+      "\n" +
+      "  void u() {}" +
+      "\n" +
+      "\n" +
+      "void v() {}" +
+      "}";
+
+    const expectedOutput =
+      "{\n" +
+      "  int i;\n" +
+      "\n" +
+      "  void t() {}\n" +
+      "\n" +
+      "  void u() {}\n" +
+      "\n" +
+      "  void v() {}\n" +
+      "}";
+
+    expectSnippetToBeFormatted({
+      snippet,
+      expectedOutput,
+      entryPoint: "classBody"
+    });
+  });
+
+  context("Empty statements", () => {
+    it("should handle an class body with only empty statements", () => {
+      expectSnippetToBeFormatted({
+        snippet: "{;;}",
+        expectedOutput: "{}",
+        entryPoint: "classBody"
+      });
+    });
+
+    it("should handle blank lines between field declarations", () => {
+      const snippet =
+        "{\n" +
+        "  int i;;int j;;\n" +
+        "  int k;;\n" +
+        "  ;\n" +
+        "  int l;;\n" +
+        "  \n" +
+        "  int m;;\n" +
+        "}";
+
+      const expectedOutput =
+        "{\n" +
+        "  int i;\n" +
+        "  int j;\n" +
+        "  int k;\n" +
+        "\n" +
+        "  int l;\n" +
+        "\n" +
+        "  int m;\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet,
+        expectedOutput,
+        entryPoint: "classBody"
+      });
+    });
+
+    it("should handle blank lines before method declarations", () => {
+      const snippet =
+        "{\n" +
+        "  int i;;\n" +
+        "  void t() {}" +
+        "\n" +
+        "\n;" +
+        "  void u() {}" +
+        "\n;;" +
+        "\n" +
+        "void v() {}" +
+        "}";
+
+      const expectedOutput =
+        "{\n" +
+        "  int i;\n" +
+        "\n" +
+        "  void t() {}\n" +
+        "\n" +
+        "  void u() {}\n" +
+        "\n" +
+        "  void v() {}\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet,
+        expectedOutput,
+        entryPoint: "classBody"
+      });
+    });
+
+    it("should print comments attached to empty statement where only empty statements", () => {
+      expectSnippetToBeFormatted({
+        snippet: "{;/* TODO */;}",
+        expectedOutput: "{\n" + "  /* TODO */\n" + "}",
+        entryPoint: "classBody"
+      });
+    });
+
+    it("should print comments attached to empty statement between field declarations", () => {
+      const snippet =
+        "{\n" +
+        "  int i;/* TODO */;int j;;\n" +
+        "  int k;/* TODO */;\n" +
+        "  \n" +
+        "  /* TODO */;\n" +
+        "  \n" +
+        "  int l;;\n" +
+        "}";
+
+      const expectedOutput =
+        "{\n" +
+        "  int i;\n" +
+        "  /* TODO */\n" +
+        "  int j;\n" +
+        "  int k;\n" +
+        "\n" +
+        "  /* TODO */\n" +
+        "  /* TODO */\n" +
+        "  int l;\n" +
+        "}";
+
+      expectSnippetToBeFormatted({
+        snippet,
+        expectedOutput,
+        entryPoint: "classBody"
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->
Fix line breaks in class bodies with empty statements. The calculation of separators between class member declarations was not taking account correctly of empty statements.

## Example

```java
// Input
public class Test {
  public TestField testField;;

  @Override
  public void someMethod() {}
}
// Output (v0.6.0)
public class Test {
  public TestField testField;
  @Override
  public void someMethod() {}
}

// Output after PR:
public class Test {
  public TestField testField;

  @Override
  public void someMethod() {}
}
```

## Relative issues or prs:
Fix #356 