### PR TITLE
fix: fix stable formatting for fields & methods with annotations

### DIFF
--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -334,8 +334,7 @@ function needLineClassBodyDeclaration(declaration) {
       classMemberDeclaration.children.fieldDeclaration[0];
     if (
       fieldDeclaration.children.fieldModifier !== undefined &&
-      fieldDeclaration.children.fieldModifier[0].children.annotation !==
-        undefined
+      hasAnnotation(fieldDeclaration.children.fieldModifier)
     ) {
       return true;
     }
@@ -352,8 +351,7 @@ function needLineInterfaceMemberDeclaration(declaration) {
     const constantDeclaration = declaration.children.constantDeclaration[0];
     if (
       constantDeclaration.children.constantModifier !== undefined &&
-      constantDeclaration.children.constantModifier[0].children.annotation !==
-        undefined
+      hasAnnotation(constantDeclaration.children.constantModifier)
     ) {
       return true;
     }
@@ -364,8 +362,9 @@ function needLineInterfaceMemberDeclaration(declaration) {
     if (
       interfaceMethodDeclaration.children.interfaceMethodModifier !==
         undefined &&
-      interfaceMethodDeclaration.children.interfaceMethodModifier[0].children
-        .annotation !== undefined
+      hasNonTrailingAnnotation(
+        interfaceMethodDeclaration.children.interfaceMethodModifier
+      )
     ) {
       return true;
     }
@@ -389,6 +388,32 @@ function isClassBodyDeclarationASemicolon(classBodyDeclaration) {
 
 function isInterfaceMemberASemicolon(interfaceMemberDeclaration) {
   return interfaceMemberDeclaration.children.Semicolon !== undefined;
+}
+
+function hasAnnotation(modifiers) {
+  return modifiers.some(modifier => modifier.children.annotation !== undefined);
+}
+
+/**
+ * Return true if there is a method modifier that does not come after all other modifiers
+ * It is useful to know if sortModifiers will add an annotation before other modifiers
+ *
+ * @param methodModifiers
+ * @returns {boolean}
+ */
+function hasNonTrailingAnnotation(methodModifiers) {
+  const firstAnnotationIndex = methodModifiers.findIndex(
+    modifier => modifier.children.annotation !== undefined
+  );
+  const lastNonAnnotationIndex = _.findLastIndex(
+    methodModifiers,
+    modifier => modifier.children.annotation === undefined
+  );
+
+  return (
+    firstAnnotationIndex < lastNonAnnotationIndex ||
+    lastNonAnnotationIndex === -1
+  );
 }
 
 function getClassBodyDeclarationsSeparator(classBodyDeclarationContext) {

--- a/packages/prettier-plugin-java/test/unit-test/blank_lines/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/blank_lines/_input.java
@@ -8,6 +8,13 @@ public class BlankLines {
   public int k = 3;
   public int l = 4;
 
+  // Bug Fix: https://github.com/jhipster/prettier-java/issues/368
+  private String fieldOne;
+  private String fieldTwo;
+  private @Nullable String shouldAddLineBeforeAndAfter;
+  private String fieldThree;
+  private String fieldFour;
+
   public int m = 4;
   public Constructors() {
     this(true);
@@ -46,4 +53,23 @@ public class BlankLines {
 
   }
 
+}
+
+interface BlankLinesInInterfaces {
+    // Bug Fix: https://github.com/jhipster/prettier-java/issues/368
+    String fieldOne;
+    String fieldTwo;
+    @Nullable String shouldAddLineBeforeAndAfter;
+    String fieldThree;
+    String fieldFour;
+
+    private @Nullable String test();
+    private @Nullable static String test();
+    private @Nullable String test();
+    private @Nullable String test();
+    @Nullable
+    private static String test();
+    private @Nullable String test();
+    private static String test();
+    @Nullable String test();
 }

--- a/packages/prettier-plugin-java/test/unit-test/blank_lines/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/blank_lines/_output.java
@@ -5,6 +5,16 @@ public class BlankLines {
   public int k = 3;
   public int l = 4;
 
+  // Bug Fix: https://github.com/jhipster/prettier-java/issues/368
+  private String fieldOne;
+  private String fieldTwo;
+
+  @Nullable
+  private String shouldAddLineBeforeAndAfter;
+
+  private String fieldThree;
+  private String fieldFour;
+
   public int m = 4;
 
   public Constructors() {
@@ -42,4 +52,34 @@ public class BlankLines {
     int n = 4;
     for (int p = 0; p < 3; p++);
   }
+}
+
+interface BlankLinesInInterfaces {
+  // Bug Fix: https://github.com/jhipster/prettier-java/issues/368
+  String fieldOne;
+  String fieldTwo;
+
+  @Nullable
+  String shouldAddLineBeforeAndAfter;
+
+  String fieldThree;
+  String fieldFour;
+
+  private @Nullable String test();
+
+  @Nullable
+  private static String test();
+
+  private @Nullable String test();
+  private @Nullable String test();
+
+  @Nullable
+  private static String test();
+
+  private @Nullable String test();
+
+  private static String test();
+
+  @Nullable
+  String test();
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->
Fix stable formatting of fields & methods with annotations: if an annotation was added before other modifiers, the input needed to be formatted twice

## Example

```java
// Input
class T {
  private String fieldOne;
  private String fieldTwo;
  private @Nullable String shouldAddLineBeforeAndAfter;
  private String fieldThree;
  private String fieldFour;
}
// Output
class T {
  private String fieldOne;
  private String fieldTwo;
  
  @Nullable
  private String shouldAddLineBeforeAndAfter;

  private String fieldThree;
  private String fieldFour;
}
```

## Relative issues or prs:
Fix #368
<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
