### PR TITLE
fix: allow primitiveType with dims to have methodReferenceSuffixes

### DIFF
--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -219,9 +219,6 @@ function defineRules($, t) {
       { ALT: () => $.SUBRULE($.literal) },
       { ALT: () => $.CONSUME(t.This) },
       { ALT: () => $.CONSUME(t.Void) },
-      // should be extracted to primitive type with optional dims suffix?
-      { ALT: () => $.SUBRULE($.numericType) },
-      { ALT: () => $.CONSUME(t.Boolean) },
       { ALT: () => $.SUBRULE($.fqnOrRefType) },
       {
         GATE: () => isCastExpression,
@@ -318,6 +315,7 @@ function defineRules($, t) {
 
   $.RULE("fqnOrRefTypePartCommon", () => {
     $.OR([
+      { ALT: () => $.SUBRULE($.primitiveType) },
       { ALT: () => $.CONSUME(t.Identifier) },
       { ALT: () => $.CONSUME(t.Super) }
     ]);


### PR DESCRIPTION
## What changed with this PR:

Update fqn rules to detect primitive types (to detect array types). Will have to check if this impact performance

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
int[]::new
```

can now be parsed

## Relative issues or prs:

Fix #376
<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
