### PR TITLE
fix: throws rendering

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -1,6 +1,6 @@
 "use strict";
 const _ = require("lodash");
-const { line, softline, hardline } = require("prettier").doc.builders;
+const { ifBreak, line, softline, hardline } = require("prettier").doc.builders;
 const {
   getBlankLinesSeparator,
   reject,
@@ -402,11 +402,6 @@ class ClassesPrettierVisitor {
     const declarator = this.visit(ctx.methodDeclarator);
     const throws = this.visit(ctx.throws);
 
-    let throwsPart = "";
-    if (throws) {
-      throwsPart = indent(rejectAndConcat([softline, throws]));
-    }
-
     return group(
       concat([
         rejectAndJoin(" ", [
@@ -414,7 +409,7 @@ class ClassesPrettierVisitor {
           rejectAndJoin(line, annotations),
           result,
           declarator,
-          throwsPart
+          throws
         ])
       ])
     );
@@ -514,7 +509,13 @@ class ClassesPrettierVisitor {
 
   throws(ctx) {
     const exceptionTypeList = this.visit(ctx.exceptionTypeList);
-    return join(" ", [ctx.Throws[0], exceptionTypeList]);
+    const throwsDeclaration = join(" ", [ctx.Throws[0], exceptionTypeList]);
+    return group(
+      ifBreak(
+        indent(rejectAndConcat([softline, throwsDeclaration])),
+        throwsDeclaration
+      )
+    );
   }
 
   exceptionTypeList(ctx) {
@@ -554,11 +555,6 @@ class ClassesPrettierVisitor {
     const throws = this.visit(ctx.throws);
     const constructorBody = this.visit(ctx.constructorBody);
 
-    let throwsPart = "";
-    if (throws) {
-      throwsPart = indent(rejectAndConcat([softline, throws]));
-    }
-
     return rejectAndJoin(" ", [
       group(
         rejectAndJoin(hardline, [
@@ -566,7 +562,7 @@ class ClassesPrettierVisitor {
           rejectAndJoin(" ", [
             join(" ", otherModifiers),
             constructorDeclarator,
-            throwsPart
+            throws
           ])
         ])
       ),

--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -1,6 +1,6 @@
 "use strict";
 const _ = require("lodash");
-const { ifBreak, line, softline, hardline } = require("prettier").doc.builders;
+const { line, softline, hardline } = require("prettier").doc.builders;
 const {
   getBlankLinesSeparator,
   reject,
@@ -510,12 +510,7 @@ class ClassesPrettierVisitor {
   throws(ctx) {
     const exceptionTypeList = this.visit(ctx.exceptionTypeList);
     const throwsDeclaration = join(" ", [ctx.Throws[0], exceptionTypeList]);
-    return group(
-      ifBreak(
-        indent(rejectAndConcat([softline, throwsDeclaration])),
-        throwsDeclaration
-      )
-    );
+    return group(indent(rejectAndConcat([softline, throwsDeclaration])));
   }
 
   exceptionTypeList(ctx) {

--- a/packages/prettier-plugin-java/test/unit-test/comments/interface/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/interface/_output.java
@@ -18,6 +18,5 @@ public /*a*/interface /*b*/MyInterface
     Param1 /*a*/p1/*b*//*a*/,
     /*b*//*a*/Param2 /*b*//*a*/p2/*b*/,
     Param3 p3
-  )
-    /*a*/throws /*b*/Exception/*a*/, /*b*/RuntimeException /*a*/;/*b*/
+  ) /*a*/throws /*b*/Exception/*a*/, /*b*/RuntimeException /*a*/;/*b*/
 }

--- a/packages/prettier-plugin-java/test/unit-test/throws/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/throws/_input.java
@@ -20,9 +20,33 @@ public abstract class Throws {
     throw new RuntimeException();
   }
 
-  void throwException6(String string1, String string2, String string3) throws RuntimeException, RuntimeException, RuntimeException {
+  void throwException6(String string1, String string2, String string3)
+    throws RuntimeException, RuntimeException, RuntimeException {
     throw new RuntimeException();
   }
+
+  void throwException7(String string1, String string2, String string3, String string4) throws RuntimeException {
+    throw new RuntimeException();
+  }
+
+  void throwException8(String string1, String string2, String string3, String string4)
+    throws RuntimeException, RuntimeException, RuntimeException {
+    throw new RuntimeException();
+  }
+
+  void throwException9(String string1, String string2, String string3, String string4)
+    throws RuntimeException, RuntimeException, RuntimeException, RuntimeException {
+    throw new RuntimeException();
+  }
+
+  void aVeryLongNameForAMethodWichShouldBreakTheExpression()
+    throws aVeryLongException {}
+
+  void aVeryLongNameForAMethodWichShouldBreakTheExpression()
+    throws aVeryLongException, aVeryLongException {}
+
+  void aVeryLongNameForAMethodWichShouldBreakTheExpression()
+    throws Exception, Exception, Exception, Exception, Exception, Exception, Exception {}
 
   abstract void absThrowException1() throws RuntimeException;
 
@@ -34,7 +58,14 @@ public abstract class Throws {
 
   abstract void absThrowException5(String string) throws RuntimeException, RuntimeException, RuntimeException;
 
-  abstract void absThrowException6(String string1, String string2, String string3) throws RuntimeException, RuntimeException, RuntimeException;
+  abstract void absThrowException6(String string1, String string2, String string3)
+    throws RuntimeException, RuntimeException, RuntimeException;
+
+  abstract void absThrowException7(String string1, String string2, String string3, String string4)
+    throws RuntimeException, RuntimeException, RuntimeException;
+
+  abstract void absThrowException8(String string1, String string2, String string3, String string4)
+    throws RuntimeException, RuntimeException, RuntimeException, RuntimeException;
 
   public Throws(String string1)
       throws RuntimeException {
@@ -43,6 +74,16 @@ public abstract class Throws {
 
   public Throws(String string1, String string2, String string3)
       throws RuntimeException {
+    System.out.println("Constructor with throws that should wrap");
+  }
+
+  public Throws(String string1, String string2, String string3, String string4, String string5)
+      throws RuntimeException {
+    System.out.println("Constructor with throws that should wrap");
+  }
+
+  public Throws(String string1, String string2, String string3, String string4, String string5)
+      throws RuntimeException, RuntimeException, RuntimeException, RuntimeException {
     System.out.println("Constructor with throws that should wrap");
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/throws/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/throws/_output.java
@@ -28,6 +28,42 @@ public abstract class Throws {
     throw new RuntimeException();
   }
 
+  void throwException7(
+    String string1,
+    String string2,
+    String string3,
+    String string4
+  ) throws RuntimeException {
+    throw new RuntimeException();
+  }
+
+  void throwException8(
+    String string1,
+    String string2,
+    String string3,
+    String string4
+  ) throws RuntimeException, RuntimeException, RuntimeException {
+    throw new RuntimeException();
+  }
+
+  void throwException9(
+    String string1,
+    String string2,
+    String string3,
+    String string4
+  ) throws RuntimeException, RuntimeException, RuntimeException, RuntimeException {
+    throw new RuntimeException();
+  }
+
+  void aVeryLongNameForAMethodWichShouldBreakTheExpression()
+    throws aVeryLongException {}
+
+  void aVeryLongNameForAMethodWichShouldBreakTheExpression()
+    throws aVeryLongException, aVeryLongException {}
+
+  void aVeryLongNameForAMethodWichShouldBreakTheExpression()
+    throws Exception, Exception, Exception, Exception, Exception, Exception, Exception {}
+
   abstract void absThrowException1() throws RuntimeException;
 
   abstract void absThrowException2(String string) throws RuntimeException;
@@ -36,8 +72,7 @@ public abstract class Throws {
     String string1,
     String string2,
     String string3
-  )
-    throws RuntimeException;
+  ) throws RuntimeException;
 
   abstract void absThrowException4()
     throws RuntimeException, RuntimeException, RuntimeException;
@@ -49,8 +84,21 @@ public abstract class Throws {
     String string1,
     String string2,
     String string3
-  )
-    throws RuntimeException, RuntimeException, RuntimeException;
+  ) throws RuntimeException, RuntimeException, RuntimeException;
+
+  abstract void absThrowException7(
+    String string1,
+    String string2,
+    String string3,
+    String string4
+  ) throws RuntimeException, RuntimeException, RuntimeException;
+
+  abstract void absThrowException8(
+    String string1,
+    String string2,
+    String string3,
+    String string4
+  ) throws RuntimeException, RuntimeException, RuntimeException, RuntimeException;
 
   public Throws(String string1) throws RuntimeException {
     System.out.println("Constructor with throws that should not wrap");
@@ -58,6 +106,26 @@ public abstract class Throws {
 
   public Throws(String string1, String string2, String string3)
     throws RuntimeException {
+    System.out.println("Constructor with throws that should wrap");
+  }
+
+  public Throws(
+    String string1,
+    String string2,
+    String string3,
+    String string4,
+    String string5
+  ) throws RuntimeException {
+    System.out.println("Constructor with throws that should wrap");
+  }
+
+  public Throws(
+    String string1,
+    String string2,
+    String string3,
+    String string4,
+    String string5
+  ) throws RuntimeException, RuntimeException, RuntimeException, RuntimeException {
     System.out.println("Constructor with throws that should wrap");
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/throws/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/throws/_output.java
@@ -51,7 +51,8 @@ public abstract class Throws {
     String string2,
     String string3,
     String string4
-  ) throws RuntimeException, RuntimeException, RuntimeException, RuntimeException {
+  )
+    throws RuntimeException, RuntimeException, RuntimeException, RuntimeException {
     throw new RuntimeException();
   }
 
@@ -98,7 +99,8 @@ public abstract class Throws {
     String string2,
     String string3,
     String string4
-  ) throws RuntimeException, RuntimeException, RuntimeException, RuntimeException;
+  )
+    throws RuntimeException, RuntimeException, RuntimeException, RuntimeException;
 
   public Throws(String string1) throws RuntimeException {
     System.out.println("Constructor with throws that should not wrap");
@@ -125,7 +127,8 @@ public abstract class Throws {
     String string3,
     String string4,
     String string5
-  ) throws RuntimeException, RuntimeException, RuntimeException, RuntimeException {
+  )
+    throws RuntimeException, RuntimeException, RuntimeException, RuntimeException {
     System.out.println("Constructor with throws that should wrap");
   }
 }


### PR DESCRIPTION
This is a modified version of #305 that makes a more minor change. Based on #286 it seems like there's not a clear answer on how formatting should work when methods throw lots of exceptions. However, the current behavior where there's an extra newline is basically a bug, for example:

```java
public void method(
  Arg arg1,
  Arg arg2
)
  throws Exception {}
```

This PR attempts to fix the bug, while punting on the question of a more complete behavior change.

The tests should give a good idea of the behavior I was going for. Unfortunately, my prettier fu is pretty weak so a few of the tests are failing and I'm having a hard time getting things just right
