### PR TITLE
fix: empty enums

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -674,12 +674,14 @@ class ClassesPrettierVisitor {
     const enumConstantList = this.visit(ctx.enumConstantList);
     const enumBodyDeclarations = this.visit(ctx.enumBodyDeclarations);
 
+    const hasEnumConstants = ctx.enumConstantList !== undefined;
     const hasNoClassBodyDeclarations =
       ctx.enumBodyDeclarations === undefined ||
       ctx.enumBodyDeclarations[0].children.classBodyDeclaration === undefined;
 
     let optionalComma;
     if (
+      hasEnumConstants &&
       hasNoClassBodyDeclarations &&
       this.prettierOptions.trailingComma !== "none"
     ) {

--- a/packages/prettier-plugin-java/test/unit-test/enum/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_input.java
@@ -115,3 +115,9 @@ public enum OtherEnum {
 
 }
 
+public enum EmptyEnum {
+}
+
+public enum EmptyEnumWithComment {
+  // comment
+}

--- a/packages/prettier-plugin-java/test/unit-test/enum/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_output.java
@@ -131,3 +131,9 @@ public enum OtherEnum {
   /* Six */
   SIX,
 }
+
+public enum EmptyEnum {}
+
+public enum EmptyEnumWithComment {
+  // comment
+}


### PR DESCRIPTION
## What changed with this PR:

Fix handling of empty enums to not insert a trailing comma

## Example

The tests show examples of the new behavior. Without this PR, the output is:

```java
public enum EmptyEnum {
  ,
}

public enum EmptyEnumWithComment {
  ,
  // comment
}
```

Which doesn't compile