### PR TITLE
fix: comment on enum

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -16,7 +16,10 @@ const {
 } = require("./printer-utils");
 const { concat, join, group, indent } = require("./prettier-builder");
 const { printTokenWithComments } = require("./comments/format-comments");
-const { hasLeadingLineComments } = require("./comments/comments-utils");
+const {
+  hasLeadingLineComments,
+  hasLeadingComments
+} = require("./comments/comments-utils");
 
 class ClassesPrettierVisitor {
   classDeclaration(ctx) {
@@ -679,6 +682,13 @@ class ClassesPrettierVisitor {
       ctx.enumBodyDeclarations === undefined ||
       ctx.enumBodyDeclarations[0].children.classBodyDeclaration === undefined;
 
+    // edge case: https://github.com/jhipster/prettier-java/issues/383
+    const handleEnumBodyDeclarationsLeadingComments =
+      !hasNoClassBodyDeclarations &&
+      hasLeadingComments(ctx.enumBodyDeclarations[0])
+        ? hardline
+        : "";
+
     let optionalComma;
     if (
       hasEnumConstants &&
@@ -691,7 +701,12 @@ class ClassesPrettierVisitor {
     }
 
     return putIntoBraces(
-      rejectAndConcat([enumConstantList, optionalComma, enumBodyDeclarations]),
+      rejectAndConcat([
+        enumConstantList,
+        optionalComma,
+        handleEnumBodyDeclarationsLeadingComments,
+        enumBodyDeclarations
+      ]),
       hardline,
       ctx.LCurly[0],
       ctx.RCurly[0]

--- a/packages/prettier-plugin-java/test/unit-test/enum/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_input.java
@@ -121,3 +121,29 @@ public enum EmptyEnum {
 public enum EmptyEnumWithComment {
   // comment
 }
+
+enum PrettierErrors {
+  WE_LOVE_PRETTIER,
+  // And I can't believe
+  // it is free
+  // why are people
+  // so damn generous
+  ;
+
+  void printTest() {
+    System.out.println("Hey there");
+  }
+}
+
+
+enum PrettierErrors {
+  WE_LOVE_PRETTIER;
+  // And I can't believe
+  // it is free
+  // why are people
+  // so damn generous
+
+  void printTest() {
+    System.out.println("Hey there");
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/enum/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_output.java
@@ -137,3 +137,29 @@ public enum EmptyEnum {}
 public enum EmptyEnumWithComment {
   // comment
 }
+
+enum PrettierErrors {
+  WE_LOVE_PRETTIER
+  // And I can't believe
+  // it is free
+  // why are people
+  // so damn generous
+  ;
+
+  void printTest() {
+    System.out.println("Hey there");
+  }
+}
+
+enum PrettierErrors {
+  WE_LOVE_PRETTIER;
+
+  // And I can't believe
+  // it is free
+  // why are people
+  // so damn generous
+
+  void printTest() {
+    System.out.println("Hey there");
+  }
+}


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
enum PrettierErrors {
  WE_LOVE_PRETTIER,
  // And I can't believe
  // it is free
  // why are people
  // so damn generous
  ;

  void printTest() {
    System.out.println("Hey there");
  }
}

// Output
enum PrettierErrors {
  WE_LOVE_PRETTIER
  // And I can't believe
  // it is free
  // why are people
  // so damn generous
  ;

  void printTest() {
    System.out.println("Hey there");
  }
}
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
Fix #383
