### PR TITLE
fix: wrong indent on single method call following a constructor 

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -293,16 +293,19 @@ class ExpressionsPrettierVisitor {
     const suffixes = [];
 
     if (ctx.primarySuffix !== undefined) {
-
       // edge case: https://github.com/jhipster/prettier-java/issues/381
       let hasFirstInvocationArg = true;
 
-      if(ctx.primarySuffix.length > 1 &&
+      if (
+        ctx.primarySuffix.length > 1 &&
         ctx.primarySuffix[1].children.methodInvocationSuffix &&
-        Object.keys(ctx.primarySuffix[1].children.methodInvocationSuffix[0].children).length === 2) {
+        Object.keys(
+          ctx.primarySuffix[1].children.methodInvocationSuffix[0].children
+        ).length === 2
+      ) {
         hasFirstInvocationArg = false;
       }
-      
+
       if (
         ctx.primarySuffix[0].children.Dot !== undefined &&
         ctx.primaryPrefix[0].children.newExpression !== undefined
@@ -325,7 +328,7 @@ class ExpressionsPrettierVisitor {
         return group(
           rejectAndConcat([
             primaryPrefix,
-            hasFirstInvocationArg?suffixes[0]:indent(suffixes[0]),
+            hasFirstInvocationArg ? suffixes[0] : indent(suffixes[0]),
             indent(rejectAndConcat(suffixes.slice(1)))
           ])
         );

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -293,6 +293,16 @@ class ExpressionsPrettierVisitor {
     const suffixes = [];
 
     if (ctx.primarySuffix !== undefined) {
+
+      // edge case: https://github.com/jhipster/prettier-java/issues/381
+      let hasFirstInvocationArg = true;
+
+      if(ctx.primarySuffix.length > 1 &&
+        ctx.primarySuffix[1].children.methodInvocationSuffix &&
+        Object.keys(ctx.primarySuffix[1].children.methodInvocationSuffix[0].children).length === 2) {
+        hasFirstInvocationArg = false;
+      }
+      
       if (
         ctx.primarySuffix[0].children.Dot !== undefined &&
         ctx.primaryPrefix[0].children.newExpression !== undefined
@@ -315,7 +325,7 @@ class ExpressionsPrettierVisitor {
         return group(
           rejectAndConcat([
             primaryPrefix,
-            suffixes[0],
+            hasFirstInvocationArg?suffixes[0]:indent(suffixes[0]),
             indent(rejectAndConcat(suffixes.slice(1)))
           ])
         );

--- a/packages/prettier-plugin-java/test/unit-test/instantiation/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/instantiation/_input.java
@@ -8,6 +8,8 @@ public class Instantiation {
       new Nested("that", "have", "nested", new Nested("instantiation"), "everywhere", "!"),
       "should", "wrap"
     );
+
+    new MethodWrappingFollowingContstructor().aLongEnoughMethodNameToForceThingsToWrap();
   }
 
 }

--- a/packages/prettier-plugin-java/test/unit-test/instantiation/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/instantiation/_output.java
@@ -21,5 +21,8 @@ public class Instantiation {
       "should",
       "wrap"
     );
+
+    new MethodWrappingFollowingContstructor()
+      .aLongEnoughMethodNameToForceThingsToWrap();
   }
 }


### PR DESCRIPTION
## What changed with this PR:

Fix #381 

## Example

```java
// Input
public class MethodWrappingFollowingContstructor {

  public static void callMethod() {
    new MethodWrappingFollowingContstructor().aLongEnoughMethodNameToForceThingsToWrap();
    System.out.println(
      "This operation with two very long string should break" +
      "in a very nice way"
    );
  }

  public void aLongEnoughMethodNameToForceThingsToWrap() {}
}
// Output
public class MethodWrappingFollowingContstructor {

  public static void callMethod() {
    new MethodWrappingFollowingContstructor()
      .aLongEnoughMethodNameToForceThingsToWrap();
    System.out.println(
      "This operation with two very long string should break" +
      "in a very nice way"
    );
  }

  public void aLongEnoughMethodNameToForceThingsToWrap() {}
}

```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
