### PR TITLE
fix: Long fully qualified name indent

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -381,20 +381,40 @@ class ExpressionsPrettierVisitor {
     const fqnOrRefTypePartRest = this.mapVisit(ctx.fqnOrRefTypePartRest);
     const dims = this.visit(ctx.dims);
     const dots = ctx.Dot ? ctx.Dot : [];
+    const isMethodInvocation = ctx.Dot && ctx.Dot.length === 1;
 
     if (
       params !== undefined &&
       params.shouldBreakBeforeFirstMethodInvocation === true
     ) {
-      return rejectAndConcat([
-        indent(
-          rejectAndJoin(concat([softline, dots[0]]), [
-            fqnOrRefTypePartFirst,
-            rejectAndJoinSeps(dots.slice(1), fqnOrRefTypePartRest),
+      // when fqnOrRefType is a method call from an object
+      if (isMethodInvocation) {
+        return rejectAndConcat([
+          indent(
+            rejectAndJoin(concat([softline, dots[0]]), [
+              fqnOrRefTypePartFirst,
+              rejectAndJoinSeps(dots.slice(1), fqnOrRefTypePartRest),
+              dims
+            ])
+          )
+        ]);
+        // otherwise it is a fully qualified name but we need to exclude when it is just a method call
+      } else if (ctx.Dot) {
+        return indent(
+          rejectAndConcat([
+            rejectAndJoinSeps(dots.slice(0, dots.length - 1), [
+              fqnOrRefTypePartFirst,
+              ...fqnOrRefTypePartRest.slice(0, fqnOrRefTypePartRest.length - 1)
+            ]),
+            softline,
+            rejectAndConcat([
+              dots[dots.length - 1],
+              fqnOrRefTypePartRest[fqnOrRefTypePartRest.length - 1]
+            ]),
             dims
           ])
-        )
-      ]);
+        );
+      }
     }
 
     return rejectAndConcat([

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
@@ -174,5 +174,13 @@ public class Expressions {
     }
   }
 
+  public void longFullyQualifiedName() {
+    com
+      .me.very.very.very.very.very.very.very.very.very.very.very.very.very.longg.fully.qualified.name.FullyQualifiedName.builder()
+      .build();
+    
+    com.FullyQualifiedName.builder();
+  }
+
 }
 

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -227,4 +227,12 @@ public class Expressions {
       System.out.println("Prettier-java is cool !");
     }
   }
+
+  public void longFullyQualifiedName() {
+    com.me.very.very.very.very.very.very.very.very.very.very.very.very.very.longg.fully.qualified.name.FullyQualifiedName
+      .builder()
+      .build();
+
+    com.FullyQualifiedName.builder();
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->
Fix #339

## Example

```java
// Input
public void longFullyQualifiedName() {

  com.me.very.very.very.very.very.very.very.very.very.very.very.very.very.longg.fully.qualified.name.FullyQualifiedName.builder().build();

  com.FullyQualifiedName.builder();
  }
// Output
public void longFullyQualifiedName() {

  com.me.very.very.very.very.very.very.very.very.very.very.very.very.very.longg.fully.qualified.name.FullyQualifiedName
    .builder()
    .build();

  com.FullyQualifiedName.builder();
}

```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
