### PR TITLE
fix: enforce blank line after body declaration

### DIFF
--- a/packages/prettier-plugin-java/scripts/single-printer-run/_output.java
+++ b/packages/prettier-plugin-java/scripts/single-printer-run/_output.java
@@ -1,9 +1,13 @@
 public enum Enum {
-  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM;
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM,
 }
 
 public enum Enum {
-  THIS_IS_GOOD("abc"), THIS_IS_FINE("abc");
+  THIS_IS_GOOD("abc"),
+  THIS_IS_FINE("abc");
+
   public static final String thisWillBeDeleted = "DELETED";
 
   private final String value;
@@ -20,6 +24,7 @@ public enum Enum {
 class CLassWithEnum {
 
   public static enum VALID_THINGS {
-    FIRST, SECOND;
+    FIRST,
+    SECOND,
   }
 }

--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -130,10 +130,8 @@ class ClassesPrettierVisitor {
         !(
           ctx.classBodyDeclaration[0].children.classMemberDeclaration !==
             undefined &&
-          (ctx.classBodyDeclaration[0].children.classMemberDeclaration[0]
-            .children.fieldDeclaration !== undefined ||
-            ctx.classBodyDeclaration[0].children.classMemberDeclaration[0]
-              .children.Semicolon !== undefined)
+          ctx.classBodyDeclaration[0].children.classMemberDeclaration[0]
+            .children.Semicolon !== undefined
         )
       ) {
         content = rejectAndConcat([hardline, content]);

--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -43,7 +43,7 @@ class ClassesPrettierVisitor {
     const optionalTypeParams = this.visit(ctx.typeParameters);
     const optionalSuperClasses = this.visit(ctx.superclass);
     const optionalSuperInterfaces = this.visit(ctx.superinterfaces);
-    const body = this.visit(ctx.classBody);
+    const body = this.visit(ctx.classBody, { isNormalClassDeclaration: true });
 
     let superClassesPart = "";
     if (optionalSuperClasses) {
@@ -113,7 +113,7 @@ class ClassesPrettierVisitor {
     return group(rejectAndJoinSeps(commas, interfaceType));
   }
 
-  classBody(ctx) {
+  classBody(ctx, param) {
     let content = "";
     if (ctx.classBodyDeclaration !== undefined) {
       const classBodyDeclsVisited = reject(
@@ -141,7 +141,9 @@ class ClassesPrettierVisitor {
       if (
         (ctx.classBodyDeclaration[0].children.classMemberDeclaration ||
           ctx.classBodyDeclaration[0].children.constructorDeclaration) &&
-        shouldHardline
+        shouldHardline &&
+        param &&
+        param.isNormalClassDeclaration
       ) {
         content = rejectAndConcat([hardline, content]);
       }

--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -126,13 +126,22 @@ class ClassesPrettierVisitor {
 
       content = rejectAndJoinSeps(separators, classBodyDeclsVisited);
 
+      // edge case when we have SemiColons
+      let shouldHardline = false;
+      ctx.classBodyDeclaration.forEach(elt => {
+        if (
+          (elt.children.classMemberDeclaration &&
+            !elt.children.classMemberDeclaration[0].children.Semicolon) ||
+          elt.children.constructorDeclaration
+        ) {
+          shouldHardline = true;
+        }
+      });
+
       if (
-        !(
-          ctx.classBodyDeclaration[0].children.classMemberDeclaration !==
-            undefined &&
-          ctx.classBodyDeclaration[0].children.classMemberDeclaration[0]
-            .children.Semicolon !== undefined
-        )
+        (ctx.classBodyDeclaration[0].children.classMemberDeclaration ||
+          ctx.classBodyDeclaration[0].children.constructorDeclaration) &&
+        shouldHardline
       ) {
         content = rejectAndConcat([hardline, content]);
       }

--- a/packages/prettier-plugin-java/test/unit-test/blank_lines/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/blank_lines/_output.java
@@ -1,4 +1,5 @@
 public class BlankLines {
+
   public int i = 1;
   public int j = 2;
 

--- a/packages/prettier-plugin-java/test/unit-test/char_literal/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/char_literal/_output.java
@@ -1,4 +1,5 @@
 public class CharLiteral {
+
   final char singleQuote = '\'';
 
   final char backslash = '\\';

--- a/packages/prettier-plugin-java/test/unit-test/classes/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/classes/_output.java
@@ -12,5 +12,6 @@ public class ClassDeclaration {
 }
 
 class ClassWithSemicolon {
+
   private FieldOneClass fieldOne;
 }

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -235,7 +235,6 @@ public final class ArrayTable<R, C, V>
     Entry<K, V> getEntry(final int index) {
       checkElementIndex(index, size());
       return new AbstractMapEntry<K, V>() {
-
         @Override
         public K getKey() {
           return ArrayMap.this.getKey(index);
@@ -256,7 +255,6 @@ public final class ArrayTable<R, C, V>
     @Override
     Iterator<Entry<K, V>> entryIterator() {
       return new AbstractIndexedListIterator<Entry<K, V>>(size()) {
-
         @Override
         protected Entry<K, V> get(final int index) {
           return getEntry(index);
@@ -573,7 +571,6 @@ public final class ArrayTable<R, C, V>
   @Override
   Iterator<Cell<R, C, V>> cellIterator() {
     return new AbstractIndexedListIterator<Cell<R, C, V>>(size()) {
-
       @Override
       protected Cell<R, C, V> get(final int index) {
         return getCell(index);
@@ -592,7 +589,6 @@ public final class ArrayTable<R, C, V>
 
   private Cell<R, C, V> getCell(final int index) {
     return new Tables.AbstractCell<R, C, V>() {
-
       final int rowIndex = index / columnList.size();
       final int columnIndex = index % columnList.size();
 
@@ -820,7 +816,6 @@ public final class ArrayTable<R, C, V>
   @Override
   Iterator<V> valuesIterator() {
     return new AbstractIndexedListIterator<V>(size()) {
-
       @Override
       protected V get(int index) {
         return getValue(index);

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -200,6 +200,7 @@ public final class ArrayTable<R, C, V>
 
   private abstract static class ArrayMap<K, V>
     extends IteratorBasedAbstractMap<K, V> {
+
     private final ImmutableMap<K, Integer> keyIndex;
 
     private ArrayMap(ImmutableMap<K, Integer> keyIndex) {
@@ -591,6 +592,7 @@ public final class ArrayTable<R, C, V>
 
   private Cell<R, C, V> getCell(final int index) {
     return new Tables.AbstractCell<R, C, V>() {
+
       final int rowIndex = index / columnList.size();
       final int columnIndex = index % columnList.size();
 
@@ -638,6 +640,7 @@ public final class ArrayTable<R, C, V>
   }
 
   private class Column extends ArrayMap<R, V> {
+
     final int columnIndex;
 
     Column(int columnIndex) {
@@ -728,6 +731,7 @@ public final class ArrayTable<R, C, V>
   }
 
   private class Row extends ArrayMap<C, V> {
+
     final int rowIndex;
 
     Row(int rowIndex) {

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/complex/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/complex/_output.java
@@ -1,4 +1,5 @@
 public class PrettierTest {
+
   var x = 0;
 
   public void myFunction(int arg1) {

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/end-of-block/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/end-of-block/_output.java
@@ -32,6 +32,7 @@ class H {
 }
 
 class I { // alpha
+
   // beta
   int i;
   // one

--- a/packages/prettier-plugin-java/test/unit-test/complex_generic_class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/complex_generic_class/_output.java
@@ -1,4 +1,5 @@
 public class GenericClass<BEAN extends Comparable<BEAN>> {
+
   private BEAN bean;
 
   public GenericClass(BEAN bean) {

--- a/packages/prettier-plugin-java/test/unit-test/empty_statement/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/empty_statement/_output.java
@@ -87,6 +87,7 @@ public class EmptyStament {
 
 // Bug Fix: #356
 public class Test {
+
   public TestField testField;
 
   @Override

--- a/packages/prettier-plugin-java/test/unit-test/generic_class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/generic_class/_output.java
@@ -1,4 +1,5 @@
 public class GenericClass<BEAN> {
+
   private BEAN bean;
 
   public GenericClass(BEAN bean) {

--- a/packages/prettier-plugin-java/test/unit-test/marker_annotations/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/marker_annotations/_output.java
@@ -8,6 +8,7 @@ package test;
 @NormalAnnotation("value")
 @MarkerAnnotation
 public class MarkerAnnotations {
+
   @SingleMemberAnnotation2(
     name = "Something much long that breaks",
     date = "01/01/2018"

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
@@ -25,6 +25,7 @@ public static interface InterfaceWithModifiers {
 @AnnotationOne
 @AnnotationTwo
 public abstract class AbstractClassWithModifiers {
+
   @Annotation
   private static volatile String field;
 
@@ -41,6 +42,7 @@ public abstract class AbstractClassWithModifiers {
 @AnnotationOne
 @AnnotationTwo
 public static final class ClassWithModifiers {
+
   @AnnotationOne
   @AnnotationTwo
   private static final transient String CONSTANT = "abc";

--- a/packages/prettier-plugin-java/test/unit-test/prettier-ignore/method/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/prettier-ignore/method/_output.java
@@ -1,4 +1,5 @@
 public class PrettierIgnoreClass {
+
   int myInteger;
 
   public void myPrettierIgnoreMethod(

--- a/packages/prettier-plugin-java/test/unit-test/prettier-ignore/multiple-ignore/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/prettier-ignore/multiple-ignore/_output.java
@@ -1,4 +1,5 @@
 public class PrettierIgnoreClass {
+
   int myInteger;
 
   public void myPrettierIgnoreMethod(

--- a/packages/prettier-plugin-java/test/unit-test/snippets/classes/class-body.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/classes/class-body.spec.js
@@ -14,7 +14,7 @@ describe("Class Body", () => {
   it("should handle a class body with one field declaration", () => {
     // prettier-ignore
     const expectedOutput =
-      "{\n\n" +
+      "{\n" +
       "  int i;\n" +
       "}";
 
@@ -37,7 +37,7 @@ describe("Class Body", () => {
 
     // prettier-ignore
     const expectedOutput =
-      "{\n\n" +
+      "{\n" +
       "  int i;\n" +
       "  int j;\n" +
       "\n" +
@@ -64,7 +64,7 @@ describe("Class Body", () => {
 
     // prettier-ignore
     const expectedOutput =
-      "{\n\n" +
+      "{\n" +
       "  int i;\n" +
       "\n" +
       "  int j;\n" +
@@ -90,7 +90,7 @@ describe("Class Body", () => {
       "}";
 
     const expectedOutput =
-      "{\n\n" +
+      "{\n" +
       "  int i;\n" +
       "\n" +
       "  void t() {}\n" +
@@ -128,7 +128,7 @@ describe("Class Body", () => {
         "}";
 
       const expectedOutput =
-        "{\n\n" +
+        "{\n" +
         "  int i;\n" +
         "  int j;\n" +
         "  int k;\n" +
@@ -159,7 +159,7 @@ describe("Class Body", () => {
         "}";
 
       const expectedOutput =
-        "{\n\n" +
+        "{\n" +
         "  int i;\n" +
         "\n" +
         "  void t() {}\n" +
@@ -196,7 +196,7 @@ describe("Class Body", () => {
         "}";
 
       const expectedOutput =
-        "{\n\n" +
+        "{\n" +
         "  int i;\n" +
         "  /* TODO */\n" +
         "  int j;\n" +

--- a/packages/prettier-plugin-java/test/unit-test/snippets/classes/class-body.spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/snippets/classes/class-body.spec.js
@@ -14,7 +14,7 @@ describe("Class Body", () => {
   it("should handle a class body with one field declaration", () => {
     // prettier-ignore
     const expectedOutput =
-      "{\n" +
+      "{\n\n" +
       "  int i;\n" +
       "}";
 
@@ -37,7 +37,7 @@ describe("Class Body", () => {
 
     // prettier-ignore
     const expectedOutput =
-      "{\n" +
+      "{\n\n" +
       "  int i;\n" +
       "  int j;\n" +
       "\n" +
@@ -64,7 +64,7 @@ describe("Class Body", () => {
 
     // prettier-ignore
     const expectedOutput =
-      "{\n" +
+      "{\n\n" +
       "  int i;\n" +
       "\n" +
       "  int j;\n" +
@@ -90,7 +90,7 @@ describe("Class Body", () => {
       "}";
 
     const expectedOutput =
-      "{\n" +
+      "{\n\n" +
       "  int i;\n" +
       "\n" +
       "  void t() {}\n" +
@@ -128,7 +128,7 @@ describe("Class Body", () => {
         "}";
 
       const expectedOutput =
-        "{\n" +
+        "{\n\n" +
         "  int i;\n" +
         "  int j;\n" +
         "  int k;\n" +
@@ -159,7 +159,7 @@ describe("Class Body", () => {
         "}";
 
       const expectedOutput =
-        "{\n" +
+        "{\n\n" +
         "  int i;\n" +
         "\n" +
         "  void t() {}\n" +
@@ -196,7 +196,7 @@ describe("Class Body", () => {
         "}";
 
       const expectedOutput =
-        "{\n" +
+        "{\n\n" +
         "  int i;\n" +
         "  /* TODO */\n" +
         "  int j;\n" +

--- a/packages/prettier-plugin-java/test/unit-test/variables/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_output.java
@@ -46,7 +46,6 @@ public class Variables {
   private int octLiteral = 001;
 
   private Interface anonymousClassVariable = new Interface() {
-
     @Override
     void doSomething() {
       System.out.println("do something");

--- a/packages/prettier-plugin-java/test/unit-test/variables/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_output.java
@@ -1,4 +1,5 @@
 public class Variables {
+
   public static int STATIC_VARIABLE = 123;
   private static final Logger LOGGER = LoggerFactory.getLogger(
     ComplexFilterTest.class


### PR DESCRIPTION
## What changed with this PR:

Fix #271

## Example

```java
// Input
public class JWTFilter extends GenericFilterBean {
    public static final String AUTHORIZATION_HEADER = "Authorization";

    private TokenProvider tokenProvider;
}
// Output
public class JWTFilter extends GenericFilterBean {

    public static final String AUTHORIZATION_HEADER = "Authorization";

    private TokenProvider tokenProvider;
}
```
However it should be noted that we can have this case:
```java
// Input
public class MyClass {
    public void myMethod() {
        return new AnonymousClass() {
            int a;
        }
    }
}
// Output
public class MyClass {
    public void myMethod() {
        return new AnonymousClass() {

            int a;
        }
    }
}
```
Since inside the class this is also a classBodyDeclaration node.
I think we can probably make an exception on class body for anonymous class but I don't know if we should.
## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
