### PR TITLE
feat: upload binary artifacts on github release

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -6,7 +6,7 @@ jobs:
   generate:
     env:
       # The version needs to match with the one used in the printer
-      PRETTIER_API: 2.0.0
+      PRETTIER_CORE_LIB_VERSION: 2.0.0
     name: Create release artifacts
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: prettier/prettier
-          ref: refs/tags/${{ env.PRETTIER_API }}
+          ref: refs/tags/${{ env.PRETTIER_CORE_LIB_VERSION }}
           path: prettier
       - name: Link Prettier-java to Prettier
         run: |

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -37,6 +37,7 @@ jobs:
           ref: refs/tags/${{ env.PRETTIER_CORE_LIB_VERSION }}
           path: prettier
       - name: Link Prettier-java to Prettier
+        # We need to give the path to the plugin for pkg
         run: |
           cd $GITHUB_WORKSPACE/prettier
           npm i

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,55 @@
+on:
+  release:
+    types: [created]
+name: Binary artifacts
+jobs:
+  generate:
+    env:
+      # The version needs to match with the one used in the printer
+      PRETTIER_API: 2.0.0
+    name: Create release artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+        with:
+          path: 'prettier-java'
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install tools
+        run: |
+          sudo apt update
+          sudo apt install jq
+          npm i -g pkg
+      - name: Installing/Linking dependencies
+        run: |
+          cd $GITHUB_WORKSPACE/prettier-java/packages/java-parser
+          npm i
+          npm link
+          cd $GITHUB_WORKSPACE/prettier-java/packages/prettier-plugin-java
+          npm i
+          npm link java-parser
+      - name: Checkout Prettier
+        uses: actions/checkout@v2
+        with:
+          repository: prettier/prettier
+          ref: refs/tags/${{ env.PRETTIER_API }}
+          path: prettier
+      - name: Link Prettier-java to Prettier
+        run: |
+          cd $GITHUB_WORKSPACE/prettier
+          npm i
+          npm link prettier-plugin-java
+          mv package.json package.json.old
+          jq '.dependencies["prettier-plugin-java"] = "./node_modules/prettier-plugin-java"' package.json.old | cat > package.json
+      - name: Build the artifacts
+        run: |
+          cd $GITHUB_WORKSPACE/prettier
+          pkg package.json -o $GITHUB_WORKSPACE/prettier-java-${GITHUB_REF##*/} --targets node10-linux-x64,node10-macos-x64,node10-win-x64
+      - name: Upload the artifacts
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: 'prettier-java-*'

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-name: prettier-java
+name: Prettier-java
 on: [push, pull_request]
 jobs:
   tests:


### PR DESCRIPTION
## What changed with this PR:
This PR will provide binary artifacts on github release.
Working on linux but I have tested for macos or windows thought.

Close #326
<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input

// Output
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
