### PR TITLE
fix: unknown sed option on macos

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -7,7 +7,7 @@ const tasks = arr => arr.join(" && ");
 function checkEntrypointOptions() {
   const missingRules = [];
   const rules = execSync(
-    `sed -nr 's/.*RULE\\("([^"]+)".*/\\1/p' $(ls packages/java-parser/src/productions/*)`
+    `sed -nE 's/.*RULE\\("([^"]+)".*/\\1/p' $(ls packages/java-parser/src/productions/*)`
   )
     .toString()
     .split("\n");


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input

// Output
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
