### PR TITLE
Add more context to the Maven plugin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To see an advanced usage: please go to the [Advanced Usage](./docs/advanced_usag
 ## Maven plugin
 
 A neat maven plugin for prettier-java was made by developers from HubSpot. \
-It is currently available at:
+Add it to the `plugins` section of your `build` configuration
 
 ```xml
 <build>
@@ -95,7 +95,7 @@ It is currently available at:
     <plugin>
       <groupId>com.hubspot.maven.plugins</groupId>
         <artifactId>prettier-maven-plugin</artifactId>
-        <!-- Find the latest version -->
+        <!-- Find the latest version at https://github.com/jhipster/prettier-java/releases -->
         <version>0.8</version>
     </plugin>
   </plugins>

--- a/README.md
+++ b/README.md
@@ -90,12 +90,16 @@ A neat maven plugin for prettier-java was made by developers from HubSpot. \
 It is currently available at:
 
 ```xml
-<plugin>
-    <groupId>com.hubspot.maven.plugins</groupId>
-    <artifactId>prettier-maven-plugin</artifactId>
-    <!-- Find the latest version -->
-    <version>0.8</version>
-</plugin>
+<build>
+  <plugins>
+    <plugin>
+      <groupId>com.hubspot.maven.plugins</groupId>
+        <artifactId>prettier-maven-plugin</artifactId>
+        <!-- Find the latest version -->
+        <version>0.8</version>
+    </plugin>
+  </plugins>
+</build>
 ```
 
 If you would like to use this plugin, we recommend you to check their [project](https://github.com/HubSpot/prettier-maven-plugin) as is it well documented.


### PR DESCRIPTION
## What changed with this PR:
Improving the README documentation so that it shows what part of the pom.xml the plugin entry belongs in. It's been a while since I've used Maven, so it took me a little while to figure out how to actually use this plugin in a fresh pom.xml without a <plugins> block.
