### PR TITLE
fix: fix parsing of unannPrimitiveType in primary

### DIFF
--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -222,17 +222,17 @@ function defineRules($, t) {
     $.OR([
       // Spec Deviation: The array type "dims" suffix was extracted to this rule
       // to avoid backtracking for performance reasons.
-      {
-        ALT: () => {
-          $.SUBRULE($.unannPrimitiveType);
-          $.OPTION({
-            GATE: () => this.BACKTRACK_LOOKAHEAD($.isDims),
-            DEF: () => $.SUBRULE2($.dims)
-          });
-        }
-      },
+      { ALT: () => $.SUBRULE($.unannPrimitiveTypeWithOptionalDimsSuffix) },
       { ALT: () => $.SUBRULE($.unannReferenceType) }
     ]);
+  });
+
+  $.RULE("unannPrimitiveTypeWithOptionalDimsSuffix", () => {
+    $.SUBRULE($.unannPrimitiveType);
+    $.OPTION({
+      GATE: () => this.BACKTRACK_LOOKAHEAD($.isDims),
+      DEF: () => $.SUBRULE2($.dims)
+    });
   });
 
   // https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-UnannPrimitiveType

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -219,9 +219,7 @@ function defineRules($, t) {
       { ALT: () => $.SUBRULE($.literal) },
       { ALT: () => $.CONSUME(t.This) },
       { ALT: () => $.CONSUME(t.Void) },
-      // should be extracted to primitive type with optional dims suffix?
-      { ALT: () => $.SUBRULE($.numericType) },
-      { ALT: () => $.CONSUME(t.Boolean) },
+      { ALT: () => $.SUBRULE($.unannPrimitiveTypeWithOptionalDimsSuffix) },
       { ALT: () => $.SUBRULE($.fqnOrRefType) },
       {
         GATE: () => isCastExpression,

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -87,4 +87,9 @@ describe("The Java Parser fixed bugs", () => {
     const input = "(left) < right";
     expect(() => javaParser.parse(input, "expression")).to.not.throw();
   });
+
+  it("issue #412 - should parse a double[][] as primaryPrefix", () => {
+    const input = "double[][]";
+    expect(() => javaParser.parse(input, "primaryPrefix")).to.not.throw();
+  });
 });

--- a/packages/prettier-plugin-java/src/options.js
+++ b/packages/prettier-plugin-java/src/options.js
@@ -74,6 +74,7 @@ module.exports = {
       { value: "variableInitializer" },
       { value: "unannType" },
       { value: "unannPrimitiveType" },
+      { value: "unannPrimitiveTypeWithOptionalDimsSuffix" },
       { value: "unannReferenceType" },
       { value: "unannClassOrInterfaceType" },
       { value: "unannClassType" },

--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -300,10 +300,10 @@ class ClassesPrettierVisitor {
   }
 
   unannType(ctx) {
-    if (ctx.unannReferenceType !== undefined) {
-      return this.visit(ctx.unannReferenceType);
-    }
+    return this.visitSingle(ctx);
+  }
 
+  unannPrimitiveTypeWithOptionalDimsSuffix(ctx) {
     const unannPrimitiveType = this.visit(ctx.unannPrimitiveType);
     const dims = this.visit(ctx.dims);
 

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -362,7 +362,7 @@ class ExpressionsPrettierVisitor {
   }
 
   primaryPrefix(ctx, params) {
-    if (ctx.This || ctx.Void || ctx.Boolean) {
+    if (ctx.This || ctx.Void) {
       return printTokenWithComments(this.getSingle(ctx));
     }
 

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
@@ -89,7 +89,7 @@ public class Expressions {
     }
 
     if(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42 && myValue == 42) {
-      
+
     }
 
     if(myValue != 42 && myValue == 42) {
@@ -103,11 +103,11 @@ public class Expressions {
     }
 
     switch(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42 && myValue == 42) {
-      
+
     }
 
     switch(myValue != 42) {
-      
+
     }
 
     switch(myValue != 42 && myValue == 42) {
@@ -117,17 +117,17 @@ public class Expressions {
 
   public void printWhile() {
     while/*infinite*/ (true) /*stop the program*/throw new RuntimeException();
-    
+
     while(myValue == 42 || myValue == 42 && myValue == 42 && myValue == 42 || myValue == 42 && myValue == 42) {
 
     }
 
     while(myValue != 42 && 42/42 || myValue & 42 && myValue > 42 || myValue < 42 && myValue == 42) {
-      
+
     }
 
     while(myValue != 42) {
-      
+
     }
 
     while(myValue != 42 && myValue == 42) {
@@ -178,9 +178,12 @@ public class Expressions {
     com
       .me.very.very.very.very.very.very.very.very.very.very.very.very.very.longg.fully.qualified.name.FullyQualifiedName.builder()
       .build();
-    
+
     com.FullyQualifiedName.builder();
   }
 
+  public void unannTypePrimitiveWithMethodReferenceSuffix(String[] args) {
+    List.of(new double[][] { 1,2,3,4.1,5.6846465}, new double[][] { 1,2,3,4.1,5.6846465}, new double[][] { 1,2,3,4.1,5.6846465}).toArray(double[][]::new);
+  }
 }
 

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -235,4 +235,14 @@ public class Expressions {
 
     com.FullyQualifiedName.builder();
   }
+
+  public void unannTypePrimitiveWithMethodReferenceSuffix(String[] args) {
+    List
+      .of(
+        new double[][] { 1, 2, 3, 4.1, 5.6846465 },
+        new double[][] { 1, 2, 3, 4.1, 5.6846465 },
+        new double[][] { 1, 2, 3, 4.1, 5.6846465 }
+      )
+      .toArray(double[][]::new);
+  }
 }


### PR DESCRIPTION
What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->
Fix parsing of this kind of code:

```java
import java.util.List;

public class Test {
    public static void main(String[] args) {
        List.of().toArray(double[][]::new);
    }
}
```

## Example

```java
// Input
List.of(new double[][] { 1,2,3,4.1,5.6846465}, new double[][] { 1,2,3,4.1,5.6846465}, new double[][] { 1,2,3,4.1,5.6846465}).toArray(double[][]::new);

// Output
    List
      .of(
        new double[][] { 1, 2, 3, 4.1, 5.6846465 },
        new double[][] { 1, 2, 3, 4.1, 5.6846465 },
        new double[][] { 1, 2, 3, 4.1, 5.6846465 }
      )
      .toArray(double[][]::new);
```

## Relative issues or prs:

Fix #412 & Fix #376
