### PR TITLE
Feat/add support for text blocks

### DIFF
--- a/packages/java-parser/api.d.ts
+++ b/packages/java-parser/api.d.ts
@@ -504,6 +504,7 @@ export type LiteralCtx = {
   floatingPointLiteral?: FloatingPointLiteralCstNode[];
   booleanLiteral?: BooleanLiteralCstNode[];
   CharLiteral?: IToken[];
+  TextBlock?: IToken[];
   StringLiteral?: IToken[];
   Null?: IToken[];
 };

--- a/packages/java-parser/src/productions/lexical-structure.js
+++ b/packages/java-parser/src/productions/lexical-structure.js
@@ -7,6 +7,7 @@ function defineRules($, t) {
       { ALT: () => $.SUBRULE($.floatingPointLiteral) },
       { ALT: () => $.SUBRULE($.booleanLiteral) },
       { ALT: () => $.CONSUME(t.CharLiteral) },
+      { ALT: () => $.CONSUME(t.TextBlock) },
       { ALT: () => $.CONSUME(t.StringLiteral) },
       { ALT: () => $.CONSUME(t.Null) }
     ]);

--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -224,6 +224,12 @@ createToken({
     "'(?:[^\\\\']|(?:(?:{{EscapeSequence}})|{{UnicodeInputCharacter}}))'"
   )
 });
+
+createToken({
+  name: "TextBlock",
+  pattern: /"""\s*\n(\\"|\s|.)*?"""/
+});
+
 createToken({
   name: "StringLiteral",
   pattern: MAKE_PATTERN('"(?:[^\\\\"]|{{StringCharacter}})*"')

--- a/packages/java-parser/test/test-block-spec.js
+++ b/packages/java-parser/test/test-block-spec.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const { expect } = require("chai");
+
+const javaParser = require("../src/index");
+
+describe("The Java Parser should parse TextBlocks", () => {
+  it("should not parse a one word 'TextBlock'", () => {
+    const input = `"""word"""`;
+
+    expect(() => javaParser.parse(input, "literal")).to.throw();
+  });
+
+  it("should not parse a one word 'TextBlock' with starting spaces", () => {
+    const input = `"""   word"""`;
+
+    expect(() => javaParser.parse(input, "literal")).to.throw();
+  });
+
+  it("should parse a one word 'TextBlock' starting with new line", () => {
+    const input = `"""
+    one"""`;
+
+    expect(() => javaParser.parse(input, "literal")).to.not.throw();
+  });
+
+  it("should parse a one word 'TextBlock' starting with spaces and new line", () => {
+    const input = `"""${"    "}
+    one"""`;
+
+    expect(() => javaParser.parse(input, "literal")).to.not.throw();
+  });
+
+  it("should parse a one line 'TextBlock' starting with new line", () => {
+    const input = `"""
+    one sentence"""`;
+
+    expect(() => javaParser.parse(input, "literal")).to.not.throw();
+  });
+
+  it("should parse a one line 'TextBlock' starting with spaces and new line", () => {
+    const input = `"""${"    "}
+    one sentence"""`;
+
+    expect(() => javaParser.parse(input, "literal")).to.not.throw();
+  });
+
+  it("should parse a multiline 'TextBlock'", () => {
+    const input = `"""
+    one word
+
+    sentence
+
+    """`;
+
+    expect(() => javaParser.parse(input, "literal")).to.not.throw();
+  });
+
+  it("should not parse a multiline 'TextBlock' which do not start with new line", () => {
+    const input = `"""one word
+
+    sentence
+
+    """`;
+
+    expect(() => javaParser.parse(input, "literal")).to.throw();
+  });
+
+  it("should parse a multiline 'TextBlock' with ", () => {
+    const input = `"""
+    one word
+
+    "sentence"
+
+    """`;
+
+    expect(() => javaParser.parse(input, "literal")).to.not.throw();
+  });
+
+  it("should not parse a 'TextBlock' ending with 4x\"", () => {
+    const input = `"""
+    one word
+
+    "sentence"
+
+    """"`;
+
+    expect(() => javaParser.parse(input, "literal")).to.throw();
+  });
+
+  it("should not parse a 'TextBlock' ending with 4x\"", () => {
+    const input = `"""
+    one word
+
+    "sentence"""
+
+    ""`;
+
+    expect(() => javaParser.parse(input, "literal")).to.throw();
+  });
+
+  it("should not parse a 'TextBlock' ending with 4x\"", () => {
+    const input = `"""
+    my text
+
+
+    sentence\\"""
+
+    """
+    `;
+    expect(() => javaParser.parse(input, "literal")).to.not.throw();
+  });
+});

--- a/packages/prettier-plugin-java/src/printers/lexical-structure.js
+++ b/packages/prettier-plugin-java/src/printers/lexical-structure.js
@@ -3,7 +3,7 @@ const { printTokenWithComments } = require("./comments/format-comments");
 
 class LexicalStructurePrettierVisitor {
   literal(ctx) {
-    if (ctx.CharLiteral || ctx.StringLiteral || ctx.Null) {
+    if (ctx.CharLiteral || ctx.TextBlock || ctx.StringLiteral || ctx.Null) {
       return printTokenWithComments(this.getSingle(ctx));
     }
     return this.visitSingle(ctx);

--- a/packages/prettier-plugin-java/test/unit-test/text-blocks/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/text-blocks/_input.java
@@ -1,0 +1,29 @@
+public class TextBlock {
+
+  void method() {
+      String myTextBlock = """
+         my text
+
+
+    sentence\"""
+
+    """;
+
+
+    String source = """
+                public void print(%s object) {
+                    System.out.println(Objects.toString(object));
+                }
+                """.formatted(type);
+
+
+                String html = """
+              <html>\r
+                  <body>\r
+                      <p>Hello, world</p>\r
+                  </body>\r
+              </html>\r
+              """;
+  }
+
+}

--- a/packages/prettier-plugin-java/test/unit-test/text-blocks/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/text-blocks/_output.java
@@ -1,0 +1,30 @@
+public class TextBlock {
+
+  void method() {
+    String myTextBlock = """
+         my text
+
+
+    sentence\"""
+
+    """;
+
+    String source =
+      """
+                public void print(%s object) {
+                    System.out.println(Objects.toString(object));
+                }
+                """.formatted(
+          type
+        );
+
+    String html =
+      """
+              <html>\r
+                  <body>\r
+                      <p>Hello, world</p>\r
+                  </body>\r
+              </html>\r
+              """;
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/text-blocks/text-block-spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/text-blocks/text-block-spec.js
@@ -1,0 +1,3 @@
+describe("Text Blocks", () => {
+  require("../../test-utils").testSample(__dirname);
+});


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
public class TextBlock {

  void method() {
      String myTextBlock = """
         my text


    sentence\"""

    """;


    String source = """
                public void print(%s object) {
                    System.out.println(Objects.toString(object));
                }
                """.formatted(type);


                String html = """
              <html>\r
                  <body>\r
                      <p>Hello, world</p>\r
                  </body>\r
              </html>\r
              """;
  }

}

// Output
public class TextBlock {

  void method() {
    String myTextBlock = """
         my text


    sentence\"""

    """;

    String source =
      """
                public void print(%s object) {
                    System.out.println(Objects.toString(object));
                }
                """.formatted(
          type
        );

    String html =
      """
              <html>\r
                  <body>\r
                      <p>Hello, world</p>\r
                  </body>\r
              </html>\r
              """;
  }
}

```

## Relative issues or prs:

#277 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
