### PR TITLE
fix: space before comma in multi-value switch expression case label

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.js
@@ -229,10 +229,21 @@ class BlocksAndStatementPrettierVisitor {
   switchLabel(ctx) {
     if (ctx.Case) {
       const caseConstants = this.mapVisit(ctx.caseConstant);
-      return rejectAndConcat([
-        concat([ctx.Case[0], " "]),
-        rejectAndJoin(" ,", caseConstants)
-      ]);
+
+      const commas = ctx.Comma
+        ? ctx.Comma.map(elt => {
+            return concat([elt, line]);
+          })
+        : [];
+
+      return group(
+        indent(
+          rejectAndConcat([
+            concat([ctx.Case[0], " "]),
+            rejectAndJoinSeps(commas, caseConstants)
+          ])
+        )
+      );
     }
 
     return concat([ctx.Default[0]]);

--- a/packages/prettier-plugin-java/test/unit-test/switch/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/switch/_input.java
@@ -75,4 +75,22 @@ class Switch {
         return this;
     }
   }
+
+  public void multipleCaseConstants(TestEnum testEnum) {
+    switch (testEnum) {
+      case FOO -> System.out.println("Foo!");
+        case BAR, BAZ -> System.out.println("Not Foo!");
+      case BAR, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ -> System.out.println("Not Foo!");
+
+    }
+  }
+
+  public void caseConstantsWithComments(TestEnum testEnum) {
+    switch (testEnum) {
+        case BAR /* foo */, BAZ -> System.out.println("Not Foo!");
+        case BAR /* foo */, /* bar */ BAZ -> System.out.println("Not Foo!");
+        case BAR, /* bar */ BAZ -> System.out.println("Not Foo!");
+
+    }
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/switch/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/switch/_output.java
@@ -81,4 +81,39 @@ class Switch {
         return this;
     }
   }
+
+  public void multipleCaseConstants(TestEnum testEnum) {
+    switch (testEnum) {
+      case FOO -> System.out.println("Foo!");
+      case BAR, BAZ -> System.out.println("Not Foo!");
+      case BAR,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ,
+        BAZ -> System.out.println("Not Foo!");
+    }
+  }
+
+  public void caseConstantsWithComments(TestEnum testEnum) {
+    switch (testEnum) {
+      case BAR/* foo */, BAZ -> System.out.println("Not Foo!");
+      case BAR/* foo */, /* bar */BAZ -> System.out.println("Not Foo!");
+      case BAR, /* bar */BAZ -> System.out.println("Not Foo!");
+    }
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/yield-statement/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/yield-statement/_output.java
@@ -12,7 +12,7 @@ class Test {
 
   public int calculate(Day d) {
     switch (d) {
-      case SATURDAY ,SUNDAY -> d.ordinal();
+      case SATURDAY, SUNDAY -> d.ordinal();
       default -> {
         int len = d.toString().length();
         yield len * len;
@@ -23,7 +23,7 @@ class Test {
 
   public int calculate(Day d) {
     return switch (d) {
-      case SATURDAY ,SUNDAY -> d.ordinal();
+      case SATURDAY, SUNDAY -> d.ordinal();
       default -> {
         int len = d.toString().length();
         yield len * len;


### PR DESCRIPTION
Fix #439

## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
  public void multipleCaseConstants(TestEnum testEnum) {
    switch (testEnum) {
      case FOO -> System.out.println("Foo!");
        case BAR, BAZ -> System.out.println("Not Foo!");
      case BAR, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ, BAZ -> System.out.println("Not Foo!");

    }
  }

  public void caseConstantsWithComments(TestEnum testEnum) {
    switch (testEnum) {
        case BAR /* foo */, BAZ -> System.out.println("Not Foo!");
        case BAR /* foo */, /* bar */ BAZ -> System.out.println("Not Foo!");
        case BAR, /* bar */ BAZ -> System.out.println("Not Foo!");

    }
  }

// Output
  public void multipleCaseConstants(TestEnum testEnum) {
    switch (testEnum) {
      case FOO -> System.out.println("Foo!");
      case BAR, BAZ -> System.out.println("Not Foo!");
      case BAR,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ,
        BAZ -> System.out.println("Not Foo!");
    }
  }

  public void caseConstantsWithComments(TestEnum testEnum) {
    switch (testEnum) {
      case BAR/* foo */, BAZ -> System.out.println("Not Foo!");
      case BAR/* foo */, /* bar */BAZ -> System.out.println("Not Foo!");
      case BAR, /* bar */BAZ -> System.out.println("Not Foo!");
    }
  }
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
