### PR TITLE
Feat/consistent indent new chain method

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -341,7 +341,10 @@ class ExpressionsPrettierVisitor {
         suffixes.push(this.visit(ctx.primarySuffix[i]));
       }
 
-      if (countMethodInvocation === 1) {
+      if (
+        countMethodInvocation === 1 &&
+        ctx.primaryPrefix[0].children.newExpression === undefined
+      ) {
         return group(
           rejectAndConcat([
             primaryPrefix,

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -167,7 +167,7 @@ class ExpressionsPrettierVisitor {
       groupsOfOperator,
       sortedBinaryOperators
     } = separateTokensIntoGroups(ctx);
-    const segmentsSplittedByBinaryOperator = [];
+    const segmentsSplitByBinaryOperator = [];
     let currentSegment = [];
 
     if (groupsOfOperator.length === 1 && groupsOfOperator[0].length === 0) {
@@ -212,7 +212,7 @@ class ExpressionsPrettierVisitor {
           );
         }
       }
-      segmentsSplittedByBinaryOperator.push(
+      segmentsSplitByBinaryOperator.push(
         group(rejectAndJoin(" ", currentSegment))
       );
     });
@@ -227,7 +227,7 @@ class ExpressionsPrettierVisitor {
               group(
                 rejectAndJoinSeps(
                   sortedBinaryOperators.map(elt => concat([" ", elt, line])),
-                  segmentsSplittedByBinaryOperator
+                  segmentsSplitByBinaryOperator
                 )
               )
             ])
@@ -241,7 +241,7 @@ class ExpressionsPrettierVisitor {
     return group(
       rejectAndJoinSeps(
         sortedBinaryOperators.map(elt => concat([" ", elt, line])),
-        segmentsSplittedByBinaryOperator
+        segmentsSplitByBinaryOperator
       )
     );
   }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
@@ -53,4 +53,9 @@ public class BinaryOperations {
 
     return a || b || c;
   }
+
+    public void method() {
+        new Foo(stuff, thing, "auaaaaaaaaa some very long stuff", "some more").bar(10);
+        foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more").bar(10);
+    }
 }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -75,4 +75,11 @@ public class BinaryOperations {
 
     return a || b || c;
   }
+
+  public void method() {
+    new Foo(stuff, thing, "auaaaaaaaaa some very long stuff", "some more")
+      .bar(10);
+    foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more")
+      .bar(10);
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
public void method() {
    new Foo(stuff, thing, "auaaaaaaaaa some very long stuff", "some more").bar(10);
    foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more").bar(10);
}

// Before PR
public void method() {
    new Foo(stuff, thing, "auaaaaaaaaa some very long stuff", "some more")
    .bar(10);
    foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more")
        .bar(10);
}

// Output
public void method() {
    new Foo(stuff, thing, "auaaaaaaaaa some very long stuff", "some more")
      .bar(10);
    foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more")
      .bar(10);
}
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->

Fix #448