### PR TITLE
fix: stable reformating for method invocation with only comments

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -586,10 +586,6 @@ class ExpressionsPrettierVisitor {
   }
 
   methodInvocationSuffix(ctx, params) {
-    if (ctx.argumentList === undefined) {
-      return rejectAndConcat([ctx.LBrace[0], ctx.RBrace[0]]);
-    }
-
     const argumentList = this.visit(ctx.argumentList);
     if (params && params.shouldDedent) {
       return dedent(

--- a/packages/prettier-plugin-java/test/unit-test/comments/bug-fixes/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/bug-fixes/_input.java
@@ -43,4 +43,20 @@ class T {
     void t() {
 
     }
+
+    public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
+        Arrays.asList(// a
+                      // b
+                      // c
+                      // d
+        )
+    );
+
+    public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
+        Arrays.asList(// a
+                      // b
+                      // c
+                      // d
+        /*e*/)
+    );
 }

--- a/packages/prettier-plugin-java/test/unit-test/comments/bug-fixes/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/bug-fixes/_output.java
@@ -32,4 +32,21 @@ class T {
                 *line 2
                */
   void t() {}
+
+  public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
+    Arrays.asList( // a
+      // b
+      // c
+      // d
+    )
+  );
+
+  public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
+    Arrays.asList( // a
+      // b
+      // c
+      // d
+      /*e*/
+    )
+  );
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
    Arrays.asList(// a
                  // b
                  // c
                  // d
    )
);
public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
    Arrays.asList(// a
                  // b
                  // c
                  // d
    /*e*/)
);

// Before PR

public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
    Arrays.asList(// b // a
    // c
    // d
    )
);

// After PR
public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
  Arrays.asList( // a
    // b
    // c
    // d
  )
);
public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
  Arrays.asList( // a
    // b
    // c
    // d
    /*e*/
  )
);

```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->

Fix #443 