### PR TITLE
fix: Java-parser routing to the wrong rule on class defining records …

### DIFF
--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -850,7 +850,8 @@ function defineRules($, t) {
 
       if (
         tokenMatcher(nextTokenType, t.Class) ||
-        tokenMatcher(nextTokenType, t.Enum)
+        tokenMatcher(nextTokenType, t.Enum) ||
+        tokenMatcher(nextTokenType, t.Record)
       ) {
         return classBodyTypes.classDeclaration;
       }
@@ -923,6 +924,7 @@ function defineRules($, t) {
   $.RULE("isCompactConstructorDeclaration", () => {
     $.MANY($.constructorModifier);
     $.SUBRULE($.simpleTypeName);
+    $.CONSUME(t.LCurly);
   });
 }
 

--- a/packages/java-parser/test/records/records-spec.js
+++ b/packages/java-parser/test/records/records-spec.js
@@ -25,4 +25,63 @@ describe("The Java Parser fixed bugs", () => {
     `;
     expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
+
+  it("should handle Java records with simplified constructors inside java class declaration", () => {
+    const input = `
+    public class RecordClass {
+      record MyRecord(String name, int age) {
+          public MyRecord {
+            if (age < 0) {
+              throw new IllegalArgumentException("Age cannot be negative");
+            }
+    
+            if (name == null || name.isBlank()) {
+              throw new IllegalArgumentException("Name cannot be blank");
+            }
+          }
+      }
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
+
+  it("should handle Java records with constructor inside java class declaration", () => {
+    const input = `
+    public class RecordClass {
+      record MyRecord(String name, int age) {
+          public MyRecord(String name, int age) {
+            if (age < 0) {
+              throw new IllegalArgumentException("Age cannot be negative");
+            }
+    
+            if (name == null || name.isBlank()) {
+              throw new IllegalArgumentException("Name cannot be blank");
+            }
+          }
+      }
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
+
+  it("should handle Java records with constructor inside java class declaration", () => {
+    const input = `
+    public class RecordClass {
+      public record MyRecord(String name, int age) {
+          @Annotation
+          @Annotation2
+          public MyRecord {
+            if (age < 0) {
+              throw new IllegalArgumentException("Age cannot be negative");
+            }
+    
+            if (name == null || name.isBlank()) {
+              throw new IllegalArgumentException("Name cannot be blank");
+            }
+          }
+      }
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
 });

--- a/packages/prettier-plugin-java/scripts/clone-samples.js
+++ b/packages/prettier-plugin-java/scripts/clone-samples.js
@@ -48,7 +48,8 @@ const jhipster1 = [
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-nocache",
-    branch: "main"
+    branch: "main",
+    commitHash: "fda6dee77651042083780c812a1a54ff2de8da47"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-hazelcast",
@@ -97,10 +98,21 @@ fs.emptyDirSync(samplesDir);
 
 sampleRepos.forEach(cloneRepo);
 
-function cloneRepo({ repoUrl, branch }) {
+function cloneRepo({ repoUrl, branch, commitHash }) {
   console.log(`cloning ${repoUrl}`);
-  cp.execSync(`git clone ${repoUrl} --branch ${branch} --depth 1`, {
-    cwd: samplesDir,
-    stdio: [0, 1, 2]
-  });
+  if (commitHash) {
+    cp.execSync(`git clone ${repoUrl} --branch ${branch}`, {
+      cwd: samplesDir,
+      stdio: [0, 1, 2]
+    });
+    cp.execSync(`git checkout ${commitHash}`, {
+      cwd: path.resolve(samplesDir, repoUrl.split("/").pop()),
+      stdio: [0, 1, 2]
+    });
+  } else {
+    cp.execSync(`git clone ${repoUrl} --branch ${branch} --depth 1`, {
+      cwd: samplesDir,
+      stdio: [0, 1, 2]
+    });
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/records/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_input.java
@@ -38,4 +38,55 @@ class T {
     void t() {
         record = "12";
     }
+
+class MyRecordSimplifiedConstructor {
+    record MyRecord(String name, int age
+    ) {
+public MyRecord {
+            if (age < 0) {
+              throw new IllegalArgumentException("Age cannot be negative");
+            }
+    
+      if (name == null || name.isBlank()) {
+              throw new IllegalArgumentException("Name cannot be blank");
+       }
+          }
+      }
+}
+
+class MyRecordConstructor {
+    record MyRecord(String name,
+     int age) {
+          public MyRecord(String name,
+           int age) {
+            if (age < 0) {
+  throw new IllegalArgumentException("Age cannot be negative");
+            }
+                if (name == null || name.isBlank()) {
+              throw new IllegalArgumentException("Name cannot be blank");
+        }
+          }
+      }
+}
+
+public class MyRecordWithAnnotationAndModifiers {
+                public record MyRecord(
+          String name, 
+          int age) {
+                @Annotation
+          @Annotation2
+          public MyRecord {
+            if (
+                age < 0) 
+            {
+              throw new IllegalArgumentException("Age cannot be negative");
+            }
+    
+            if (name == null || 
+            name.isBlank()) {
+              throw new IllegalArgumentException("Name cannot be blank");
+            }
+          }
+      }
+    }
 }

--- a/packages/prettier-plugin-java/test/unit-test/records/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_output.java
@@ -31,4 +31,50 @@ class T {
   void t() {
     record = "12";
   }
+
+  class MyRecordSimplifiedConstructor {
+
+    record MyRecord(String name, int age) {
+      public MyRecord {
+        if (age < 0) {
+          throw new IllegalArgumentException("Age cannot be negative");
+        }
+
+        if (name == null || name.isBlank()) {
+          throw new IllegalArgumentException("Name cannot be blank");
+        }
+      }
+    }
+  }
+
+  class MyRecordConstructor {
+
+    record MyRecord(String name, int age) {
+      public MyRecord(String name, int age) {
+        if (age < 0) {
+          throw new IllegalArgumentException("Age cannot be negative");
+        }
+        if (name == null || name.isBlank()) {
+          throw new IllegalArgumentException("Name cannot be blank");
+        }
+      }
+    }
+  }
+
+  public class MyRecordWithAnnotationAndModifiers {
+
+    public record MyRecord(String name, int age) {
+      @Annotation
+      @Annotation2
+      public MyRecord {
+        if (age < 0) {
+          throw new IllegalArgumentException("Age cannot be negative");
+        }
+
+        if (name == null || name.isBlank()) {
+          throw new IllegalArgumentException("Name cannot be blank");
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
…with simplified and normal constructor

Fix #469 
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input

// Output

```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
