### PR TITLE
feat: support instance of pattern matching

### DIFF
--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -123,7 +123,15 @@ function defineRules($, t) {
           {
             ALT: () => {
               $.CONSUME(t.Instanceof);
-              $.SUBRULE($.referenceType);
+              $.OR1([
+                {
+                  GATE: () => this.BACKTRACK_LOOKAHEAD($.pattern),
+                  ALT: () => $.SUBRULE($.pattern)
+                },
+                {
+                  ALT: () => $.SUBRULE($.referenceType)
+                }
+              ]);
             }
           },
           {
@@ -557,6 +565,14 @@ function defineRules($, t) {
       //   for a semantic analysis phase
       { ALT: () => $.CONSUME(t.New) }
     ]);
+  });
+
+  $.RULE("pattern", () => {
+    $.SUBRULE($.typePattern);
+  });
+
+  $.RULE("typePattern", () => {
+    $.SUBRULE($.localVariableDeclaration);
   });
 
   // backtracking lookahead logic

--- a/packages/java-parser/test/blocks-and-statements/switch-case-spec.js
+++ b/packages/java-parser/test/blocks-and-statements/switch-case-spec.js
@@ -3,7 +3,7 @@
 const { expect } = require("chai");
 const javaParser = require("../../src/index");
 
-describe("The Java Parser fixed bugs", () => {
+describe("Switch cases", () => {
   it("should handle Java 13 switch rules", () => {
     const input = `switch (k) {
       case 1 -> System.out.println("one");

--- a/packages/java-parser/test/blocks-and-statements/yield-statement-spec.js
+++ b/packages/java-parser/test/blocks-and-statements/yield-statement-spec.js
@@ -3,7 +3,7 @@
 const { expect } = require("chai");
 const javaParser = require("../../src/index");
 
-describe("The Java Parser fixed bugs", () => {
+describe("Yield statements", () => {
   it("should handle yield as a special keyword", () => {
     const input = `String yield;`;
     expect(() => javaParser.parse(input, "blockStatement")).to.not.throw();

--- a/packages/java-parser/test/pattern-matching/pattern-matching-spec.js
+++ b/packages/java-parser/test/pattern-matching/pattern-matching-spec.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const { expect } = require("chai");
+const javaParser = require("../../src/index");
+
+describe("Pattern matching", () => {
+  it("should handle Java instanceof with reference types", () => {
+    const input = `a instanceof Point`;
+    expect(() => javaParser.parse(input, "binaryExpression")).to.not.throw();
+  });
+
+  it("should handle Java instanceof with pattern matching", () => {
+    const input = `a instanceof Point p`;
+    expect(() => javaParser.parse(input, "binaryExpression")).to.not.throw();
+  });
+
+  it("should handle Java instanceof with pattern matching inside method", () => {
+    const input = `
+    static String formatter(Object o) {
+        String formatted = "unknown";
+        if (o instanceof Integer i) {
+            formatted = String.format("int %d", i);
+        } else if (o instanceof Long l) {
+            formatted = String.format("long %d", l);
+        } else if (o instanceof Double d) {
+            formatted = String.format("double %f", d);
+        } else if (o instanceof String s) {
+            formatted = String.format("String %s", s);
+        }
+        return formatted;
+    }
+    `;
+    expect(() => javaParser.parse(input, "methodDeclaration")).to.not.throw();
+  });
+});

--- a/packages/java-parser/test/records/records-spec.js
+++ b/packages/java-parser/test/records/records-spec.js
@@ -3,7 +3,7 @@
 const { expect } = require("chai");
 const javaParser = require("../../src/index");
 
-describe("The Java Parser fixed bugs", () => {
+describe("Records", () => {
   it("should handle Java records without body", () => {
     const input = `record Pet(String name, int age) {}`;
     expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();

--- a/packages/prettier-plugin-java/src/options.js
+++ b/packages/prettier-plugin-java/src/options.js
@@ -168,6 +168,8 @@ module.exports = {
       { value: "classLiteralSuffix" },
       { value: "arrayAccessSuffix" },
       { value: "methodReferenceSuffix" },
+      { value: "pattern" },
+      { value: "typePattern" },
       { value: "identifyNewExpressionType" },
       { value: "isLambdaExpression" },
       { value: "isCastExpression" },

--- a/packages/prettier-plugin-java/src/printers/expressions.js
+++ b/packages/prettier-plugin-java/src/printers/expressions.js
@@ -12,6 +12,7 @@ const {
   rejectAndJoin,
   rejectAndConcat,
   sortAnnotationIdentifier,
+  sortNodes,
   rejectAndJoinSeps,
   findDeepElementInPartsArray,
   isExplicitLambdaParameter,
@@ -159,7 +160,9 @@ class ExpressionsPrettierVisitor {
   binaryExpression(ctx, params) {
     handleCommentsBinaryExpression(ctx);
 
-    const referenceType = this.mapVisit(ctx.referenceType);
+    const instanceofReferences = this.mapVisit(
+      sortNodes(ctx.pattern, ctx.referenceType)
+    );
     const expression = this.mapVisit(ctx.expression);
     const unaryExpression = this.mapVisit(ctx.unaryExpression);
 
@@ -181,7 +184,10 @@ class ExpressionsPrettierVisitor {
         const shiftOperator = isShiftOperator(subgroup, i);
         if (token.tokenType.name === "Instanceof") {
           currentSegment.push(
-            rejectAndJoin(" ", [ctx.Instanceof[0], referenceType.shift()])
+            rejectAndJoin(" ", [
+              ctx.Instanceof[0],
+              instanceofReferences.shift()
+            ])
           );
         } else if (matchCategory(token, "'AssignmentOperator'")) {
           currentSegment.push(
@@ -659,6 +665,14 @@ class ExpressionsPrettierVisitor {
     const typeArguments = this.visit(ctx.typeArguments);
     const identifierOrNew = ctx.New ? ctx.New[0] : ctx.Identifier[0];
     return rejectAndConcat([ctx.ColonColon[0], typeArguments, identifierOrNew]);
+  }
+
+  pattern(ctx) {
+    return this.visitSingle(ctx);
+  }
+
+  typePattern(ctx) {
+    return this.visitSingle(ctx);
   }
 
   identifyNewExpressionType() {

--- a/packages/prettier-plugin-java/src/printers/printer-utils.js
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.js
@@ -109,6 +109,22 @@ function sortTokens() {
   });
 }
 
+function sortNodes() {
+  let nodes = [];
+
+  _.forEach(arguments, argument => {
+    if (argument) {
+      nodes = nodes.concat(argument);
+    }
+  });
+
+  return nodes.sort((a, b) => {
+    const aOffset = a.startOffset ? a.startOffset : a.location.startOffset;
+    const bOffset = b.startOffset ? b.startOffset : b.location.startOffset;
+    return aOffset - bOffset;
+  });
+}
+
 function matchCategory(token, categoryName) {
   const labels = token.tokenType.CATEGORIES.map(category => {
     return category.LABEL;
@@ -673,7 +689,7 @@ module.exports = {
   rejectAndConcat,
   sortAnnotationIdentifier,
   sortClassTypeChildren,
-  sortTokens,
+  sortNodes,
   matchCategory,
   sortModifiers,
   rejectAndJoinSeps,

--- a/packages/prettier-plugin-java/test/unit-test/pattern-matching/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/pattern-matching/_input.java
@@ -1,0 +1,15 @@
+class T {
+    static String formatter(Object o) {
+        String formatted = "unknown";
+        if (o instanceof Integer i || p instanceof Point || q instanceof Circle c || r instanceof Square) {
+            formatted = String.format("int %d", i);
+        } else if (o instanceof Long l) {
+            formatted = String.format("long %d", l);
+        } else if (o instanceof Double d) {
+            formatted = String.format("double %f", d);
+        } else if (o instanceof String s) {
+            formatted = String.format("String %s", s);
+        }
+        return formatted;
+    }
+}

--- a/packages/prettier-plugin-java/test/unit-test/pattern-matching/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/pattern-matching/_output.java
@@ -1,0 +1,21 @@
+class T {
+
+  static String formatter(Object o) {
+    String formatted = "unknown";
+    if (
+      o instanceof Integer i ||
+      p instanceof Point ||
+      q instanceof Circle c ||
+      r instanceof Square
+    ) {
+      formatted = String.format("int %d", i);
+    } else if (o instanceof Long l) {
+      formatted = String.format("long %d", l);
+    } else if (o instanceof Double d) {
+      formatted = String.format("double %f", d);
+    } else if (o instanceof String s) {
+      formatted = String.format("String %s", s);
+    }
+    return formatted;
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/pattern-matching/pattern-matching-spec.js
+++ b/packages/prettier-plugin-java/test/unit-test/pattern-matching/pattern-matching-spec.js
@@ -1,0 +1,3 @@
+describe("pattern-matching", () => {
+  require("../../test-utils").testSample(__dirname);
+});


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->
Support instance of pattern matching: https://docs.oracle.com/javase/specs/jls/se16/html/jls-15.html#jls-InstanceofExpression

## Example

```java
// Input
class T {
    static String formatter(Object o) {
        String formatted = "unknown";
        if (o instanceof Integer i || p instanceof Point || q instanceof Circle c || r instanceof Square) {
            formatted = String.format("int %d", i);
        } else if (o instanceof Long l) {
            formatted = String.format("long %d", l);
        } else if (o instanceof Double d) {
            formatted = String.format("double %f", d);
        } else if (o instanceof String s) {
            formatted = String.format("String %s", s);
        }
        return formatted;
    }
}

// Output
class T {

  static String formatter(Object o) {
    String formatted = "unknown";
    if (
      o instanceof Integer i ||
      p instanceof Point ||
      q instanceof Circle c ||
      r instanceof Square
    ) {
      formatted = String.format("int %d", i);
    } else if (o instanceof Long l) {
      formatted = String.format("long %d", l);
    } else if (o instanceof Double d) {
      formatted = String.format("double %f", d);
    } else if (o instanceof String s) {
      formatted = String.format("String %s", s);
    }
    return formatted;
  }
}

```

## Relative issues or prs:

Closes #434 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
