### PR TITLE
feat: add space after type parameter in generic constructor

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.js
+++ b/packages/prettier-plugin-java/src/printers/classes.js
@@ -616,15 +616,18 @@ class ClassesPrettierVisitor {
     const receiverParameter = this.visit(ctx.receiverParameter);
     const formalParameterList = this.visit(ctx.formalParameterList);
     const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, " "])) : [];
-    return rejectAndConcat([
+
+    return rejectAndJoin(" ", [
       typeParameters,
-      simpleTypeName,
-      putIntoBraces(
-        rejectAndJoinSeps(commas, [receiverParameter, formalParameterList]),
-        softline,
-        ctx.LBrace[0],
-        ctx.RBrace[0]
-      )
+      concat([
+        simpleTypeName,
+        putIntoBraces(
+          rejectAndJoinSeps(commas, [receiverParameter, formalParameterList]),
+          softline,
+          ctx.LBrace[0],
+          ctx.RBrace[0]
+        )
+      ])
     ]);
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/constructors/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/constructors/_input.java
@@ -47,4 +47,6 @@ public class Constructors {
     System.out.println("constructor with this that does not wrap");
   }
 
+  public <T> GenericConstructor(T genericParameter) {}
+  public <T>GenericConstructor(T genericParameter) {}
 }

--- a/packages/prettier-plugin-java/test/unit-test/constructors/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/constructors/_output.java
@@ -58,4 +58,8 @@ public class Constructors {
     this("enough parameter", "fit");
     System.out.println("constructor with this that does not wrap");
   }
+
+  public <T> GenericConstructor(T genericParameter) {}
+
+  public <T> GenericConstructor(T genericParameter) {}
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
public <T> GenericConstructor(T genericParameter) {}

// Prettier 1.2.0
public <T>GenericConstructor(T genericParameter) {}

// Updated version
public <T> GenericConstructor(T genericParameter) {}
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->

Fix #484 
