### PR TITLE
Fix interface member detection to support inner records

### DIFF
--- a/packages/java-parser/src/productions/interfaces.js
+++ b/packages/java-parser/src/productions/interfaces.js
@@ -378,7 +378,8 @@ function defineRules($, t) {
     nextTokenType = this.LA(1).tokenType;
     if (
       tokenMatcher(nextTokenType, t.Class) ||
-      tokenMatcher(nextTokenType, t.Enum)
+      tokenMatcher(nextTokenType, t.Enum) ||
+      tokenMatcher(nextTokenType, t.Record)
     ) {
       return InterfaceBodyTypes.classDeclaration;
     }

--- a/packages/java-parser/test/records/records-spec.js
+++ b/packages/java-parser/test/records/records-spec.js
@@ -84,4 +84,37 @@ describe("Records", () => {
     `;
     expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
+
+  it("should handle Java records inside an interface definition", () => {
+    const input = `
+    public interface SomeInterface {
+      record SomeRecord(
+          String param
+      ) { }
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
+
+  it("should handle Java records implementing an interface inside an interface definition", () => {
+    const input = `
+    public interface SomeInterface {
+      record SomeRecord(
+          String param
+      ) implements AnyInterface { }
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
+
+  it("should handle Java records implementing an interface inside a class definition", () => {
+    const input = `
+    public class SomeClass {
+      record SomeRecord(
+          String param
+      ) implements AnyInterface { }
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
 });

--- a/packages/prettier-plugin-java/test/unit-test/records/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_input.java
@@ -90,3 +90,10 @@ public class MyRecordWithAnnotationAndModifiers {
       }
     }
 }
+
+public interface MyInterface {
+    record MyRecord(
+        String param) implements MyInterface {
+
+         }
+}

--- a/packages/prettier-plugin-java/test/unit-test/records/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_output.java
@@ -78,3 +78,7 @@ class T {
     }
   }
 }
+
+public interface MyInterface {
+  record MyRecord(String param) implements MyInterface {}
+}


### PR DESCRIPTION
## What changed with this PR:

This PR is intended to fix an error when parsing interfaces with inner records.

## Example

### Before fix
```java
// Input
public interface SomeInterface {
  record SomeRecord(
      String param
  ) implements AnyInterface { }
}
// Output

AssertionError: expected [Function] to not throw an error but 
Error: Sad sad panda, parsing errors detected in line: 5, column: 9!
Expecting: one of these possible Token sequences:\n  1. [\'{\'] 2. [\';\']
  but found: \'implements\'!
->compilationUnit
->ordinaryCompilationUnit
->typeDeclaration
->interfaceDeclaration
->normalInterfaceDeclaration
->interfaceBody
->interfaceMemberDeclaration
->interfaceMethodDeclaration
->methodBody' was thrown

```

As I understand it, `interfaceMemberDeclaration->interfaceMethodDeclaration` is a sign that the inner record is being identified as a method declaration, when it should be identified as a 'class' (record) definition.

### After fix

Parses without throwing

## Relative issues or prs:

None filed; I'd be happy to file one retrospectively if needed.
<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
