### PR TITLE
Fix: lambda formatting

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -91,7 +91,7 @@ import {
 } from "java-parser";
 import { Doc } from "prettier";
 import { isAnnotationCstNode, isTypeArgumentsCstNode } from "../types/utils";
-import { printArgumentListWithBraces } from "../utils/printArgumentListWithBraces";
+import { printArgumentListWithBraces } from "../utils";
 
 const { line, softline, hardline } = builders;
 

--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -91,6 +91,7 @@ import {
 } from "java-parser";
 import { Doc } from "prettier";
 import { isAnnotationCstNode, isTypeArgumentsCstNode } from "../types/utils";
+import { printArgumentListWithBraces } from "../utils/printArgumentListWithBraces";
 
 const { line, softline, hardline } = builders;
 
@@ -734,16 +735,16 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   ) {
     const typeArguments = this.visit(ctx.typeArguments);
     const keyWord = ctx.This ? ctx.This[0] : ctx.Super![0];
-    const argumentList = this.visit(ctx.argumentList);
+    const argumentList = printArgumentListWithBraces.call(
+      this,
+      ctx.argumentList,
+      ctx.RBrace![0],
+      ctx.LBrace[0]
+    );
     return rejectAndConcat([
       typeArguments,
       keyWord,
-      group(
-        rejectAndConcat([
-          putIntoBraces(argumentList, softline, ctx.LBrace[0], ctx.RBrace[0]),
-          ctx.Semicolon[0]
-        ])
-      )
+      group(rejectAndConcat([argumentList, ctx.Semicolon[0]]))
     ]);
   }
 
@@ -752,19 +753,19 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   ) {
     const expressionName = this.visit(ctx.expressionName);
     const typeArguments = this.visit(ctx.typeArguments);
-    const argumentList = this.visit(ctx.argumentList);
+    const argumentList = printArgumentListWithBraces.call(
+      this,
+      ctx.argumentList,
+      ctx.RBrace![0],
+      ctx.LBrace[0]
+    );
 
     return rejectAndConcat([
       expressionName,
       ctx.Dot[0],
       typeArguments,
       ctx.Super[0],
-      group(
-        rejectAndConcat([
-          putIntoBraces(argumentList, softline, ctx.LBrace[0], ctx.RBrace[0]),
-          ctx.Semicolon[0]
-        ])
-      )
+      group(rejectAndConcat([argumentList, ctx.Semicolon[0]]))
     ]);
   }
 
@@ -842,18 +843,22 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
     const otherModifiers = this.mapVisit(modifiers[1]);
 
     const identifier = ctx.Identifier[0];
-    const argumentList = this.visit(ctx.argumentList);
     const classBody = this.visit(ctx.classBody);
 
-    const optionnalBracesAndArgumentList = ctx.LBrace
-      ? putIntoBraces(argumentList, softline, ctx.LBrace[0], ctx.RBrace![0])
+    const optionalBracesAndArgumentList = ctx.LBrace
+      ? printArgumentListWithBraces.call(
+          this,
+          ctx.argumentList,
+          ctx.RBrace![0],
+          ctx.LBrace[0]
+        )
       : "";
 
     return rejectAndJoin(hardline, [
       rejectAndJoin(hardline, firstAnnotations),
       rejectAndJoin(" ", [
         rejectAndJoin(" ", otherModifiers),
-        rejectAndConcat([identifier, optionnalBracesAndArgumentList]),
+        rejectAndConcat([identifier, optionalBracesAndArgumentList]),
         classBody
       ])
     ]);

--- a/packages/prettier-plugin-java/src/utils/expressions-utils.ts
+++ b/packages/prettier-plugin-java/src/utils/expressions-utils.ts
@@ -1,0 +1,37 @@
+import { ArgumentListCstNode } from "java-parser";
+
+export function isArgumentListSingleLambda(
+  argumentList: ArgumentListCstNode[] | undefined
+) {
+  if (argumentList === undefined) {
+    return false;
+  }
+
+  const args = argumentList[0].children.expression;
+  if (args.length !== 1) {
+    return false;
+  }
+
+  const argument = args[0];
+  return argument.children.lambdaExpression !== undefined;
+}
+
+export const isSingleArgumentLambdaExpressionWithBlock = (
+  argumentList: ArgumentListCstNode[] | undefined
+) => {
+  if (argumentList === undefined) {
+    return false;
+  }
+
+  const args = argumentList[0].children.expression;
+  if (args.length !== 1) {
+    return false;
+  }
+
+  const argument = args[0];
+  return (
+    argument.children.lambdaExpression !== undefined &&
+    argument.children.lambdaExpression[0].children.lambdaBody[0].children
+      .block !== undefined
+  );
+};

--- a/packages/prettier-plugin-java/src/utils/index.ts
+++ b/packages/prettier-plugin-java/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { default as printArgumentListWithBraces } from "./printArgumentListWithBraces";
+export { default as printSingleLambdaInvocation } from "./printSingleLambdaInvocation";

--- a/packages/prettier-plugin-java/src/utils/printArgumentListWithBraces.ts
+++ b/packages/prettier-plugin-java/src/utils/printArgumentListWithBraces.ts
@@ -1,0 +1,39 @@
+import { ArgumentListCstNode, IToken } from "java-parser";
+import { builders } from "prettier/doc";
+import {
+  isArgumentListSingleLambda,
+  isSingleArgumentLambdaExpressionWithBlock
+} from "./expressions-utils";
+import { printTokenWithComments } from "../printers/comments/format-comments";
+import { concat, dedent, indent } from "../printers/prettier-builder";
+import { putIntoBraces } from "../printers/printer-utils";
+
+const { softline, ifBreak } = builders;
+
+export function printArgumentListWithBraces(
+  argumentListCtx: ArgumentListCstNode[] | undefined,
+  rBrace: IToken,
+  lBrace: IToken
+) {
+  const lambdaParametersGroupId = Symbol("lambdaParameters");
+  const argumentList = this.visit(argumentListCtx, {
+    lambdaParametersGroupId,
+    isInsideMethodInvocationSuffix: true
+  });
+  const isSingleLambda = isArgumentListSingleLambda(argumentListCtx);
+
+  if (isSingleLambda) {
+    const formattedRBrace = isSingleArgumentLambdaExpressionWithBlock(
+      argumentListCtx
+    )
+      ? ifBreak(
+          indent(concat([softline, rBrace])),
+          printTokenWithComments(rBrace),
+          { groupId: lambdaParametersGroupId }
+        )
+      : indent(concat([softline, rBrace]));
+    return dedent(putIntoBraces(argumentList, "", lBrace, formattedRBrace));
+  }
+
+  return putIntoBraces(argumentList, softline, lBrace, rBrace);
+}

--- a/packages/prettier-plugin-java/src/utils/printArgumentListWithBraces.ts
+++ b/packages/prettier-plugin-java/src/utils/printArgumentListWithBraces.ts
@@ -1,39 +1,28 @@
 import { ArgumentListCstNode, IToken } from "java-parser";
 import { builders } from "prettier/doc";
-import {
-  isArgumentListSingleLambda,
-  isSingleArgumentLambdaExpressionWithBlock
-} from "./expressions-utils";
-import { printTokenWithComments } from "../printers/comments/format-comments";
-import { concat, dedent, indent } from "../printers/prettier-builder";
+import { isArgumentListSingleLambda } from "./expressions-utils";
 import { putIntoBraces } from "../printers/printer-utils";
+import printSingleLambdaInvocation from "./printSingleLambdaInvocation";
 
-const { softline, ifBreak } = builders;
+const { softline } = builders;
 
-export function printArgumentListWithBraces(
+export default function printArgumentListWithBraces(
   argumentListCtx: ArgumentListCstNode[] | undefined,
   rBrace: IToken,
   lBrace: IToken
 ) {
-  const lambdaParametersGroupId = Symbol("lambdaParameters");
-  const argumentList = this.visit(argumentListCtx, {
-    lambdaParametersGroupId,
-    isInsideMethodInvocationSuffix: true
-  });
   const isSingleLambda = isArgumentListSingleLambda(argumentListCtx);
-
   if (isSingleLambda) {
-    const formattedRBrace = isSingleArgumentLambdaExpressionWithBlock(
-      argumentListCtx
-    )
-      ? ifBreak(
-          indent(concat([softline, rBrace])),
-          printTokenWithComments(rBrace),
-          { groupId: lambdaParametersGroupId }
-        )
-      : indent(concat([softline, rBrace]));
-    return dedent(putIntoBraces(argumentList, "", lBrace, formattedRBrace));
+    return printSingleLambdaInvocation.call(
+      this,
+      argumentListCtx,
+      rBrace,
+      lBrace
+    );
   }
 
+  const argumentList = this.visit(argumentListCtx, {
+    isInsideMethodInvocationSuffix: true
+  });
   return putIntoBraces(argumentList, softline, lBrace, rBrace);
 }

--- a/packages/prettier-plugin-java/src/utils/printSingleLambdaInvocation.ts
+++ b/packages/prettier-plugin-java/src/utils/printSingleLambdaInvocation.ts
@@ -1,0 +1,31 @@
+import { ArgumentListCstNode, IToken } from "java-parser";
+import { builders } from "prettier/doc";
+import { isSingleArgumentLambdaExpressionWithBlock } from "./expressions-utils";
+import { printTokenWithComments } from "../printers/comments/format-comments";
+import { concat, dedent, indent } from "../printers/prettier-builder";
+import { putIntoBraces } from "../printers/printer-utils";
+
+const { softline, ifBreak } = builders;
+
+export default function printSingleLambdaInvocation(
+  argumentListCtx: ArgumentListCstNode[] | undefined,
+  rBrace: IToken,
+  lBrace: IToken
+) {
+  const lambdaParametersGroupId = Symbol("lambdaParameters");
+  const argumentList = this.visit(argumentListCtx, {
+    lambdaParametersGroupId,
+    isInsideMethodInvocationSuffix: true
+  });
+
+  const formattedRBrace = isSingleArgumentLambdaExpressionWithBlock(
+    argumentListCtx
+  )
+    ? ifBreak(
+        indent(concat([softline, rBrace])),
+        printTokenWithComments(rBrace),
+        { groupId: lambdaParametersGroupId }
+      )
+    : indent(concat([softline, rBrace]));
+  return dedent(putIntoBraces(argumentList, "", lBrace, formattedRBrace));
+}

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
@@ -50,4 +50,69 @@ public class Lambda {
     foo.isAnotherVeryVeryLongConditionTrue());
   }
 
+  public void chainCallWithLambda() {
+      Stream
+          .of(1, 2)
+          .map(n -> {
+              // testing method
+              return n * 2;
+          })
+          .collect(Collectors.toList());
+  }
+
+  public void lambdaWithLongListOfParameters() {
+      final List<Integer> values = Stream
+          .of(1, 2)
+          .map((
+                   aVeryLongListOfParameter,
+                   aVeryLongListOfParameter,
+                   aVeryLongListOfParameter,
+                   aVeryLongListOfParameter,
+                   aVeryLongListOfParameter,
+                   aVeryLongListOfParameter
+               ) -> {
+              // testing method
+              return n * 2;
+          })
+          .collect(Collectors.toList());
+
+      final List<Integer> values = Stream
+          .of(1, 2)
+          .map((
+                   aVeryLongListOfParameter,
+                   aVeryLongListOfParameter,
+                   aParameterTha
+               ) -> {
+              // testing method
+              return n * 2;
+          })
+          .collect(Collectors.toList());
+  }
+
+  public void shortLambdaAssignation() {
+      V t = t -> toto();
+  }
+
+    public void longLambdaAssignation() {
+        V t = (
+            aVeryLongListOfParameter,
+            aVeryLongListOfParameter,
+            aVeryLongListOfParameter,
+            aVeryLongListOfParameter,
+            aVeryLongListOfParaa
+        ) -> {
+            // testing method
+            return n * 2;
+        };
+    }
+
+    public void callWithLambdaAndExtraParameter() {
+        CompletableFuture.supplyAsync(
+            () -> {
+                // some processing
+                return 2;
+            },
+            executor
+        );
+    }
 }

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
@@ -115,4 +115,111 @@ public class Lambda {
             executor
         );
     }
+
+    public void testConstructor() {
+        new Value(
+            (
+                x
+
+            ) -> {
+                // testing method
+                return n * 2;
+            }
+        );
+
+        new Value(
+            (
+                aVeryLongListOfParameter,
+                aVeryLongListOfParameter
+            ) -> {
+                // testing method
+                return n * 2;
+            }
+        );
+
+      new Value(
+          (
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter
+          ) -> {
+              // testing method
+              return n * 2;
+          }
+      );
+    }
+}
+
+class T {
+    T() {
+        super(x -> {
+            // testing method
+            return n * 2;
+        });
+    }
+
+    T() {
+        super((x,y) -> {
+            // testing method
+            return n * 2;
+        });
+    }
+
+    T() {
+        super((aVeryLongListOfParameter,
+                  aVeryLongListOfParameter,
+                  aVeryLongListOfParameter,
+                  aVeryLongListOfParameter,
+                  aVeryLongListOfParameter,
+                  aVeryLongListOfParameter) -> {
+            // testing method
+            return n * 2;
+        });
+    }
+
+    T() {
+        super((
+                  aVeryLongListOfParameter,
+                  aVeryLongListOfParameter,
+                  aParameterThatS
+              ) -> {
+            // testing method
+            return n * 2;
+        });
+    }
+}
+
+enum Enum {
+    VALUE(x -> {
+        // testing method
+        return n * 2;
+    }),
+    VALUE((x,y) -> {
+        // testing method
+        return n * 2;
+    }),
+    VALUE((aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter) -> {
+        // testing method
+        return n * 2;
+    }),
+    VALUE((
+              aVeryLongListOfParameter,
+              aVeryLongListOfParameter,
+              aParameterThatS
+          ) -> {
+        // testing method
+        return n * 2;
+    }),
+    VALUE(x -> {
+        // testing method
+        return n * 2;
+    }, other)
 }

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
@@ -1,56 +1,44 @@
 public class Lambda {
 
   public void singleArgumentWithParens() {
-    call(
-      x -> {
-        System.out.println(x);
-        System.out.println(x);
-      }
-    );
+    call(x -> {
+      System.out.println(x);
+      System.out.println(x);
+    });
   }
 
   public void singleArgumentWithoutParens() {
-    call(
-      x -> {
-        System.out.println(x);
-        System.out.println(x);
-      }
-    );
+    call(x -> {
+      System.out.println(x);
+      System.out.println(x);
+    });
   }
 
   public void multiArguments() {
-    call(
-      (x, y) -> {
-        System.out.println(x);
-        System.out.println(y);
-      }
-    );
+    call((x, y) -> {
+      System.out.println(x);
+      System.out.println(y);
+    });
   }
 
   public void multiParameters() {
-    call(
-      (Object x, final String y) -> {
-        System.out.println(x);
-        System.out.println(y);
-      }
-    );
+    call((Object x, final String y) -> {
+      System.out.println(x);
+      System.out.println(y);
+    });
   }
 
   public void emptyArguments() {
-    call(
-      () -> {
-        System.out.println();
-        System.out.println();
-      }
-    );
+    call(() -> {
+      System.out.println();
+      System.out.println();
+    });
   }
 
   public void onlyOneMethodInBodyWithCurlyBraces() {
-    call(
-      x -> {
-        System.out.println(x);
-      }
-    );
+    call(x -> {
+      System.out.println(x);
+    });
   }
 
   public void onlyOneMethodInBody() {
@@ -58,10 +46,75 @@ public class Lambda {
   }
 
   public void lambdaWithoutBracesWhichBreak() {
-    call(
-      x ->
-        foo.isVeryVeryVeryLongConditionTrue() &&
-        foo.isAnotherVeryVeryLongConditionTrue()
+    call(x ->
+      foo.isVeryVeryVeryLongConditionTrue() &&
+      foo.isAnotherVeryVeryLongConditionTrue()
+    );
+  }
+
+  public void chainCallWithLambda() {
+    Stream
+      .of(1, 2)
+      .map(n -> {
+        // testing method
+        return n * 2;
+      })
+      .collect(Collectors.toList());
+  }
+
+  public void lambdaWithLongListOfParameters() {
+    final List<Integer> values = Stream
+      .of(1, 2)
+      .map(
+        (
+          aVeryLongListOfParameter,
+          aVeryLongListOfParameter,
+          aVeryLongListOfParameter,
+          aVeryLongListOfParameter,
+          aVeryLongListOfParameter,
+          aVeryLongListOfParameter
+        ) -> {
+          // testing method
+          return n * 2;
+        }
+      )
+      .collect(Collectors.toList());
+
+    final List<Integer> values = Stream
+      .of(1, 2)
+      .map(
+        (aVeryLongListOfParameter, aVeryLongListOfParameter, aParameterTha) -> {
+          // testing method
+          return n * 2;
+        }
+      )
+      .collect(Collectors.toList());
+  }
+
+  public void shortLambdaAssignation() {
+    V t = t -> toto();
+  }
+
+  public void longLambdaAssignation() {
+    V t = (
+      aVeryLongListOfParameter,
+      aVeryLongListOfParameter,
+      aVeryLongListOfParameter,
+      aVeryLongListOfParameter,
+      aVeryLongListOfParaa
+    ) -> {
+      // testing method
+      return n * 2;
+    };
+  }
+
+  public void callWithLambdaAndExtraParameter() {
+    CompletableFuture.supplyAsync(
+      () -> {
+        // some processing
+        return 2;
+      },
+      executor
     );
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
@@ -117,4 +117,109 @@ public class Lambda {
       executor
     );
   }
+
+  public void testConstructor() {
+    new Value(x -> {
+      // testing method
+      return n * 2;
+    });
+
+    new Value((aVeryLongListOfParameter, aVeryLongListOfParameter) -> {
+      // testing method
+      return n * 2;
+    });
+
+    new Value(
+      (
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter
+      ) -> {
+        // testing method
+        return n * 2;
+      }
+    );
+  }
+}
+
+class T {
+
+  T() {
+    super(x -> {
+      // testing method
+      return n * 2;
+    });
+  }
+
+  T() {
+    super((x, y) -> {
+      // testing method
+      return n * 2;
+    });
+  }
+
+  T() {
+    super(
+      (
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter,
+        aVeryLongListOfParameter
+      ) -> {
+        // testing method
+        return n * 2;
+      }
+    );
+  }
+
+  T() {
+    super(
+      (aVeryLongListOfParameter, aVeryLongListOfParameter, aParameterThatS) -> {
+        // testing method
+        return n * 2;
+      }
+    );
+  }
+}
+
+enum Enum {
+  VALUE(x -> {
+    // testing method
+    return n * 2;
+  }),
+  VALUE((x, y) -> {
+    // testing method
+    return n * 2;
+  }),
+  VALUE(
+    (
+      aVeryLongListOfParameter,
+      aVeryLongListOfParameter,
+      aVeryLongListOfParameter,
+      aVeryLongListOfParameter,
+      aVeryLongListOfParameter,
+      aVeryLongListOfParameter
+    ) -> {
+      // testing method
+      return n * 2;
+    }
+  ),
+  VALUE(
+    (aVeryLongListOfParameter, aVeryLongListOfParameter, aParameterThatS) -> {
+      // testing method
+      return n * 2;
+    }
+  ),
+  VALUE(
+    x -> {
+      // testing method
+      return n * 2;
+    },
+    other
+  ),
 }


### PR DESCRIPTION
## What changed with this PR:

Still needs to clean the Typescript migration PR before but hopefully should close #418

## Example

```java
// Input
public class Lambda {

  public void singleArgumentWithParens() {
    call((x) -> {
      System.out.println(x);
      System.out.println(x);
    });
  }

  public void singleArgumentWithoutParens() {
    call(x -> {
      System.out.println(x);
      System.out.println(x);
    });
  }

  public void multiArguments() {
    call((x, y) -> {
      System.out.println(x);
      System.out.println(y);
    });
  }

  public void multiParameters() {
    call((Object x, final String y) -> {
      System.out.println(x);
      System.out.println(y);
    });
  }

  public void emptyArguments() {
    call(() -> {
      System.out.println();
      System.out.println();
    });
  }

  public void onlyOneMethodInBodyWithCurlyBraces() {
    call(x -> {
      System.out.println(x);
    });
  }

  public void onlyOneMethodInBody() {
    call(x -> System.out.println(x));
  }

  public void lambdaWithoutBracesWhichBreak() {
    call(x -> foo.isVeryVeryVeryLongConditionTrue() &&
    foo.isAnotherVeryVeryLongConditionTrue());
  }

  public void chainCallWithLambda() {
      Stream
          .of(1, 2)
          .map(n -> {
              // testing method
              return n * 2;
          })
          .collect(Collectors.toList());
  }

  public void lambdaWithLongListOfParameters() {
      final List<Integer> values = Stream
          .of(1, 2)
          .map((
                   aVeryLongListOfParameter,
                   aVeryLongListOfParameter,
                   aVeryLongListOfParameter,
                   aVeryLongListOfParameter,
                   aVeryLongListOfParameter,
                   aVeryLongListOfParameter
               ) -> {
              // testing method
              return n * 2;
          })
          .collect(Collectors.toList());
  }

  public void shortLambdaAssignation() {
      V t = t -> toto();
  }

    public void longLambdaAssignation() {
        V t = (
            aVeryLongListOfParameter,
            aVeryLongListOfParameter,
            aVeryLongListOfParameter,
            aVeryLongListOfParameter,
            aVeryLongListOfParaa
        ) -> {
            // testing method
            return n * 2;
        };
    }
}

// Output
public class Lambda {

  public void singleArgumentWithParens() {
    call(x -> {
      System.out.println(x);
      System.out.println(x);
    });
  }

  public void singleArgumentWithoutParens() {
    call(x -> {
      System.out.println(x);
      System.out.println(x);
    });
  }

  public void multiArguments() {
    call((x, y) -> {
      System.out.println(x);
      System.out.println(y);
    });
  }

  public void multiParameters() {
    call((Object x, final String y) -> {
      System.out.println(x);
      System.out.println(y);
    });
  }

  public void emptyArguments() {
    call(() -> {
      System.out.println();
      System.out.println();
    });
  }

  public void onlyOneMethodInBodyWithCurlyBraces() {
    call(x -> {
      System.out.println(x);
    });
  }

  public void onlyOneMethodInBody() {
    call(x -> System.out.println(x));
  }

  public void lambdaWithoutBracesWhichBreak() {
    call(x ->
      foo.isVeryVeryVeryLongConditionTrue() &&
      foo.isAnotherVeryVeryLongConditionTrue()
    );
  }

  public void chainCallWithLambda() {
    Stream
      .of(1, 2)
      .map(n -> {
        // testing method
        return n * 2;
      })
      .collect(Collectors.toList());
  }

  public void lambdaWithLongListOfParameters() {
    final List<Integer> values = Stream
      .of(1, 2)
      .map(
        (
          aVeryLongListOfParameter,
          aVeryLongListOfParameter,
          aVeryLongListOfParameter,
          aVeryLongListOfParameter,
          aVeryLongListOfParameter,
          aVeryLongListOfParameter
        ) -> {
          // testing method
          return n * 2;
        }
      )
      .collect(Collectors.toList());
  }

  public void shortLambdaAssignation() {
    V t = t -> toto();
  }

  public void longLambdaAssignation() {
    V t = (
      aVeryLongListOfParameter,
      aVeryLongListOfParameter,
      aVeryLongListOfParameter,
      aVeryLongListOfParameter,
      aVeryLongListOfParaa
    ) -> {
      // testing method
      return n * 2;
    };
  }
}


```

## Relative issues or prs:

Fix #418

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
