### PR TITLE
fix: do not crash on yield static imports

### DIFF
--- a/packages/java-parser/src/productions/blocks-and-statements.js
+++ b/packages/java-parser/src/productions/blocks-and-statements.js
@@ -98,7 +98,10 @@ function defineRules($, t) {
     $.OR({
       DEF: [
         { ALT: () => $.SUBRULE($.block) },
-        { ALT: () => $.SUBRULE($.yieldStatement) },
+        {
+          GATE: () => this.BACKTRACK_LOOKAHEAD($.yieldStatement),
+          ALT: () => $.SUBRULE($.yieldStatement)
+        },
         { ALT: () => $.SUBRULE($.emptyStatement) },
         {
           GATE: () => !tokenMatcher(this.LA(1).tokenType, t.Switch),

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -92,4 +92,11 @@ describe("The Java Parser fixed bugs", () => {
     const input = "double[][]";
     expect(() => javaParser.parse(input, "primaryPrefix")).to.not.throw();
   });
+
+  it("issue #498 - should not throw on yield static imports", () => {
+    const inputs = ["Thread.yield();", "yield();", "yield(a);"];
+    inputs.forEach(input => {
+      expect(() => javaParser.parse(input, "statement")).to.not.throw();
+    });
+  });
 });

--- a/packages/prettier-plugin-java/test/unit-test/yield-statement/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/yield-statement/_input.java
@@ -25,4 +25,10 @@
             }
         };
     }
+
+    void should_not_throw_on_yield_static_imports() {
+        Thread.yield ();
+        yield();
+        yield(a);
+    }
 }

--- a/packages/prettier-plugin-java/test/unit-test/yield-statement/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/yield-statement/_output.java
@@ -30,4 +30,10 @@ class Test {
       }
     };
   }
+
+  void should_not_throw_on_yield_static_imports() {
+    Thread.yield();
+    yield();
+    yield (a);
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
void should_not_throw_on_yield_static_imports() {
        Thread.yield ();
        yield();
        yield(a);
}

// Output
void should_not_throw_on_yield_static_imports() {
    Thread.yield();
    yield();
    yield (a);
}

```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->

Fix #498 
