### PR TITLE
refactor: remove nested inline rules in java parser

### DIFF
--- a/packages/java-parser/api.d.ts
+++ b/packages/java-parser/api.d.ts
@@ -3219,18 +3219,8 @@ export interface FqnOrRefTypePartRestCstNode extends CstNode {
 
 export type FqnOrRefTypePartRestCtx = {
   annotation?: AnnotationCstNode[];
-  $methodTypeArguments?: FqnOrRefTypePartRest$MethodTypeArgumentsCstNode[];
+  typeArguments?: TypeArgumentsCstNode[];
   fqnOrRefTypePartCommon: FqnOrRefTypePartCommonCstNode[];
-};
-
-export interface FqnOrRefTypePartRest$MethodTypeArgumentsCstNode
-  extends CstNode {
-  name: "fqnOrRefTypePartRest$methodTypeArguments";
-  children: FqnOrRefTypePartRest$MethodTypeArgumentsCtx;
-}
-
-export type FqnOrRefTypePartRest$MethodTypeArgumentsCtx = {
-  typeArguments: TypeArgumentsCstNode[];
 };
 
 export interface FqnOrRefTypePartCommonCstNode extends CstNode {
@@ -3241,17 +3231,7 @@ export interface FqnOrRefTypePartCommonCstNode extends CstNode {
 export type FqnOrRefTypePartCommonCtx = {
   Identifier?: IToken[];
   Super?: IToken[];
-  $classTypeArguments?: FqnOrRefTypePartCommon$ClassTypeArgumentsCstNode[];
-};
-
-export interface FqnOrRefTypePartCommon$ClassTypeArgumentsCstNode
-  extends CstNode {
-  name: "fqnOrRefTypePartCommon$classTypeArguments";
-  children: FqnOrRefTypePartCommon$ClassTypeArgumentsCtx;
-}
-
-export type FqnOrRefTypePartCommon$ClassTypeArgumentsCtx = {
-  typeArguments: TypeArgumentsCstNode[];
+  typeArguments?: TypeArgumentsCstNode[];
 };
 
 export interface FqnOrRefTypePartFirstCstNode extends CstNode {

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -309,12 +309,7 @@ function defineRules($, t) {
       $.SUBRULE($.annotation);
     });
 
-    $.OPTION({
-      NAME: "$methodTypeArguments",
-      DEF: () => {
-        $.SUBRULE2($.typeArguments);
-      }
-    });
+    $.OPTION(() => $.SUBRULE2($.typeArguments));
 
     $.SUBRULE($.fqnOrRefTypePartCommon);
   });
@@ -335,7 +330,6 @@ function defineRules($, t) {
     }
 
     $.OPTION2({
-      NAME: "$classTypeArguments",
       // unrestricted typeArguments here would create an ambiguity with "LessThan" operator
       // e.g: "var x = a < b;"
       // The "<" would be parsed as the beginning of a "typeArguments"

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -503,23 +503,11 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const annotation = this.mapVisit(ctx.annotation);
     const fqnOrRefTypeCommon = this.visit(ctx.fqnOrRefTypePartCommon);
 
-    let fqnOrRefTypePart$methodTypeArguments: Doc = "";
-    if (
-      ctx.$methodTypeArguments &&
-      ctx.$methodTypeArguments[0].children &&
-      ctx.$methodTypeArguments[0].children.typeArguments
-    ) {
-      fqnOrRefTypePart$methodTypeArguments = this.visit(
-        ctx.$methodTypeArguments
-      );
-    }
+    const typeArguments = this.visit(ctx.typeArguments);
 
     return rejectAndJoin(" ", [
       rejectAndJoin(" ", annotation),
-      rejectAndConcat([
-        fqnOrRefTypePart$methodTypeArguments,
-        fqnOrRefTypeCommon
-      ])
+      rejectAndConcat([typeArguments, fqnOrRefTypeCommon])
     ]);
   }
 
@@ -531,24 +519,9 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
       keyWord = ctx.Super![0];
     }
 
-    let fqnOrRefTypePart$classTypeArguments: Doc = "";
-    if (
-      ctx.$classTypeArguments &&
-      ctx.$classTypeArguments[0].children &&
-      ctx.$classTypeArguments[0].children.typeArguments
-    ) {
-      fqnOrRefTypePart$classTypeArguments = this.visit(ctx.$classTypeArguments);
-    }
+    const typeArguments = this.visit(ctx.typeArguments);
 
-    return rejectAndConcat([keyWord, fqnOrRefTypePart$classTypeArguments]);
-  }
-
-  fqnOrRefTypePartRest$methodTypeArguments(ctx: TypeArgumentListCtx) {
-    return this.visitSingle(ctx);
-  }
-
-  fqnOrRefTypePartCommon$classTypeArguments(ctx: TypeArgumentListCtx) {
-    return this.visitSingle(ctx);
+    return rejectAndConcat([keyWord, typeArguments]);
   }
 
   parenthesisExpression(ctx: ParenthesisExpressionCtx) {

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
@@ -185,5 +185,9 @@ public class Expressions {
   public void unannTypePrimitiveWithMethodReferenceSuffix(String[] args) {
     List.of(new double[][] { 1,2,3,4.1,5.6846465}, new double[][] { 1,2,3,4.1,5.6846465}, new double[][] { 1,2,3,4.1,5.6846465}).toArray(double[][]::new);
   }
+
+  public void typeExpressionsInFqnParts() {
+    var myVariable = ImmutableMap.<R, V>of<T>::a();
+  }
 }
 

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -245,4 +245,8 @@ public class Expressions {
       )
       .toArray(double[][]::new);
   }
+
+  public void typeExpressionsInFqnParts() {
+    var myVariable = ImmutableMap.<R, V>of<T>::a();
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

Remove useless inline rules in Java parser, that makes more complex visitor without adding much value

No changes in the printer.

## Relative issues or prs:

None
<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
