### PR TITLE
feat: split record parameters on several lines

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -924,7 +924,7 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   }
   recordComponentList(ctx: RecordComponentListCtx) {
     const recordComponents = this.mapVisit(ctx.recordComponent);
-    const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, " "])) : [];
+    const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, line])) : [];
 
     return rejectAndJoinSeps(commas, recordComponents);
   }

--- a/packages/prettier-plugin-java/test/unit-test/records/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_input.java
@@ -1,4 +1,12 @@
 public record Pet(
+@NotNull String name
+    ) {}
+
+    public record Pet(
+@NotNull String name, int age
+    ) {}
+
+public record Pet(
 @NotNull String name, int age, String... others, Object @Nullable... errorMessageArgs
     ) {
 public Pet {
@@ -46,7 +54,7 @@ public MyRecord {
             if (age < 0) {
               throw new IllegalArgumentException("Age cannot be negative");
             }
-    
+
       if (name == null || name.isBlank()) {
               throw new IllegalArgumentException("Name cannot be blank");
        }
@@ -71,18 +79,18 @@ class MyRecordConstructor {
 
 public class MyRecordWithAnnotationAndModifiers {
                 public record MyRecord(
-          String name, 
+          String name,
           int age) {
                 @Annotation
           @Annotation2
           public MyRecord {
             if (
-                age < 0) 
+                age < 0)
             {
               throw new IllegalArgumentException("Age cannot be negative");
             }
-    
-            if (name == null || 
+
+            if (name == null ||
             name.isBlank()) {
               throw new IllegalArgumentException("Name cannot be blank");
             }
@@ -91,9 +99,30 @@ public class MyRecordWithAnnotationAndModifiers {
     }
 }
 
+class MySplitRecordConstructor {
+    record MyRecord(String name,
+     int age, String name,
+     int age,String name,
+     int age) {
+          public MyRecord(String name,
+           int age) {
+            if (age < 0) {
+  throw new IllegalArgumentException("Age cannot be negative");
+            }
+                if (name == null || name.isBlank()) {
+              throw new IllegalArgumentException("Name cannot be blank");
+        }
+          }
+      }
+}
+
 public interface MyInterface {
     record MyRecord(
         String param) implements MyInterface {
 
          }
+}
+
+public interface MyInterface {
+  record MySplitRecord(String param, String param, String param, String param, String param, String param) implements MyInterface {}
 }

--- a/packages/prettier-plugin-java/test/unit-test/records/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_output.java
@@ -1,5 +1,12 @@
+public record Pet(@NotNull String name) {}
+
+public record Pet(@NotNull String name, int age) {}
+
 public record Pet(
-  @NotNull String name, int age, String... others, Object @Nullable... errorMessageArgs
+  @NotNull String name,
+  int age,
+  String... others,
+  Object @Nullable... errorMessageArgs
 ) {
   public Pet {
     if (age < 0) {
@@ -15,7 +22,10 @@ public record Pet(
 }
 
 public record Pet(
-  @NotNull String name, int age, String... others, Object @Nullable... errorMessageArgs
+  @NotNull String name,
+  int age,
+  String... others,
+  Object @Nullable... errorMessageArgs
 ) {}
 
 public record Pet() {}
@@ -79,6 +89,39 @@ class T {
   }
 }
 
+class MySplitRecordConstructor {
+
+  record MyRecord(
+    String name,
+    int age,
+    String name,
+    int age,
+    String name,
+    int age
+  ) {
+    public MyRecord(String name, int age) {
+      if (age < 0) {
+        throw new IllegalArgumentException("Age cannot be negative");
+      }
+      if (name == null || name.isBlank()) {
+        throw new IllegalArgumentException("Name cannot be blank");
+      }
+    }
+  }
+}
+
 public interface MyInterface {
   record MyRecord(String param) implements MyInterface {}
+}
+
+public interface MyInterface {
+  record MySplitRecord(
+    String param,
+    String param,
+    String param,
+    String param,
+    String param,
+    String param
+  )
+    implements MyInterface {}
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->
Split record parameters on several lines if does not fit on one line

## Example

```java
// Input
public record Person(
    String firstName, String lastName, String email,
    String phoneNumber,
    String streetAddress,
    String city,
    String state,
    String zipCode
) {}

// Output before this PR
public record Person(
  String firstName, String lastName, String email, String phoneNumber, String streetAddress, String city, String state, String zipCode
) {}


// Output with this PR
public record Person(
  String firstName,
  String lastName,
  String email,
  String phoneNumber,
  String streetAddress,
  String city,
  String state,
  String zipCode
) {}

```

## Relative issues or prs:

Fix #507 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
