### PR TITLE
feat: improve printing of class with long typeParameterList

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -168,14 +168,19 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   typeParameters(ctx: TypeParametersCtx) {
     const typeParameterList = this.visit(ctx.typeParameterList);
 
-    return rejectAndConcat([ctx.Less[0], typeParameterList, ctx.Greater[0]]);
+    return putIntoBraces(
+      typeParameterList,
+      softline,
+      ctx.Less[0],
+      ctx.Greater[0]
+    );
   }
 
   typeParameterList(ctx: TypeParameterListCtx) {
     const typeParameter = this.mapVisit(ctx.typeParameter);
-    const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, " "])) : [];
+    const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, line])) : [];
 
-    return rejectAndJoinSeps(commas, typeParameter);
+    return group(rejectAndJoinSeps(commas, typeParameter));
   }
 
   superclass(ctx: SuperclassCtx) {

--- a/packages/prettier-plugin-java/test/unit-test/complex_generic_class/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/complex_generic_class/_input.java
@@ -21,3 +21,9 @@ public class GenericClass<BEAN extends Comparable<BEAN>> {
   }
 
 }
+
+public abstract class AbstractGenericClass<Value extends AbstractValue, Value1 extends AbstractValue, Value2 extends AbstractValue, Value3 extends AbstractValue, Value4 extends AbstractValue, Value5 extends AbstractValue> {
+    public Value getValue() {
+        return new Value();
+    }
+}

--- a/packages/prettier-plugin-java/test/unit-test/complex_generic_class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/complex_generic_class/_output.java
@@ -21,3 +21,17 @@ public class GenericClass<BEAN extends Comparable<BEAN>> {
     }
   }
 }
+
+public abstract class AbstractGenericClass<
+  Value extends AbstractValue,
+  Value1 extends AbstractValue,
+  Value2 extends AbstractValue,
+  Value3 extends AbstractValue,
+  Value4 extends AbstractValue,
+  Value5 extends AbstractValue
+> {
+
+  public Value getValue() {
+    return new Value();
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/generic_class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/generic_class/_output.java
@@ -16,7 +16,11 @@ public class GenericClass<BEAN> {
   }
 }
 
-public class ComplexGenericClass<BEAN extends AbstractBean & BeanItemSelect<BEANTYPE>, BEANTYPE, CONFIG extends BeanConfig<BEAN, BEANTYPE, CONFIG>>
+public class ComplexGenericClass<
+  BEAN extends AbstractBean & BeanItemSelect<BEANTYPE>,
+  BEANTYPE,
+  CONFIG extends BeanConfig<BEAN, BEANTYPE, CONFIG>
+>
   extends AbstractBeanConfig<BEAN, CONFIG> {
 
   public <BEAN> List<? super BEAN> getBean(final Class<BEAN> beanClass) {


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
public class ComplexGenericClass<BEAN extends AbstractBean & BeanItemSelect<BEANTYPE>, BEANTYPE, CONFIG extends BeanConfig<BEAN, BEANTYPE, CONFIG>> {}

// Output before the PR
public class ComplexGenericClass<BEAN extends AbstractBean & BeanItemSelect<BEANTYPE>, BEANTYPE, CONFIG extends BeanConfig<BEAN, BEANTYPE, CONFIG>> {}

// Output after the PR
public class ComplexGenericClass<
  BEAN extends AbstractBean & BeanItemSelect<BEANTYPE>,
  BEANTYPE,
  CONFIG extends BeanConfig<BEAN, BEANTYPE, CONFIG>
> {}
```

## Relative issues or prs:

None 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
