### PR TITLE
fix: fix casting with additional bounds

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -579,15 +579,23 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
 
   referenceTypeCastExpression(ctx: ReferenceTypeCastExpressionCtx) {
     const referenceType = this.visit(ctx.referenceType);
-    const additionalBound = this.mapVisit(ctx.additionalBound);
+    const hasAdditionalBounds = ctx.additionalBound !== undefined;
+    const additionalBounds = rejectAndJoin(
+      line,
+      this.mapVisit(ctx.additionalBound)
+    );
 
     const expression = ctx.lambdaExpression
       ? this.visit(ctx.lambdaExpression)
       : this.visit(ctx.unaryExpressionNotPlusMinus);
 
     return rejectAndJoin(" ", [
-      rejectAndConcat([ctx.LBrace[0], referenceType, ctx.RBrace[0]]),
-      additionalBound,
+      putIntoBraces(
+        rejectAndJoin(line, [referenceType, additionalBounds]),
+        hasAdditionalBounds ? softline : "",
+        ctx.LBrace[0],
+        ctx.RBrace[0]
+      ),
       expression
     ]);
   }

--- a/packages/prettier-plugin-java/test/unit-test/cast/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/cast/_input.java
@@ -1,0 +1,17 @@
+public class Cast {
+
+    void should_cast_with_single_element() {
+        var myElem = (int) othrElement;
+        var myElem = (A) othrElement;
+        var myElem = (A) (othrElement, value) -> othrElement + value;
+        var myElem = (Aaeaozeaonzeoazneaozenazonelkadndpndpazdpazdpazdpazdpazeazpeaazdpazdpazpdazdpa) othrElement;
+    }
+
+    void should_cast_with_additional_bounds() {
+        foo((A & B) obj);
+        foo((A & B & C) obj);
+        foo((Aaeaozeaonzeoazneaozenazone & Bazoieoainzeonaozenoazne & Cjneazeanezoanezoanzeoaneonazeono) obj);
+        foo((Aaeaozeaonzeoazneaozenazone & Bazoieoainzeonaozenoazne & Cjneazeanezoanezoanzeoaneonazeono) (othrElement, value) -> othrElement + value);
+    }
+
+}

--- a/packages/prettier-plugin-java/test/unit-test/cast/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/cast/_output.java
@@ -1,0 +1,28 @@
+public class Cast {
+
+  void should_cast_with_single_element() {
+    var myElem = (int) othrElement;
+    var myElem = (A) othrElement;
+    var myElem = (A) (othrElement, value) -> othrElement + value;
+    var myElem = (Aaeaozeaonzeoazneaozenazonelkadndpndpazdpazdpazdpazdpazeazpeaazdpazdpazpdazdpa) othrElement;
+  }
+
+  void should_cast_with_additional_bounds() {
+    foo((A & B) obj);
+    foo((A & B & C) obj);
+    foo(
+      (
+        Aaeaozeaonzeoazneaozenazone
+        & Bazoieoainzeonaozenoazne
+        & Cjneazeanezoanezoanzeoaneonazeono
+      ) obj
+    );
+    foo(
+      (
+        Aaeaozeaonzeoazneaozenazone
+        & Bazoieoainzeonaozenoazne
+        & Cjneazeanezoanezoanzeoaneonazeono
+      ) (othrElement, value) -> othrElement + value
+    );
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/cast/cast-spec.ts
+++ b/packages/prettier-plugin-java/test/unit-test/cast/cast-spec.ts
@@ -1,0 +1,5 @@
+import { testSample } from "../../test-utils";
+
+describe("cast", () => {
+  testSample(__dirname);
+});


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
    void should_cast_with_single_element() {
        var myElem = (int) othrElement;
        var myElem = (A) othrElement;
        var myElem = (A) (othrElement, value) -> othrElement + value;
        var myElem = (Aaeaozeaonzeoazneaozenazonelkadndpndpazdpazdpazdpazdpazeazpeaazdpazdpazpdazdpa) othrElement;
    }

    void should_cast_with_additional_bounds() {
        foo((A & B) obj);
        foo((A & B & C) obj);
        foo((Aaeaozeaonzeoazneaozenazone & Bazoieoainzeonaozenoazne & Cjneazeanezoanezoanzeoaneonazeono) obj);
        foo((Aaeaozeaonzeoazneaozenazone & Bazoieoainzeonaozenoazne & Cjneazeanezoanezoanzeoaneonazeono) (othrElement, value) -> othrElement + value);
    }

// Output before PR
void should_cast_with_single_element() {
    var myElem = (int) othrElement;
    var myElem = (A) othrElement;
    var myElem = (A) (othrElement, value) -> othrElement + value;
    var myElem = (Aaeaozeaonzeoazneaozenazonelkadndpndpazdpazdpazdpazdpazeazpeaazdpazdpazpdazdpa) othrElement;
  }

  void should_cast_with_additional_bounds() {
    foo((A) & B obj);
    foo((A) & B& C obj);
    foo(
      (Aaeaozeaonzeoazneaozenazone) & Bazoieoainzeonaozenoazne& Cjneazeanezoanezoanzeoaneonazeono obj
    );
    foo(
      (Aaeaozeaonzeoazneaozenazone) & Bazoieoainzeonaozenoazne& Cjneazeanezoanezoanzeoaneonazeono (
          othrElement,
          value
        ) ->
        othrElement + value
    );
  }

// Output with PR
  void should_cast_with_single_element() {
    var myElem = (int) othrElement;
    var myElem = (A) othrElement;
    var myElem = (A) (othrElement, value) -> othrElement + value;
    var myElem = (Aaeaozeaonzeoazneaozenazonelkadndpndpazdpazdpazdpazdpazeazpeaazdpazdpazpdazdpa) othrElement;
  }

  void should_cast_with_additional_bounds() {
    foo((A & B) obj);
    foo((A & B & C) obj);
    foo(
      (
        Aaeaozeaonzeoazneaozenazone
        & Bazoieoainzeonaozenoazne
        & Cjneazeanezoanezoanzeoaneonazeono
      ) obj
    );
    foo(
      (
        Aaeaozeaonzeoazneaozenazone
        & Bazoieoainzeonaozenoazne
        & Cjneazeanezoanezoanzeoaneonazeono
      ) (othrElement, value) -> othrElement + value
    );
  }
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->

Fix #517 