### PR TITLE
feat: improve records arguments printing

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -929,7 +929,16 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   }
   recordComponentList(ctx: RecordComponentListCtx) {
     const recordComponents = this.mapVisit(ctx.recordComponent);
-    const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, line])) : [];
+
+    const blankLineSeparators = getBlankLinesSeparator(
+      ctx.recordComponent,
+      line
+    );
+    const commas = ctx.Comma
+      ? ctx.Comma.map((elt, index) =>
+          concat([elt, blankLineSeparators![index]])
+        )
+      : [];
 
     return rejectAndJoinSeps(commas, recordComponents);
   }
@@ -938,11 +947,12 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
     const unannType = this.visit(ctx.unannType);
 
     if (ctx.Identifier !== undefined) {
-      return rejectAndJoin(" ", [
-        join(" ", modifiers),
-        unannType,
-        ctx.Identifier[0]
-      ]);
+      return group(
+        rejectAndJoin(line, [
+          join(line, modifiers),
+          join(" ", [unannType, ctx.Identifier[0]])
+        ])
+      );
     }
 
     const variableArityRecordComponent = this.visit(
@@ -951,16 +961,20 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
     if (
       ctx.variableArityRecordComponent![0].children.annotation !== undefined
     ) {
-      return rejectAndJoin(" ", [
-        join(" ", modifiers),
-        join(" ", [unannType, variableArityRecordComponent])
-      ]);
+      return group(
+        rejectAndJoin(line, [
+          join(line, modifiers),
+          join(" ", [unannType, variableArityRecordComponent])
+        ])
+      );
     }
 
-    return rejectAndJoin(" ", [
-      join(" ", modifiers),
-      concat([unannType, variableArityRecordComponent])
-    ]);
+    return group(
+      rejectAndJoin(line, [
+        join(line, modifiers),
+        concat([unannType, variableArityRecordComponent])
+      ])
+    );
   }
   variableArityRecordComponent(ctx: VariableArityRecordComponentCtx) {
     const annotations = this.mapVisit(ctx.annotation);

--- a/packages/prettier-plugin-java/src/printers/printer-utils.ts
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.ts
@@ -311,7 +311,10 @@ export function isExplicitLambdaParameter(ctx: LambdaParametersWithBracesCtx) {
   );
 }
 
-export function getBlankLinesSeparator(ctx: CstNode[] | undefined) {
+export function getBlankLinesSeparator(
+  ctx: CstNode[] | undefined,
+  separator: builders.Line | builders.Concat = hardline
+) {
   if (ctx === undefined) {
     return undefined;
   }
@@ -331,7 +334,7 @@ export function getBlankLinesSeparator(ctx: CstNode[] | undefined) {
     if (nextRuleStartLineWithComment - previousRuleEndLineWithComment > 1) {
       separators.push(concat([hardline, hardline]));
     } else {
-      separators.push(hardline);
+      separators.push(separator);
     }
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/records/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_input.java
@@ -126,3 +126,38 @@ public interface MyInterface {
 public interface MyInterface {
   record MySplitRecord(String param, String param, String param, String param, String param, String param) implements MyInterface {}
 }
+
+public record Record(
+    @JsonSerialize(using = StatusSerializer.class, nullsUsing = NullSerializer.class)
+    @Schema(type = "integer", description = "Some fancy description")
+
+    Status status,
+
+
+
+    @NotNull
+    Integer number,
+
+    Integer anotherNumber
+) {}
+
+public record Record(
+    @JsonSerialize(using = StatusSerializer.class, nullsUsing = NullSerializer.class)
+    @Schema(type = "integer", description = "Some fancy description")
+    // comment
+    Status status,
+
+
+
+    // comment
+    @NotNull
+    Integer number
+) {}
+
+public record Record(
+    @Schema(type = "integer", description = "A small description ")
+    Status status,
+
+    @Schema(type = "integer", description = "A longer description  ") Status status
+    )
+{}

--- a/packages/prettier-plugin-java/test/unit-test/records/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_output.java
@@ -125,3 +125,36 @@ public interface MyInterface {
   )
     implements MyInterface {}
 }
+
+public record Record(
+  @JsonSerialize(
+    using = StatusSerializer.class,
+    nullsUsing = NullSerializer.class
+  )
+  @Schema(type = "integer", description = "Some fancy description")
+  Status status,
+
+  @NotNull Integer number,
+
+  Integer anotherNumber
+) {}
+
+public record Record(
+  @JsonSerialize(
+    using = StatusSerializer.class,
+    nullsUsing = NullSerializer.class
+  )
+  @Schema(type = "integer", description = "Some fancy description")
+  // comment
+  Status status,
+
+  // comment
+  @NotNull Integer number
+) {}
+
+public record Record(
+  @Schema(type = "integer", description = "A small description ") Status status,
+
+  @Schema(type = "integer", description = "A longer description  ")
+  Status status
+) {}


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
public record Record(
    @JsonSerialize(using = StatusSerializer.class, nullsUsing = NullSerializer.class)
    @Schema(type = "integer", description = "Some fancy description")
    Status status,

    @NotNull
    Integer number
) {}

public record Record(
    @JsonSerialize(using = StatusSerializer.class, nullsUsing = NullSerializer.class)
    @Schema(type = "integer", description = "Some fancy description")
    // comment
    Status status,


    // another comment
    @NotNull
    Integer number
) {}

// Before PR
public record Record(
  @JsonSerialize(
    using = StatusSerializer.class,
    nullsUsing = NullSerializer.class
  ) @Schema(
    type = "integer",
    description = "Some fancy description"
  ) Status status,
  @NotNull Integer number
) {}

public record Record(
  @JsonSerialize(
    using = StatusSerializer.class,
    nullsUsing = NullSerializer.class
  ) @Schema(type = "integer", description = "Some fancy description") // comment
  Status status,
  // another comment
  @NotNull Integer number
) {}

// Output after PR
public record Record(
  @JsonSerialize(
    using = StatusSerializer.class,
    nullsUsing = NullSerializer.class
  )
  @Schema(type = "integer", description = "Some fancy description")
  Status status,

  @NotNull Integer number
) {}

public record Record(
  @JsonSerialize(
    using = StatusSerializer.class,
    nullsUsing = NullSerializer.class
  )
  @Schema(type = "integer", description = "Some fancy description")
  // comment
  Status status,

  // another comment
  @NotNull Integer number
) {}

```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->

Fix #515 
