### PR TITLE
fix: correct parsing of nested sealed classes

### DIFF
--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -849,6 +849,8 @@ function defineRules($, t) {
             { ALT: () => $.CONSUME(t.Volatile) },
             { ALT: () => $.CONSUME(t.Synchronized) },
             { ALT: () => $.CONSUME(t.Native) },
+            { ALT: () => $.CONSUME(t.Sealed) },
+            { ALT: () => $.CONSUME(t.NonSealed) },
             { ALT: () => $.CONSUME(t.Strictfp) }
           ]);
         }

--- a/packages/java-parser/test/sealed/sealed-spec.js
+++ b/packages/java-parser/test/sealed/sealed-spec.js
@@ -55,4 +55,26 @@ describe("Sealed Classes & Interfaces", () => {
     `;
     expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
+
+  it("should handle sealed classes inside class declarations", () => {
+    const input = `
+    public class SealedClasses {
+        public static sealed abstract class SealedParent permits SealedChild {}
+
+        final static class SealedChild extends SealedParent {}
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
+
+  it("should handle non-sealed classes inside class declarations", () => {
+    const input = `
+    public class SealedClasses {
+        public static non-sealed abstract class SealedParent {}
+
+        final static class SealedChild extends SealedParent {}
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
 });

--- a/packages/prettier-plugin-java/test/unit-test/sealed/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/sealed/_input.java
@@ -70,3 +70,15 @@ public sealed interface Shape permits ALongVeryLongCircle, ALongVeryLongRectangl
 public sealed interface Shape extends AbstractShape permits ALongVeryLongCircle, ALongVeryLongRectangle, ALongVeryLongTriangle, ALongVeryLongUnicorn {}
 public sealed class Shape permits ALongVeryLongCircle, ALongVeryLongRectangle, ALongVeryLongTriangle, ALongVeryLongUnicorn {}
 public sealed class Shape extends AbstractShape permits ALongVeryLongCircle, ALongVeryLongRectangle, ALongVeryLongTriangle, ALongVeryLongUnicorn {}
+
+public class NestedSealedClasses {
+    public static sealed abstract class SealedParent permits SealedChild {}
+
+    final static class SealedChild extends SealedParent {}
+}
+
+public class NestedNonSealedClasses {
+    public static non-sealed abstract class NonSealedParent {}
+
+    final static class SealedChild extends NonSealedParent {}
+}

--- a/packages/prettier-plugin-java/test/unit-test/sealed/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/sealed/_output.java
@@ -87,3 +87,17 @@ public sealed class Shape
     ALongVeryLongRectangle,
     ALongVeryLongTriangle,
     ALongVeryLongUnicorn {}
+
+public class NestedSealedClasses {
+
+  public abstract static sealed class SealedParent permits SealedChild {}
+
+  static final class SealedChild extends SealedParent {}
+}
+
+public class NestedNonSealedClasses {
+
+  public abstract static non-sealed class NonSealedParent {}
+
+  static final class SealedChild extends NonSealedParent {}
+}


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

Fix parsing of nested sealed and non-sealed classes

## Example

```java
// Input
package nl.jqno.equalsverifier.integration.extended_contract;

public class SealedClasses {
    public static sealed abstract class SealedParent permits SealedChild {}

    final static class SealedChild extends SealedParent {}
}

// Output
public class NestedSealedClasses {

  public abstract static sealed class SealedParent permits SealedChild {}

  static final class SealedChild extends SealedParent {}
}
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->

Fix #522