### PR TITLE
Update License to 2022

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2021 the original author or authors from the JHipster project.
+# Copyright 2018-2022 the original author or authors from the JHipster project.
 #
 # This file is part of the JHipster project, see https://www.jhipster.tech/
 # for more information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-    Copyright 2018-2021 the original author or authors from the JHipster project
+    Copyright 2018-2022 the original author or authors from the JHipster project
 
                                  Apache License
                            Version 2.0, January 2004

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 prettier-java
-Copyright 2018-2021 the original author or authors from the JHipster project.
+Copyright 2018-2022 the original author or authors from the JHipster project.
 
 For more information on the prettier-java project, see https://github.com/jhipster/prettier-java
 prettier-java is part of the JHipster organization on GitHub, for more information on JHipster, see https://www.jhipster.tech/


### PR DESCRIPTION
- related to https://github.com/jhipster/generator-jhipster/issues/17509