### PR TITLE
fix: add space after annotation in typeBounds

### DIFF
--- a/packages/prettier-plugin-java/src/printers/types-values-and-variables.ts
+++ b/packages/prettier-plugin-java/src/printers/types-values-and-variables.ts
@@ -95,7 +95,7 @@ export class TypesValuesAndVariablesPrettierVisitor extends BaseCstPrettierPrint
         segments.push(rejectAndConcat(currentSegment));
         currentSegment = [];
       } else if (isAnnotationCstNode(token)) {
-        currentSegment.push(this.visit([token]));
+        currentSegment.push(this.visit([token]), " ");
       } else {
         currentSegment.push(token);
         if (

--- a/packages/prettier-plugin-java/test/unit-test/generic_class/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/generic_class/_input.java
@@ -35,3 +35,10 @@ public class ComplexGenericClass<
 		}
 
   }
+
+public class Foo<T> {
+
+    public <U extends @NotNull T> void example(U u) {}
+
+    public <U extends com.java.Any.@NotNull T> void example(U u) {}
+}

--- a/packages/prettier-plugin-java/test/unit-test/generic_class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/generic_class/_output.java
@@ -27,3 +27,10 @@ public class ComplexGenericClass<
     return new ArrayList<>();
   }
 }
+
+public class Foo<T> {
+
+  public <U extends @NotNull T> void example(U u) {}
+
+  public <U extends com.java.Any.@NotNull T> void example(U u) {}
+}


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
public class Foo<T> {

  public <U extends @NotNull T> void example(U u) {}

  public <U extends com.java.Any.@NotNull T> void example(U u) {}
}

// Prettier 1.6.1
public class Foo<T> {

  public <U extends @NotNullT> void example(U u) {}

  public <U extends com.java.Any.@NotNullT> void example(U u) {}
}

// Next
public class Foo<T> {

  public <U extends @NotNull T> void example(U u) {}

  public <U extends com.java.Any.@NotNull T> void example(U u) {}
}
```

## Relative issues or prs:

Fix #536 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
