### PR TITLE
fix: fix parsing of nested sealed interfaces and classes

### DIFF
--- a/packages/java-parser/src/productions/interfaces.js
+++ b/packages/java-parser/src/productions/interfaces.js
@@ -366,11 +366,13 @@ function defineRules($, t) {
           { ALT: () => $.CONSUME(t.Public) },
           { ALT: () => $.CONSUME(t.Protected) },
           { ALT: () => $.CONSUME(t.Private) },
-          { ALT: () => $.CONSUME(t.Static) },
-          { ALT: () => $.CONSUME(t.Final) },
           { ALT: () => $.CONSUME(t.Abstract) },
-          { ALT: () => $.CONSUME(t.Default) },
-          { ALT: () => $.CONSUME(t.Strictfp) }
+          { ALT: () => $.CONSUME(t.Static) },
+          { ALT: () => $.CONSUME(t.Sealed) },
+          { ALT: () => $.CONSUME(t.NonSealed) },
+          { ALT: () => $.CONSUME(t.Strictfp) },
+          { ALT: () => $.CONSUME(t.Final) },
+          { ALT: () => $.CONSUME(t.Default) }
         ]);
       }
     });

--- a/packages/java-parser/test/sealed/sealed-spec.js
+++ b/packages/java-parser/test/sealed/sealed-spec.js
@@ -56,9 +56,11 @@ describe("Sealed Classes & Interfaces", () => {
     expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
-  it("should handle sealed classes inside class declarations", () => {
+  it("should handle sealed classes and interfaces inside class declarations", () => {
     const input = `
     public class SealedClasses {
+        sealed interface SealedParent {}
+
         public static sealed abstract class SealedParent permits SealedChild {}
 
         final static class SealedChild extends SealedParent {}
@@ -67,9 +69,35 @@ describe("Sealed Classes & Interfaces", () => {
     expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
-  it("should handle non-sealed classes inside class declarations", () => {
+  it("should handle non-sealed classes and interfaces inside class declarations", () => {
     const input = `
     public class SealedClasses {
+        non-sealed interface SealedParent {}
+
+        public static non-sealed abstract class SealedParent {}
+
+        final static class SealedChild extends SealedParent {}
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
+
+  it("should handle sealed classes and interfaces inside interface declarations", () => {
+    const input = `
+    public interface Test {
+        sealed interface Inner {}
+
+        public static sealed abstract class SealedParent {}
+    }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
+
+  it("should handle non-sealed classes and interfaces inside interface declarations", () => {
+    const input = `
+    public interface SealedClasses {
+        non-sealed interface Inner {}
+
         public static non-sealed abstract class SealedParent {}
 
         final static class SealedChild extends SealedParent {}

--- a/packages/prettier-plugin-java/test/unit-test/sealed/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/sealed/_input.java
@@ -82,3 +82,15 @@ public class NestedNonSealedClasses {
 
     final static class SealedChild extends NonSealedParent {}
 }
+
+public interface Test {
+    sealed interface Inner {}
+
+    public static sealed abstract class SealedParent {}
+
+    non-sealed interface Inner {}
+
+    public static non-sealed abstract class SealedParent {}
+
+    final static class SealedChild extends SealedParent {}
+}

--- a/packages/prettier-plugin-java/test/unit-test/sealed/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/sealed/_output.java
@@ -101,3 +101,15 @@ public class NestedNonSealedClasses {
 
   static final class SealedChild extends NonSealedParent {}
 }
+
+public interface Test {
+  sealed interface Inner {}
+
+  public abstract static sealed class SealedParent {}
+
+  non-sealed interface Inner {}
+
+  public abstract static non-sealed class SealedParent {}
+
+  static final class SealedChild extends SealedParent {}
+}


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

Fix parsing of sealed/non-sealed classes & interfaces in an interface's body

**Example**
```java
public interface Test {
    sealed interface Inner {}

    public static sealed abstract class SealedParent {}

    non-sealed interface Inner {}

    public static non-sealed abstract class SealedParent {}

    final static class SealedChild extends SealedParent {}
}

```

## Relative issues or prs:

Fix #533 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
