### PR TITLE
fix: fix parsing of escaped spaces in strings

### DIFF
--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -49,7 +49,7 @@ FRAGMENT(
   "OctalEscape",
   "\\\\({{OctalDigit}}|{{ZeroToThree}}?{{OctalDigit}}{2})"
 );
-FRAGMENT("EscapeSequence", "\\\\[btnfr\"'\\\\]|{{OctalEscape}}");
+FRAGMENT("EscapeSequence", "\\\\[bstnfr\"'\\\\]|{{OctalEscape}}");
 // Not using InputCharacter terminology there because CR and LF are already captured in EscapeSequence
 FRAGMENT(
   "StringCharacter",

--- a/packages/java-parser/test/string-literals.spec.js
+++ b/packages/java-parser/test/string-literals.spec.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const { expect } = require("chai");
+const javaParser = require("../src/index");
+
+describe("String literals", () => {
+  it("should parse unicode", () => {
+    const inputs = [
+      '"π or \\u03c0"',
+      '"\\uD83C\\uDF4F"',
+      '"\\uD83C\\uDF4C"',
+      '"\\uD83C\\uDF52"',
+      '"🍎"'
+    ];
+    inputs.forEach(input => {
+      expect(() => javaParser.parse(input, "literal")).to.not.throw();
+    });
+  });
+
+  it("should parse octal literals", () => {
+    const inputs = ['"\\52"', '"\\133"'];
+    inputs.forEach(input => {
+      expect(() => javaParser.parse(input, "literal")).to.not.throw();
+    });
+  });
+
+  it("should parse escaped sequence", () => {
+    const inputs = [
+      '"\\b"',
+      '"\\s"',
+      '"\\t"',
+      '"\\n"',
+      '"\\f"',
+      '"\\r"',
+      '"\\""',
+      '"\\\'"',
+      '"\\\\"'
+    ];
+    inputs.forEach(input => {
+      expect(() => javaParser.parse(input, "literal")).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

Fix parsing of escaped spaces in strings like these following example

```java
"\s"
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->

Fix #541 