### PR TITLE
doc: add VSCode Java import order configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ For IntelliJ, you can use this configuration:
 
 You can also import the Checkstyle configuration provided in the next section.
 
+For VSCode with [Language Support for Java](https://marketplace.visualstudio.com/items?itemName=redhat.java), you can use this configuration (`settings.json`):
+```json
+{
+  "java.completion.importOrder": [
+    "#"
+  ]
+}
+```
+
 ## Checkstyle configuration
 
 You can use Prettier in combination with other linter, like Checkstyle.

--- a/README.md
+++ b/README.md
@@ -116,11 +116,10 @@ For IntelliJ, you can use this configuration:
 You can also import the Checkstyle configuration provided in the next section.
 
 For VSCode with [Language Support for Java](https://marketplace.visualstudio.com/items?itemName=redhat.java), you can use this configuration (`settings.json`):
+
 ```json
 {
-  "java.completion.importOrder": [
-    "#"
-  ]
+  "java.completion.importOrder": ["#"]
 }
 ```
 


### PR DESCRIPTION
## What changed with this PR:

Add configuration for import order in VSCode to the README.md 
