### PR TITLE
Fix formatting of module info to avoid space right before semicolons …

### DIFF
--- a/packages/prettier-plugin-java/src/printers/packages-and-modules.ts
+++ b/packages/prettier-plugin-java/src/printers/packages-and-modules.ts
@@ -153,28 +153,35 @@ export class PackagesAndModulesPrettierVisitor extends BaseCstPrettierPrinter {
 
   exportsModuleDirective(ctx: ExportsModuleDirectiveCtx) {
     const packageName = this.visit(ctx.packageName);
-    const to = ctx.To ? ctx.To[0] : "";
     const moduleNames = this.mapVisit(ctx.moduleName);
     const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, line])) : [];
 
-    return group(
-      rejectAndConcat([
-        indent(
-          rejectAndJoin(line, [
-            rejectAndJoin(" ", [ctx.Exports[0], packageName]),
-            group(
-              indent(
-                rejectAndJoin(line, [
-                  to,
-                  rejectAndJoinSeps(commas, moduleNames)
-                ])
+    if (ctx.To) {
+      return group(
+        rejectAndConcat([
+          indent(
+            rejectAndJoin(line, [
+              rejectAndJoin(" ", [ctx.Exports[0], packageName]),
+              group(
+                indent(
+                  rejectAndJoin(line, [
+                    ctx.To[0],
+                    rejectAndJoinSeps(commas, moduleNames)
+                  ])
+                )
               )
-            )
-          ])
-        ),
-        ctx.Semicolon[0]
-      ])
-    );
+            ])
+          ),
+          ctx.Semicolon[0]
+        ])
+      );
+    }
+    
+    return rejectAndConcat([
+      concat([ctx.Exports[0], " "]),
+      packageName,
+      ctx.Semicolon[0]
+    ]);
   }
 
   opensModuleDirective(ctx: OpensModuleDirectiveCtx) {
@@ -183,24 +190,32 @@ export class PackagesAndModulesPrettierVisitor extends BaseCstPrettierPrinter {
     const moduleNames = this.mapVisit(ctx.moduleName);
     const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, line])) : [];
 
-    return group(
-      rejectAndConcat([
-        indent(
-          rejectAndJoin(line, [
-            rejectAndJoin(" ", [ctx.Opens[0], packageName]),
-            group(
-              indent(
-                rejectAndJoin(line, [
-                  to,
-                  rejectAndJoinSeps(commas, moduleNames)
-                ])
+    if (ctx.To) {
+      return group(
+        rejectAndConcat([
+          indent(
+            rejectAndJoin(line, [
+              rejectAndJoin(" ", [ctx.Opens[0], packageName]),
+              group(
+                indent(
+                  rejectAndJoin(line, [
+                    ctx.To[0],
+                    rejectAndJoinSeps(commas, moduleNames)
+                  ])
+                )
               )
-            )
-          ])
-        ),
-        ctx.Semicolon[0]
-      ])
-    );
+            ])
+          ),
+          ctx.Semicolon[0]
+        ])
+      );
+    }
+
+    return rejectAndConcat([
+      concat([ctx.Opens[0], " "]),
+      packageName,
+      ctx.Semicolon[0]
+    ]);
   }
 
   usesModuleDirective(ctx: UsesModuleDirectiveCtx) {

--- a/packages/prettier-plugin-java/test/unit-test/modules/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/modules/_input.java
@@ -3,11 +3,13 @@ open module soat.vending.machine.gui {
   requires soat.vending.machine.model;
   requires transitive soat.core;
    exports  fr.soat.vending.machine.model to another , again, ano;
+   exports  fr.soat.vending.machine.model.without.destination ;
 
    exports  fr.soat.vending.machine.model.it.should.be.breaking.but.only.a.part to another , again, ano;
 
    exports  fr.soat.vending.machine.model to another , again, ano, waht, another , again, ano, averyveryveryveryveryveryveryveryveryveryverylongname;
 
+   opens  fr.soat.vending.machine.model.without.destination ;
 
    opens  fr.soat.vending.machine.model to another , again,ano ;
 

--- a/packages/prettier-plugin-java/test/unit-test/modules/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/modules/_output.java
@@ -3,6 +3,7 @@ open module soat.vending.machine.gui {
   requires soat.vending.machine.model;
   requires transitive soat.core;
   exports fr.soat.vending.machine.model to another, again, ano;
+  exports fr.soat.vending.machine.model.without.destination;
 
   exports fr.soat.vending.machine.model.it.should.be.breaking.but.only.a.part
     to another, again, ano;
@@ -17,6 +18,8 @@ open module soat.vending.machine.gui {
       again,
       ano,
       averyveryveryveryveryveryveryveryveryveryverylongname;
+
+  opens fr.soat.vending.machine.model.without.destination;
 
   opens fr.soat.vending.machine.model to another, again, ano;
 


### PR DESCRIPTION
…(Fixes jhipster/prettier-java#550)

## What changed with this PR:
Fix for https://github.com/jhipster/prettier-java/issues/550

## Example

```java
// Input
open module org.myorg.module {
    requires some.required.module;

    exports  org.myorg.module.exportpackage ;
    opens  org.myorg.module.openpackage ;
}

// Prettier 1.6.2
open module org.myorg.module {
    requires some.required.module;

    exports org.myorg.module.exportpackage ;
    opens org.myorg.module.openpackage ;
}

// Output
open module org.myorg.module {
    requires some.required.module;

    exports org.myorg.module.exportpackage;
    opens org.myorg.module.openpackage;
}
```

## Relative issues or prs:
https://github.com/jhipster/prettier-java/issues/550
