### PR TITLE
fix: break long assignments after equals

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -12,7 +12,7 @@ import {
   sortClassTypeChildren,
   sortModifiers
 } from "./printer-utils";
-import { concat, group, indent, join } from "./prettier-builder";
+import { concat, group, indent, join, indentIfBreak } from "./prettier-builder";
 import { printTokenWithComments } from "./comments/format-comments";
 import {
   hasLeadingComments,
@@ -93,7 +93,7 @@ import { Doc } from "prettier";
 import { isAnnotationCstNode, isTypeArgumentsCstNode } from "../types/utils";
 import { printArgumentListWithBraces } from "../utils";
 
-const { line, softline, hardline } = builders;
+const { line, softline, hardline, lineSuffixBoundary } = builders;
 
 export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   classDeclaration(ctx: ClassDeclarationCtx) {
@@ -330,10 +330,14 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
           ctx.variableInitializer![0].children.expression![0].children
             .ternaryExpression[0].children.QuestionMark !== undefined)
       ) {
-        return rejectAndJoin(" ", [
-          variableDeclaratorId,
+        const groupId = Symbol("assignment");
+        return group([
+          group(variableDeclaratorId),
+          " ",
           ctx.Equals[0],
-          variableInitializer
+          group(indent(line), { id: groupId }),
+          lineSuffixBoundary,
+          indentIfBreak(variableInitializer, { groupId })
         ]);
       }
 
@@ -351,10 +355,14 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
           firstPrimary.children.primaryPrefix[0].children.castExpression !==
           undefined
         ) {
-          return rejectAndJoin(" ", [
-            variableDeclaratorId,
+          const groupId = Symbol("assignment");
+          return group([
+            group(variableDeclaratorId),
+            " ",
             ctx.Equals[0],
-            variableInitializer
+            group(indent(line), { id: groupId }),
+            lineSuffixBoundary,
+            indentIfBreak(variableInitializer, { groupId })
           ]);
         }
 
@@ -363,10 +371,14 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
           firstPrimary.children.primaryPrefix[0].children.newExpression !==
           undefined
         ) {
-          return rejectAndJoin(" ", [
-            variableDeclaratorId,
+          const groupId = Symbol("assignment");
+          return group([
+            group(variableDeclaratorId),
+            " ",
             ctx.Equals[0],
-            variableInitializer
+            group(indent(line), { id: groupId }),
+            lineSuffixBoundary,
+            indentIfBreak(variableInitializer, { groupId })
           ]);
         }
 
@@ -383,10 +395,14 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
         const isUniqueMethodInvocation =
           isMethodInvocation && isUniqueUnaryExpression;
         if (isUniqueMethodInvocation) {
-          return rejectAndJoin(" ", [
-            variableDeclaratorId,
+          const groupId = Symbol("assignment");
+          return group([
+            group(variableDeclaratorId),
+            " ",
             ctx.Equals[0],
-            variableInitializer
+            group(indent(line), { id: groupId }),
+            lineSuffixBoundary,
+            indentIfBreak(variableInitializer, { groupId })
           ]);
         }
       }

--- a/packages/prettier-plugin-java/src/printers/prettier-builder.ts
+++ b/packages/prettier-plugin-java/src/printers/prettier-builder.ts
@@ -65,6 +65,10 @@ export function ifBreak(
   );
 }
 
+export function indentIfBreak(contents: Doc | IToken, opts?: any) {
+  return prettier.indentIfBreak(processComments(contents), opts);
+}
+
 // TODO: remove this once prettier 3.0 is released
 const processEmptyDocs = (doc: Fill | Concat): Doc => {
   return doc.parts?.length === 0 ? "" : doc;

--- a/packages/prettier-plugin-java/test/unit-test/cast/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/cast/_output.java
@@ -4,7 +4,8 @@ public class Cast {
     var myElem = (int) othrElement;
     var myElem = (A) othrElement;
     var myElem = (A) (othrElement, value) -> othrElement + value;
-    var myElem = (Aaeaozeaonzeoazneaozenazonelkadndpndpazdpazdpazdpazdpazeazpeaazdpazdpazpdazdpa) othrElement;
+    var myElem =
+      (Aaeaozeaonzeoazneaozenazonelkadndpndpazdpazdpazdpazdpazeazpeaazdpazdpazpdazdpa) othrElement;
   }
 
   void should_cast_with_additional_bounds() {

--- a/packages/prettier-plugin-java/test/unit-test/comments/bug-fixes/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/bug-fixes/_output.java
@@ -33,20 +33,22 @@ class T {
                */
   void t() {}
 
-  public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
-    Arrays.asList( // a
-      // b
-      // c
-      // d
-    )
-  );
+  public static final List<Object> XXXXXXXXXXXXXXXXXX =
+    Collections.unmodifiableList(
+      Arrays.asList( // a
+        // b
+        // c
+        // d
+      )
+    );
 
-  public static final List<Object> XXXXXXXXXXXXXXXXXX = Collections.unmodifiableList(
-    Arrays.asList( // a
-      // b
-      // c
-      // d
-      /*e*/
-    )
-  );
+  public static final List<Object> XXXXXXXXXXXXXXXXXX =
+    Collections.unmodifiableList(
+      Arrays.asList( // a
+        // b
+        // c
+        // d
+        /*e*/
+      )
+    );
 }

--- a/packages/prettier-plugin-java/test/unit-test/variables/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_input.java
@@ -16,6 +16,11 @@ public class Variables {
   private Map<Integer, String> genericVariable4 = new HashMap<Integer, String>();
   private Map<Integer, String, Integer, String> genericVariable5 = new HashMap<Integer, String, Integer>();
 
+  private Object variableWithComment1 /* comment */= new Object();
+  private Object variableWithComment2 =/* comment */ new Object();
+  private Object variableWithComment3 /* very very very long comment */= new Object();
+  private Object variableWithComment4 =/* very very very long comment */ new Object();
+
   private Object[] arrayVariable1 = new Object[3];
   private Object[][] arrayVariable2 = new Object[3][3];
   private Object[] arrayVariable3 = new Object[] {};
@@ -98,6 +103,57 @@ public class Variables {
     boolean willDrop = predictDropResponse.getSendResult().isIgnorableFailure || predictDropResponse.getSendResult().isFatalError;
     boolean willDrop = predictDropResponsegetSendResultisIgnorableFailure || predictDropResponsegetSendResultisFatalError;
     boolean willDrop = predictDropResponse.getSendResult().isIgnorableFailure() || predictDropResponsegetSendResultisFatalError;
+  }
+
+  public void breakAfterEquals() {
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = new Object();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = new Object()
+      .other()
+      .methods();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = new Object()
+      .a()
+      .number()
+      .of()
+      .other()
+      .methods()
+      .that()
+      .should()
+      .cause()
+      .a()
+      .wrap();
+
+    Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes = new Object[10];
+
+    Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes = new Object[] {
+      new Object(),
+      new Object()
+    };
+
+    Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes = new Object[] {
+      new Object(),
+      new Object(),
+      new Object(),
+      new Object(),
+      new Object()
+    };
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = SomeClass.someStaticMethod();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = someMethod();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = someMethod()
+      .anotherMethod();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = someBooleanVariable
+      ? new Object()
+      : null;
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = anotherVeryLongNameForIllustrativePurposes !=
+      null
+      ? anotherVeryLongNameForIllustrativePurposes
+      : new Object();
   }
 
   public methodWithVariableInitializationWithComments() {

--- a/packages/prettier-plugin-java/test/unit-test/variables/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_output.java
@@ -20,8 +20,17 @@ public class Variables {
     "ghi",
     "jkl"
   );
-  private Map<Integer, String> genericVariable4 = new HashMap<Integer, String>();
-  private Map<Integer, String, Integer, String> genericVariable5 = new HashMap<Integer, String, Integer>();
+  private Map<Integer, String> genericVariable4 =
+    new HashMap<Integer, String>();
+  private Map<Integer, String, Integer, String> genericVariable5 =
+    new HashMap<Integer, String, Integer>();
+
+  private Object variableWithComment1 /* comment */= new Object();
+  private Object variableWithComment2 = /* comment */new Object();
+  private Object variableWithComment3 /* very very very long comment */=
+    new Object();
+  private Object variableWithComment4 =
+    /* very very very long comment */new Object();
 
   private Object[] arrayVariable1 = new Object[3];
   private Object[][] arrayVariable2 = new Object[3][3];
@@ -160,6 +169,59 @@ public class Variables {
     boolean willDrop =
       predictDropResponse.getSendResult().isIgnorableFailure() ||
       predictDropResponsegetSendResultisFatalError;
+  }
+
+  public void breakAfterEquals() {
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      new Object();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      new Object().other().methods();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      new Object()
+        .a()
+        .number()
+        .of()
+        .other()
+        .methods()
+        .that()
+        .should()
+        .cause()
+        .a()
+        .wrap();
+
+    Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      new Object[10];
+
+    Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      new Object[] { new Object(), new Object() };
+
+    Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      new Object[] {
+        new Object(),
+        new Object(),
+        new Object(),
+        new Object(),
+        new Object(),
+      };
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      SomeClass.someStaticMethod();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      someMethod();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      someMethod().anotherMethod();
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      someBooleanVariable ? new Object() : null;
+
+    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      anotherVeryLongNameForIllustrativePurposes != null
+        ? anotherVeryLongNameForIllustrativePurposes
+        : new Object();
   }
 
   public methodWithVariableInitializationWithComments() {


### PR DESCRIPTION
## What changed with this PR:

Long assignments (i.e. those that previously violated printWidth) of many types now break after equals the way Prettier JavaScript now does.

## Example

### Input
```java
class Example {

  void example() {
    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = new Object()
      .someMethod();

    Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes2 = new Object[] {
      new Object(),
      new Object()
    };

    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes3 = SomeClass.someStaticMethod();

    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = someMethod()
      .anotherMethod();

    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes = anotherValue !=
      null
      ? anotherValue
      : new Object();
  }
}
```

### Output
```java
class Example {

  void example() {
    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
      new Object().someMethod();

    Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes2 =
      new Object[] { new Object(), new Object() };

    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes3 =
      SomeClass.someStaticMethod();

    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
      someMethod().anotherMethod();

    Object aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
      anotherValue != null ? anotherValue : new Object();
  }
}
```

## Relative issues or prs:

Fix #527