### PR TITLE
Added support for require-pragma option (resolves #573)

### DIFF
--- a/packages/prettier-plugin-java/src/index.js
+++ b/packages/prettier-plugin-java/src/index.js
@@ -27,8 +27,8 @@ function locEnd(/* node */) {
   return -1;
 }
 
-function hasPragma(/* text */) {
-  return false;
+function hasPragma(text) {
+  return /^\/\*\*[\n][\t\s]+\*\s@(prettier|format)[\n][\t\s]+\*\//.test(text);
 }
 
 const parsers = {

--- a/packages/prettier-plugin-java/test/test-utils.ts
+++ b/packages/prettier-plugin-java/test/test-utils.ts
@@ -13,7 +13,15 @@ import { format, doc } from "prettier";
 const { printDocToString } = doc.printer;
 
 const pluginPath = resolve(__dirname, "../dist/index.js");
-export function testSample(testFolder: string, exclusive?: boolean) {
+export function testSampleWithOptions({
+  testFolder,
+  exclusive,
+  prettierOptions = {}
+}: {
+  testFolder: string;
+  exclusive?: boolean;
+  prettierOptions?: any;
+}) {
   const itOrItOnly = exclusive ? it.only : it;
   const inputPath = resolve(testFolder, "_input.java");
   const expectedPath = resolve(testFolder, "_output.java");
@@ -31,7 +39,8 @@ export function testSample(testFolder: string, exclusive?: boolean) {
   itOrItOnly(`can format <${relativeInputPath}>`, async () => {
     const actual = await format(inputContents, {
       parser: "java",
-      plugins: [pluginPath]
+      plugins: [pluginPath],
+      ...prettierOptions
     });
 
     expect(actual).to.equal(expectedContents);
@@ -40,15 +49,21 @@ export function testSample(testFolder: string, exclusive?: boolean) {
   it(`Performs a stable formatting for <${relativeInputPath}>`, async () => {
     const onePass = await format(inputContents, {
       parser: "java",
-      plugins: [pluginPath]
+      plugins: [pluginPath],
+      ...prettierOptions
     });
 
     const secondPass = await format(onePass, {
       parser: "java",
-      plugins: [pluginPath]
+      plugins: [pluginPath],
+      ...prettierOptions
     });
     expect(onePass).to.equal(secondPass);
   });
+}
+
+export function testSample(testFolder: string, exclusive?: boolean) {
+  testSampleWithOptions({ testFolder, exclusive });
 }
 
 export function testRepositorySample(

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/format-pragma/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/format-pragma/_input.java
@@ -1,0 +1,36 @@
+/**
+ * @format
+ */
+ public enum Enum {
+
+  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM;
+
+}
+
+public enum Enum {
+
+  THIS_IS_GOOD("abc"), THIS_IS_FINE("abc");
+
+  public static final String thisWillBeDeleted = "DELETED";
+
+  private final String value;
+
+  public Enum(String value) {
+    this.value = value;
+  }
+
+  public String toString() {
+    return "STRING";
+  }
+
+}
+
+class CLassWithEnum {
+
+  public static enum VALID_THINGS {
+
+    FIRST, SECOND
+
+  }
+
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/format-pragma/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/format-pragma/_output.java
@@ -1,0 +1,33 @@
+/**
+ * @format
+ */
+public enum Enum {
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM,
+}
+
+public enum Enum {
+  THIS_IS_GOOD("abc"),
+  THIS_IS_FINE("abc");
+
+  public static final String thisWillBeDeleted = "DELETED";
+
+  private final String value;
+
+  public Enum(String value) {
+    this.value = value;
+  }
+
+  public String toString() {
+    return "STRING";
+  }
+}
+
+class CLassWithEnum {
+
+  public static enum VALID_THINGS {
+    FIRST,
+    SECOND,
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/invalid-pragma/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/invalid-pragma/_input.java
@@ -1,0 +1,36 @@
+/**
+ * @surely this is invalid
+ */
+ public enum Enum {
+
+  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM;
+
+}
+
+public enum Enum {
+
+  THIS_IS_GOOD("abc"), THIS_IS_FINE("abc");
+
+  public static final String thisWillBeDeleted = "DELETED";
+
+  private final String value;
+
+  public Enum(String value) {
+    this.value = value;
+  }
+
+  public String toString() {
+    return "STRING";
+  }
+
+}
+
+class CLassWithEnum {
+
+  public static enum VALID_THINGS {
+
+    FIRST, SECOND
+
+  }
+
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/invalid-pragma/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/invalid-pragma/_output.java
@@ -1,0 +1,36 @@
+/**
+ * @surely this is invalid
+ */
+ public enum Enum {
+
+  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM;
+
+}
+
+public enum Enum {
+
+  THIS_IS_GOOD("abc"), THIS_IS_FINE("abc");
+
+  public static final String thisWillBeDeleted = "DELETED";
+
+  private final String value;
+
+  public Enum(String value) {
+    this.value = value;
+  }
+
+  public String toString() {
+    return "STRING";
+  }
+
+}
+
+class CLassWithEnum {
+
+  public static enum VALID_THINGS {
+
+    FIRST, SECOND
+
+  }
+
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/prettier-pragma/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/prettier-pragma/_input.java
@@ -1,0 +1,36 @@
+/**
+ * @prettier
+ */
+ public enum Enum {
+
+  SOME_ENUM, ANOTHER_ENUM, LAST_ENUM;
+
+}
+
+public enum Enum {
+
+  THIS_IS_GOOD("abc"), THIS_IS_FINE("abc");
+
+  public static final String thisWillBeDeleted = "DELETED";
+
+  private final String value;
+
+  public Enum(String value) {
+    this.value = value;
+  }
+
+  public String toString() {
+    return "STRING";
+  }
+
+}
+
+class CLassWithEnum {
+
+  public static enum VALID_THINGS {
+
+    FIRST, SECOND
+
+  }
+
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/prettier-pragma/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/prettier-pragma/_output.java
@@ -1,0 +1,33 @@
+/**
+ * @prettier
+ */
+public enum Enum {
+  SOME_ENUM,
+  ANOTHER_ENUM,
+  LAST_ENUM,
+}
+
+public enum Enum {
+  THIS_IS_GOOD("abc"),
+  THIS_IS_FINE("abc");
+
+  public static final String thisWillBeDeleted = "DELETED";
+
+  private final String value;
+
+  public Enum(String value) {
+    this.value = value;
+  }
+
+  public String toString() {
+    return "STRING";
+  }
+}
+
+class CLassWithEnum {
+
+  public static enum VALID_THINGS {
+    FIRST,
+    SECOND,
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/require-pragma-spec.ts
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/require-pragma-spec.ts
@@ -1,0 +1,15 @@
+import * as path from "path";
+import { testSampleWithOptions } from "../../test-utils";
+
+describe("prettier-java: require-pragma option", () => {
+  [
+    path.resolve(__dirname, "./format-pragma"),
+    path.resolve(__dirname, "./prettier-pragma"),
+    path.resolve(__dirname, "./invalid-pragma")
+  ].forEach(testFolder =>
+    testSampleWithOptions({
+      testFolder,
+      prettierOptions: { requirePragma: true }
+    })
+  );
+});


### PR DESCRIPTION
## What changed with this PR:

Added support for the require-pragma option

## Example

```java
// Input
/**
 * @prettier
 */
public class Example { private int test=-1;}

// Output
/**
 * @prettier
 */
public class Example {
  private int test = -1;
}
```

```java
// Input
public class Example { private int test=-1;}

// Output
public class Example { private int test=-1;}
```

## Relative issues or prs:
https://github.com/jhipster/prettier-java/issues/573
