### PR TITLE
feat: break long lines on type arguments

### DIFF
--- a/packages/prettier-plugin-java/test/unit-test/variables/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_input.java
@@ -156,6 +156,27 @@ public class Variables {
       : new Object();
   }
 
+  public <A extends ShortClassName & ShortClassName & ShortClassName & ShortClassName, B extends ShortClassName & ShortClassName & ShortClassName & ShortClassName & ShortClassName, C extends ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> & ExtremelyLongAndObnoxiousInterfaceName & ExtremelyLongAndObnoxiousInterfaceName & ExtremelyLongAndObnoxiousInterfaceName> void breakOnTypeArguments(
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName> parameter,
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> parameter
+  ) {
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName> variable;
+
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> variable;
+
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> variable =
+      new MyExtremelyLongAndObnoxiousClassName<>();
+
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> variable =
+      new MyExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName>();
+
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      new MyExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName>();
+
+    new MyExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName>()
+      .method();
+  }
+
   public methodWithVariableInitializationWithComments() {
     Map<String, String> map =
       // there is a random comment on this line up here

--- a/packages/prettier-plugin-java/test/unit-test/variables/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_output.java
@@ -20,10 +20,15 @@ public class Variables {
     "ghi",
     "jkl"
   );
-  private Map<Integer, String> genericVariable4 =
-    new HashMap<Integer, String>();
-  private Map<Integer, String, Integer, String> genericVariable5 =
-    new HashMap<Integer, String, Integer>();
+  private Map<Integer, String> genericVariable4 = new HashMap<
+    Integer,
+    String
+  >();
+  private Map<Integer, String, Integer, String> genericVariable5 = new HashMap<
+    Integer,
+    String,
+    Integer
+  >();
 
   private Object variableWithComment1 /* comment */= new Object();
   private Object variableWithComment2 = /* comment */new Object();
@@ -222,6 +227,94 @@ public class Variables {
       anotherVeryLongNameForIllustrativePurposes != null
         ? anotherVeryLongNameForIllustrativePurposes
         : new Object();
+  }
+
+  public <
+    A extends ShortClassName & ShortClassName & ShortClassName & ShortClassName,
+    B extends ShortClassName
+      & ShortClassName
+      & ShortClassName
+      & ShortClassName
+      & ShortClassName,
+    C extends ExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName,
+        ExtremelyLongAndObnoxiousClassName
+      >,
+      ExtremelyLongAndObnoxiousClassName
+    >
+      & ExtremelyLongAndObnoxiousInterfaceName
+      & ExtremelyLongAndObnoxiousInterfaceName
+      & ExtremelyLongAndObnoxiousInterfaceName
+  > void breakOnTypeArguments(
+    ExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName
+    > parameter,
+    ExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName,
+        ExtremelyLongAndObnoxiousClassName
+      >,
+      ExtremelyLongAndObnoxiousClassName
+    > parameter
+  ) {
+    ExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName
+    > variable;
+
+    ExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName,
+        ExtremelyLongAndObnoxiousClassName
+      >,
+      ExtremelyLongAndObnoxiousClassName
+    > variable;
+
+    ExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName,
+        ExtremelyLongAndObnoxiousClassName
+      >,
+      ExtremelyLongAndObnoxiousClassName
+    > variable = new MyExtremelyLongAndObnoxiousClassName<>();
+
+    ExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName,
+        ExtremelyLongAndObnoxiousClassName
+      >,
+      ExtremelyLongAndObnoxiousClassName
+    > variable = new MyExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName,
+        ExtremelyLongAndObnoxiousClassName
+      >,
+      ExtremelyLongAndObnoxiousClassName
+    >();
+
+    ExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName,
+        ExtremelyLongAndObnoxiousClassName
+      >,
+      ExtremelyLongAndObnoxiousClassName
+    > aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+      new MyExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName<
+          ExtremelyLongAndObnoxiousClassName,
+          ExtremelyLongAndObnoxiousClassName
+        >,
+        ExtremelyLongAndObnoxiousClassName
+      >();
+
+    new MyExtremelyLongAndObnoxiousClassName<
+      ExtremelyLongAndObnoxiousClassName<
+        ExtremelyLongAndObnoxiousClassName,
+        ExtremelyLongAndObnoxiousClassName
+      >,
+      ExtremelyLongAndObnoxiousClassName
+    >()
+      .method();
   }
 
   public methodWithVariableInitializationWithComments() {


### PR DESCRIPTION
## What changed with this PR:

Long lines containing type arguments (i.e. those that previously violated printWidth) are now broken on type arguments the way Prettier JavaScript does (on TypeScript).

## Example

### Input

```java
class Example {

  <A extends ShortClassName & ShortClassName & ShortClassName & ShortClassName, B extends ShortClassName & ShortClassName & ShortClassName & ShortClassName & ShortClassName, C extends ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> & ExtremelyLongAndObnoxiousInterfaceName & ExtremelyLongAndObnoxiousInterfaceName & ExtremelyLongAndObnoxiousInterfaceName> void example(
    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName> parameter,
    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> parameter
  ) {
    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName> variable;

    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> variable;

    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> variable =
      new MyExtremelyLongAndObnoxiousClassName<>();

    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> variable =
      new MyExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName>();

    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName> aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
      new MyExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName>();

    new MyExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName, ExtremelyLongAndObnoxiousClassName>, ExtremelyLongAndObnoxiousClassName>()
      .method();
  }
}
```

### Output
```java
class Example {

  <
    A extends ShortClassName & ShortClassName & ShortClassName & ShortClassName,
    B extends ShortClassName
      & ShortClassName
      & ShortClassName
      & ShortClassName
      & ShortClassName,
    C extends ExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName,
        ExtremelyLongAndObnoxiousClassName
      >,
      ExtremelyLongAndObnoxiousClassName
    >
      & ExtremelyLongAndObnoxiousInterfaceName
      & ExtremelyLongAndObnoxiousInterfaceName
      & ExtremelyLongAndObnoxiousInterfaceName
  > void example(
    ExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName
    > parameter,
    ExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName,
        ExtremelyLongAndObnoxiousClassName
      >,
      ExtremelyLongAndObnoxiousClassName
    > parameter
  ) {
    ExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName
    > variable;

    ExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName,
        ExtremelyLongAndObnoxiousClassName
      >,
      ExtremelyLongAndObnoxiousClassName
    > variable;

    ExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName,
        ExtremelyLongAndObnoxiousClassName
      >,
      ExtremelyLongAndObnoxiousClassName
    > variable = new MyExtremelyLongAndObnoxiousClassName<>();

    ExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName,
        ExtremelyLongAndObnoxiousClassName
      >,
      ExtremelyLongAndObnoxiousClassName
    > variable = new MyExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName,
        ExtremelyLongAndObnoxiousClassName
      >,
      ExtremelyLongAndObnoxiousClassName
    >();

    ExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName,
        ExtremelyLongAndObnoxiousClassName
      >,
      ExtremelyLongAndObnoxiousClassName
    > aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
      new MyExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName<
          ExtremelyLongAndObnoxiousClassName,
          ExtremelyLongAndObnoxiousClassName
        >,
        ExtremelyLongAndObnoxiousClassName
      >();

    new MyExtremelyLongAndObnoxiousClassName<
      ExtremelyLongAndObnoxiousClassName<
        ExtremelyLongAndObnoxiousClassName,
        ExtremelyLongAndObnoxiousClassName
      >,
      ExtremelyLongAndObnoxiousClassName
    >()
      .method();
  }
}
```

## Relative issues or prs:

None