### PR TITLE
fix: support JLS type annotations style

### DIFF
--- a/packages/prettier-plugin-java/test/unit-test/blank_lines/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/blank_lines/_input.java
@@ -11,9 +11,15 @@ public class BlankLines {
   // Bug Fix: https://github.com/jhipster/prettier-java/issues/368
   private String fieldOne;
   private String fieldTwo;
-  private @Nullable String shouldAddLineBeforeAndAfter;
+  @Nullable private String shouldAddLineBeforeAndAfter;
   private String fieldThree;
   private String fieldFour;
+
+  private String a;
+  private String b;
+  private @Nullable String shouldNotAddBlankLines;
+  private String d;
+  private String e;
 
   public int m = 4;
   public Constructors() {

--- a/packages/prettier-plugin-java/test/unit-test/blank_lines/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/blank_lines/_output.java
@@ -16,6 +16,12 @@ public class BlankLines {
   private String fieldThree;
   private String fieldFour;
 
+  private String a;
+  private String b;
+  private @Nullable String shouldNotAddBlankLines;
+  private String d;
+  private String e;
+
   public int m = 4;
 
   public Constructors() {

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -671,8 +671,7 @@ public final class ArrayTable<R, C, V>
     return columnKeyToIndex.keySet();
   }
 
-  @MonotonicNonNull
-  private transient ColumnMap columnMap;
+  private transient @MonotonicNonNull ColumnMap columnMap;
 
   @Override
   public Map<C, Map<R, V>> columnMap() {
@@ -762,8 +761,7 @@ public final class ArrayTable<R, C, V>
     return rowKeyToIndex.keySet();
   }
 
-  @MonotonicNonNull
-  private transient RowMap rowMap;
+  private transient @MonotonicNonNull RowMap rowMap;
 
   @Override
   public Map<R, Map<C, V>> rowMap() {

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_input.java
@@ -31,6 +31,14 @@
 final @AnnotationOne static public @AnnotationTwo class ClassWithModifiers {
   transient @AnnotationOne final private @AnnotationTwo static String CONSTANT = "abc";
 
+  final @AnnotationOne static @AnnotationTwo protected @AnnotationThree String CONSTANT_2 = "123";
+
+  static @AnnotationOne public @AnnotationTwo String staticField;
+
+  public @AnnotationOne @AnnotationTwo String twoTrailingAnnotations;
+
+  @AnnotationOne String onlyAnnotations;
+
   final @AnnotationOne static @AnnotationTwo synchronized protected @AnnotationThree String method() {
     return CONSTANT;
   }

--- a/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/modifiers/_output.java
@@ -49,6 +49,18 @@ public static final class ClassWithModifiers {
 
   @AnnotationOne
   @AnnotationTwo
+  protected static final @AnnotationThree String CONSTANT_2 = "123";
+
+  @AnnotationOne
+  public static @AnnotationTwo String staticField;
+
+  public @AnnotationOne @AnnotationTwo String twoTrailingAnnotations;
+
+  @AnnotationOne
+  String onlyAnnotations;
+
+  @AnnotationOne
+  @AnnotationTwo
   protected static final synchronized @AnnotationThree String method() {
     return CONSTANT;
   }


### PR DESCRIPTION
## What changed with this PR:

Annotations placed after other modifiers on field declarations are no longer moved before all modifiers, allowing field declarations to follow JLS's formatting of type annotations the same way methods do.

## Example

### Input

```java
class Example {

  @AnotherAnnotation
  private @Nullable Object object;

  @AnotherAnnotation
  private @Nullable Object method() {
    return null;
  }
}
```

### Output

```Java
class Example {

  @AnotherAnnotation
  private @Nullable Object object;

  @AnotherAnnotation
  private @Nullable Object method() {
    return null;
  }
}
```

## Relative issues or prs:

Fix #525