### PR TITLE
fix(printer): break and indent binary expression with cast properly

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -345,15 +345,17 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
         ctx.variableInitializer![0].children.expression![0].children
           .ternaryExpression !== undefined
       ) {
-        const firstPrimary =
+        const unaryExpressions =
           ctx.variableInitializer![0].children.expression![0].children
             .ternaryExpression[0].children.binaryExpression[0].children
-            .unaryExpression[0].children.primary[0];
+            .unaryExpression;
+        const firstPrimary = unaryExpressions[0].children.primary[0];
 
         // Cast Expression
         if (
           firstPrimary.children.primaryPrefix[0].children.castExpression !==
-          undefined
+            undefined &&
+          unaryExpressions.length === 1
         ) {
           const groupId = Symbol("assignment");
           return group([

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
@@ -58,4 +58,8 @@ public class BinaryOperations {
         new Foo(stuff, thing, "auaaaaaaaaa some very long stuff", "some more").bar(10);
         foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more").bar(10);
     }
+
+  public void binaryExpressionWithCast() {
+    double availability = (double) successfulCount / (successfulCount + failureCount);
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -82,4 +82,9 @@ public class BinaryOperations {
     foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more")
       .bar(10);
   }
+
+  public void binaryExpressionWithCast() {
+    double availability =
+      (double) successfulCount / (successfulCount + failureCount);
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

Assignments containing a binary expression beginning with a cast now break and indent the way Prettier JavaScript does.

## Example

### Input

```java
public class Test {

  public static void main(String[] args) {
    if (oneLevelDeep) {
      if (twoLevelsDeep) {
        if (threeLevelsDeep) {
          int successfulCount = 0;
          int failureCount = 1;
          double availability = (double) successfulCount / (successfulCount + failureCount);
        }
      }
    }
  }
}
```

### Output

```java
public class Test {

  public static void main(String[] args) {
    if (oneLevelDeep) {
      if (twoLevelsDeep) {
        if (threeLevelsDeep) {
          int successfulCount = 0;
          int failureCount = 1;
          double availability =
            (double) successfulCount / (successfulCount + failureCount);
        }
      }
    }
  }
}
```

## Relative issues or prs:

Fix #396