### PR TITLE
ci: downgrade E2E JHipster samples

### DIFF
--- a/packages/prettier-plugin-java/scripts/clone-samples.js
+++ b/packages/prettier-plugin-java/scripts/clone-samples.js
@@ -9,7 +9,7 @@ const samplesDir = path.resolve(__dirname, "../samples");
 const core = [
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster",
@@ -28,46 +28,46 @@ const core = [
 const jhipster1 = [
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-microservice",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-oauth2",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-websocket",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-noi18n",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-hazelcast",
-    branch: "main"
+    branch: "v7.9.3"
   }
 ];
 
 const jhipster2 = [
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-elasticsearch",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-dto",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-cassandra",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-mongodb",
-    branch: "main"
+    branch: "v7.9.3"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-react",
-    branch: "main"
+    branch: "v7.9.3"
   }
 ];
 


### PR DESCRIPTION
## What changed with this PR:

All of the JHipster repositories that this project uses as samples for its E2E tests had their main branches updated last week with 2 breaking changes:

1. They now require Java 17 to build.
2. Their `mvnw` script is no longer executable (@pascalgrimaud apologies for the notification, but I thought JHipster might want to be made aware of this issue, as I assume this was changed by mistake).

Both of these changes broke this repository's CI checks. The first change would be easy enough for us to resolve, we can simply upgrade the version of Java in `github-ci.yml`. However, the second change is not as easy for us to fix, nor should we have to fix it here, so we'll likely need to wait until those other repositories are updated to re-set the executable bit on their `mvnw` script.

To work around this issue while we wait, this PR downgrades the E2E JHipster samples to the latest working tag.