### PR TITLE
feat: adjust text block indentation

### DIFF
--- a/packages/prettier-plugin-java/src/printers/lexical-structure.ts
+++ b/packages/prettier-plugin-java/src/printers/lexical-structure.ts
@@ -1,4 +1,5 @@
 import { printTokenWithComments } from "./comments/format-comments";
+import { join } from "./prettier-builder";
 import { BaseCstPrettierPrinter } from "../base-cst-printer";
 import {
   BooleanLiteralCtx,
@@ -7,10 +8,24 @@ import {
   IToken,
   LiteralCtx
 } from "java-parser";
+import { builders } from "prettier/doc";
+
+const { hardline } = builders;
 
 export class LexicalStructurePrettierVisitor extends BaseCstPrettierPrinter {
   literal(ctx: LiteralCtx) {
-    if (ctx.CharLiteral || ctx.TextBlock || ctx.StringLiteral || ctx.Null) {
+    if (ctx.TextBlock) {
+      const lines = ctx.TextBlock[0].image.split("\n");
+      const open = lines.shift()!;
+      const baseIndent = Math.min(
+        ...lines.map(line => line.search(/\S/)).filter(indent => indent >= 0)
+      );
+      return join(hardline, [
+        open,
+        ...lines.map(line => line.slice(baseIndent))
+      ]);
+    }
+    if (ctx.CharLiteral || ctx.StringLiteral || ctx.Null) {
       return printTokenWithComments(this.getSingle(ctx) as IToken);
     }
     return this.visitSingle(ctx);

--- a/packages/prettier-plugin-java/test/unit-test/text-blocks/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/text-blocks/_input.java
@@ -24,6 +24,27 @@ public class TextBlock {
                   </body>\r
               </html>\r
               """;
+
+    System.out.println(
+      // leading comment
+        """
+               abaoeu
+                 euaoeu
+              aoeu
+
+               oaeu
+                    abc""" // trailing comment
+    );
+
+    System.out.println(
+        """
+ abaoeu
+   euaoeu
+aoeu
+
+ oaeu
+      abc"""
+    );
   }
 
 }

--- a/packages/prettier-plugin-java/test/unit-test/text-blocks/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/text-blocks/_output.java
@@ -1,30 +1,50 @@
 public class TextBlock {
 
   void method() {
-    String myTextBlock = """
-         my text
+    String myTextBlock =
+      """
+           my text
 
 
-    sentence\"""
+      sentence\"""
 
-    """;
+      """;
 
     String source =
       """
-                public void print(%s object) {
-                    System.out.println(Objects.toString(object));
-                }
-                """.formatted(
-          type
-        );
+      public void print(%s object) {
+          System.out.println(Objects.toString(object));
+      }
+      """.formatted(type);
 
     String html =
       """
-              <html>\r
-                  <body>\r
-                      <p>Hello, world</p>\r
-                  </body>\r
-              </html>\r
-              """;
+      <html>\r
+          <body>\r
+              <p>Hello, world</p>\r
+          </body>\r
+      </html>\r
+      """;
+
+    System.out.println(
+      // leading comment
+      """
+       abaoeu
+         euaoeu
+      aoeu
+
+       oaeu
+            abc""" // trailing comment
+    );
+
+    System.out.println(
+      """
+       abaoeu
+         euaoeu
+      aoeu
+
+       oaeu
+            abc"""
+    );
   }
 }


### PR DESCRIPTION
## What changed with this PR:

Text blocks are now split by lines when printing, with the "base indentation" removed, so that they are indented more logically by Prettier.

## Example

### Input

```java
class Example {

  void example() {
    System.out.println(
      // leading comment
        """
               abaoeu
                 euaoeu
              aoeu

               oaeu
                    abc""" // trailing comment
    );

    System.out.println(
        """
 abaoeu
   euaoeu
aoeu

 oaeu
      abc"""
    );
  }
}
```

### Output

```java
class Example {

  void example() {
    System.out.println(
      // leading comment
      """
       abaoeu
         euaoeu
      aoeu

       oaeu
            abc""" // trailing comment
    );

    System.out.println(
      """
       abaoeu
         euaoeu
      aoeu

       oaeu
            abc"""
    );
  }
}
```

## Relative issues or prs:

Closes #593