### PR TITLE
fix(parser): Correctly detect `process`

### DIFF
--- a/packages/java-parser/src/utils.js
+++ b/packages/java-parser/src/utils.js
@@ -10,7 +10,7 @@
  */
 function getSkipValidations() {
   return (
-    (process && // (not every runtime has a global `process` object
+    (typeof process !== "undefined" && // (not every runtime has a global `process` object
       process.env &&
       process.env["prettier-java-development-mode"] === "enabled") === false
   );


### PR DESCRIPTION
## What changed with this PR:

In JavaScript, it is a common mistake to check if a variable exists by directly referencing it. 
The correct way to do this is to use the `typeof` operator.

## Example

N/A

## Relative issues or prs:

- fix #597 