### PR TITLE
chore: fix plugin README's banner URL

### DIFF
--- a/packages/prettier-plugin-java/README.md
+++ b/packages/prettier-plugin-java/README.md
@@ -2,7 +2,7 @@
 
 # prettier-plugin-java
 
-![Prettier Java Banner](https://raw.githubusercontent.com/jhipster/prettier-java/master/logo/prettier-java-banner-light.svg)
+![Prettier Java Banner](https://raw.githubusercontent.com/jhipster/prettier-java/main/logo/prettier-java-banner-light.svg)
 
 Prettier is an opinionated code formatter which forces a certain coding style. It makes the code consistent through an entire project.
 


### PR DESCRIPTION
## What changed with this PR:

I entered the incorrect main branch name in the banner URL I added to the plugin's README in #590. This PR fixes the branch name in that URL.

## Relative issues or prs:

#590