### PR TITLE
fix: correct indentation of assignment operations

### DIFF
--- a/packages/prettier-plugin-java/src/printers/printer-utils.ts
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.ts
@@ -659,7 +659,8 @@ export function binary(nodes: Doc[], tokens: IToken[], isRoot = false): Doc {
     }
   }
   level.push(nodes.shift()!);
-  return group(join(line, level));
+  const content = group(join(line, level));
+  return levelOperator === "=" ? indent(content) : content;
 }
 
 function getOperator(tokens: IToken[]) {

--- a/packages/prettier-plugin-java/test/unit-test/variables/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_input.java
@@ -185,4 +185,21 @@ public class Variables {
         someRandomMethodThatReturnsTheInitialMapThatWeWantToMutate()
       );
   }
+
+  void assignment() {
+    fileSystemDetails =
+      FileHandlerDetails
+        .builder()
+        .fileSystemType(
+          EntityUtils.update(
+            entity.getFileSystemDetails().getFileSystemType(),
+            update.getFileSystemDetails().getFileSystemType()
+          )
+        );
+
+    aaaaaaaaaaaaaaaaa =
+      bbbbbbbbbbbbbbbbb ? ccccccccccccccccc : ddddddddddddddddd;
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = ccccccccccccccccccccccccccccccccccccccc + ddddddddddddddddddddddddddddddddd;
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/variables/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_output.java
@@ -325,4 +325,24 @@ public class Variables {
         someRandomMethodThatReturnsTheInitialMapThatWeWantToMutate()
       );
   }
+
+  void assignment() {
+    fileSystemDetails =
+      FileHandlerDetails
+        .builder()
+        .fileSystemType(
+          EntityUtils.update(
+            entity.getFileSystemDetails().getFileSystemType(),
+            update.getFileSystemDetails().getFileSystemType()
+          )
+        );
+
+    aaaaaaaaaaaaaaaaa =
+      bbbbbbbbbbbbbbbbb ? ccccccccccccccccc : ddddddddddddddddd;
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
+        ccccccccccccccccccccccccccccccccccccccc +
+        ddddddddddddddddddddddddddddddddd;
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

Non-declarative assignment operations now indent properly again.

## Example

### Input
```java
class Example {

  void example() {
    fileSystemDetails =
      FileHandlerDetails
        .builder()
        .fileSystemType(
          EntityUtils.update(
            entity.getFileSystemDetails().getFileSystemType(),
            update.getFileSystemDetails().getFileSystemType()
          )
        );

    aaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbb ? ccccccccccccccccc : ddddddddddddddddd;

    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = ccccccccccccccccccccccccccccccccccccccc + ddddddddddddddddddddddddddddddddd;
  }
}
```

### Output
```java
class Example {

  void example() {
    fileSystemDetails =
      FileHandlerDetails
        .builder()
        .fileSystemType(
          EntityUtils.update(
            entity.getFileSystemDetails().getFileSystemType(),
            update.getFileSystemDetails().getFileSystemType()
          )
        );

    aaaaaaaaaaaaaaaaa =
      bbbbbbbbbbbbbbbbb ? ccccccccccccccccc : ddddddddddddddddd;

    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
        ccccccccccccccccccccccccccccccccccccccc +
        ddddddddddddddddddddddddddddddddd;
  }
}
```

## Relative issues or prs:

Closes #601