### PR TITLE
fix(parser): no longer ignore whole block when prettier-ignore at start

### DIFF
--- a/packages/java-parser/src/comments.js
+++ b/packages/java-parser/src/comments.js
@@ -238,7 +238,12 @@ function attachComments(
       // prettier ignore support
       for (let i = 0; i < nodeLeadingComments.length; i++) {
         if (isPrettierIgnoreComment(nodeLeadingComments[i])) {
-          mostEnclosiveCstNodeByStartOffset[startOffset].ignore = true;
+          const node = mostEnclosiveCstNodeByStartOffset[startOffset];
+          const ignoreNode =
+            node.name === "blockStatements"
+              ? node.children.blockStatement[0]
+              : node;
+          ignoreNode.ignore = true;
           break;
         }
       }

--- a/packages/prettier-plugin-java/test/unit-test/prettier-ignore/block/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/prettier-ignore/block/_input.java
@@ -1,0 +1,19 @@
+package tech.jhipster;
+
+import java.util.Map;
+
+public class StrangePrettierIgnore {
+
+  private StrangePrettierIgnore() {}
+
+  public static void drinkBeers() {
+    // prettier-ignore
+    Map<String, String> beers = Map.of(
+      "beer1", "Gulden Draak",
+      "beer2", "Piraat",
+      "beer3", "Kapittel"
+    );
+
+           System.out.println(beers); // not well formated here
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/prettier-ignore/block/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/prettier-ignore/block/_output.java
@@ -1,0 +1,19 @@
+package tech.jhipster;
+
+import java.util.Map;
+
+public class StrangePrettierIgnore {
+
+  private StrangePrettierIgnore() {}
+
+  public static void drinkBeers() {
+    // prettier-ignore
+    Map<String, String> beers = Map.of(
+      "beer1", "Gulden Draak",
+      "beer2", "Piraat",
+      "beer3", "Kapittel"
+    );
+
+    System.out.println(beers); // not well formated here
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/prettier-ignore/prettier-ignore-spec.ts
+++ b/packages/prettier-plugin-java/test/unit-test/prettier-ignore/prettier-ignore-spec.ts
@@ -2,6 +2,7 @@ import { testSample } from "../../test-utils";
 import * as path from "path";
 
 describe("prettier-java: try catch", () => {
+  testSample(path.resolve(__dirname, "./block"));
   testSample(path.resolve(__dirname, "./classDeclaration"));
   testSample(path.resolve(__dirname, "./method"));
   testSample(path.resolve(__dirname, "./multiple-ignore"));


### PR DESCRIPTION
## What changed with this PR:

When a block begins with `// prettier-ignore`, only the first statement is ignored, rather than the whole block.

## Example

### Input

```java
package tech.jhipster;

import java.util.Map;

public class StrangePrettierIgnore {

  private StrangePrettierIgnore() {}

  public static void drinkBeers() {
    // prettier-ignore
    Map<String, String> beers = Map.of(
      "beer1", "Gulden Draak",
      "beer2", "Piraat",
      "beer3", "Kapittel"
    );

           System.out.println(beers); // not well formated here
  }
}
```

### Output

```java
package tech.jhipster;

import java.util.Map;

public class StrangePrettierIgnore {

  private StrangePrettierIgnore() {}

  public static void drinkBeers() {
    // prettier-ignore
    Map<String, String> beers = Map.of(
      "beer1", "Gulden Draak",
      "beer2", "Piraat",
      "beer3", "Kapittel"
    );

    System.out.println(beers); // not well formated here
  }
}
```

## Relative issues or prs:

Closes #505