### PR TITLE
fix: separate binary expression from pattern

### DIFF
--- a/packages/java-parser/api.d.ts
+++ b/packages/java-parser/api.d.ts
@@ -3498,8 +3498,6 @@ export interface PatternCstNode extends CstNode {
 
 export type PatternCtx = {
   primaryPattern: PrimaryPatternCstNode[];
-  AndAnd?: IToken[];
-  binaryExpression?: BinaryExpressionCstNode[];
 };
 
 export interface PrimaryPatternCstNode extends CstNode {

--- a/packages/java-parser/src/productions/blocks-and-statements.js
+++ b/packages/java-parser/src/productions/blocks-and-statements.js
@@ -245,10 +245,6 @@ function defineRules($, t) {
       { ALT: () => $.CONSUME(t.Null) },
       { ALT: () => $.CONSUME(t.Default) },
       {
-        GATE: () => this.BACKTRACK_LOOKAHEAD($.pattern),
-        ALT: () => $.SUBRULE($.pattern)
-      },
-      {
         GATE: () => tokenMatcher($.LA(1).tokenType, t.Null) === false,
         ALT: () => $.SUBRULE($.caseConstant)
       }

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -116,17 +116,23 @@ function defineRules($, t) {
   });
 
   $.RULE("binaryExpression", () => {
-    $.SUBRULE($.unaryExpression);
+    $.OR([
+      {
+        GATE: () => this.BACKTRACK_LOOKAHEAD($.pattern),
+        ALT: () => $.SUBRULE($.pattern)
+      },
+      { ALT: () => $.SUBRULE($.unaryExpression) }
+    ]);
     $.MANY(() => {
-      $.OR({
+      $.OR1({
         DEF: [
           {
             ALT: () => {
               $.CONSUME(t.Instanceof);
-              $.OR1([
+              $.OR2([
                 {
                   GATE: () => this.BACKTRACK_LOOKAHEAD($.pattern),
-                  ALT: () => $.SUBRULE($.pattern)
+                  ALT: () => $.SUBRULE2($.pattern)
                 },
                 {
                   ALT: () => $.SUBRULE($.referenceType)
@@ -150,7 +156,7 @@ function defineRules($, t) {
               tokenMatcher($.LA(2).tokenType, t.Less) ||
               tokenMatcher($.LA(2).tokenType, t.Greater),
             ALT: () => {
-              $.OR2([
+              $.OR3([
                 {
                   GATE: () => $.LA(1).startOffset + 1 === $.LA(2).startOffset,
                   ALT: () => {
@@ -563,10 +569,6 @@ function defineRules($, t) {
 
   $.RULE("pattern", () => {
     $.SUBRULE($.primaryPattern);
-    $.OPTION(() => {
-      $.CONSUME(t.AndAnd);
-      $.SUBRULE($.binaryExpression);
-    });
   });
 
   $.RULE("primaryPattern", () => {

--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
@@ -336,7 +336,12 @@ export class BlocksAndStatementPrettierVisitor extends BaseCstPrettierPrinter {
   }
 
   caseConstant(ctx: CaseConstantCtx) {
-    return this.visitSingle(ctx);
+    const constant = this.visitSingle(ctx);
+    const isParenthesisExpression =
+      ctx.ternaryExpression[0].children.binaryExpression[0].children
+        .unaryExpression?.[0].children.primary[0].children.primaryPrefix[0]
+        .children.parenthesisExpression !== undefined;
+    return isParenthesisExpression ? dedent(constant) : constant;
   }
 
   whileStatement(ctx: WhileStatementCtx) {

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -715,19 +715,7 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
   }
 
   pattern(ctx: PatternCtx) {
-    const primaryPattern = this.visit(ctx.primaryPattern);
-    if (ctx.AndAnd === undefined) {
-      return primaryPattern;
-    }
-
-    const binaryExpression = this.visit(ctx.binaryExpression);
-    return rejectAndConcat([
-      primaryPattern,
-      " ",
-      ctx.AndAnd[0],
-      line,
-      binaryExpression
-    ]);
+    return this.visit(ctx.primaryPattern);
   }
 
   primaryPattern(ctx: PrimaryPatternCtx) {

--- a/packages/prettier-plugin-java/test/unit-test/pattern-matching/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/pattern-matching/_input.java
@@ -13,6 +13,10 @@ class T {
         return formatted;
     }
 
+    public boolean test(final Object obj) {
+        return obj instanceof final Integer x && (x == 5 || x == 6 || x == 7 || x == 8 || x == 9 || x == 10 || x == 11);
+    }
+
     void test(Buyer other) {
         return switch (other) {
             case null -> true;

--- a/packages/prettier-plugin-java/test/unit-test/pattern-matching/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/pattern-matching/_output.java
@@ -19,6 +19,13 @@ class T {
     return formatted;
   }
 
+  public boolean test(final Object obj) {
+    return (
+      obj instanceof final Integer x &&
+      (x == 5 || x == 6 || x == 7 || x == 8 || x == 9 || x == 10 || x == 11)
+    );
+  }
+
   void test(Buyer other) {
     return switch (other) {
       case null -> true;
@@ -39,20 +46,16 @@ class T {
         this.bestPrice > b.bestPrice -> {
         return true;
       }
-      case (
-          Buyer b &&
-          this.bestPrice > b.bestPrice &&
-          this.bestPrice > b.bestPrice &&
-          this.bestPrice > b.bestPrice &&
-          this.bestPrice > b.bestPrice
-        ) -> true;
-      case (
-          Buyer b &&
-          this.bestPrice > b.bestPrice &&
-          this.bestPrice > b.bestPrice &&
-          this.bestPrice > b.bestPrice &&
-          this.bestPrice > b.bestPrice
-        ) -> {
+      case (Buyer b &&
+        this.bestPrice > b.bestPrice &&
+        this.bestPrice > b.bestPrice &&
+        this.bestPrice > b.bestPrice &&
+        this.bestPrice > b.bestPrice) -> true;
+      case (Buyer b &&
+        this.bestPrice > b.bestPrice &&
+        this.bestPrice > b.bestPrice &&
+        this.bestPrice > b.bestPrice &&
+        this.bestPrice > b.bestPrice) -> {
         return true;
       }
       default -> false;


### PR DESCRIPTION
## What changed with this PR:

Rather than treating the optional binary expression following a pattern as part of the pattern itself, treat the entire expression as a binary expression, of which the pattern is a part, so that the usual binary expression formatting applies.

## Example

### Input

```java
class Example {

  public boolean test(final Object obj) {
    return obj instanceof final Integer x && (x == 5 || x == 6 || x == 7 || x == 8 || x == 9 || x == 10 || x == 11);
  }
}
```

### Output

```java
class Example {

  public boolean test(final Object obj) {
    return (
      obj instanceof final Integer x &&
      (x == 5 || x == 6 || x == 7 || x == 8 || x == 9 || x == 10 || x == 11)
    );
  }
}
```

## Relative issues or prs:

Closes #605