### PR TITLE
Support receiver parameter in method declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .DS_Store
 coverage
 .idea
+*.iml
+dist/

--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -359,11 +359,23 @@ function defineRules($, t) {
   $.RULE("methodDeclarator", () => {
     $.CONSUME(t.Identifier);
     $.CONSUME(t.LBrace);
-    $.OPTION(() => {
+    $.OPTION({
+      // a "formalParameterList" and a "receiverParameter"
+      // cannot be distinguished using fixed lookahead.
+      GATE: $.BACKTRACK($.receiverParameter),
+      DEF: () => {
+        $.SUBRULE($.receiverParameter);
+        $.OPTION2({
+          GATE: () => $.LA(1).tokenType !== t.RBrace,
+          DEF: () => $.CONSUME(t.Comma)
+        });
+      }
+    });
+    $.OPTION3(() => {
       $.SUBRULE($.formalParameterList);
     });
     $.CONSUME(t.RBrace);
-    $.OPTION2(() => {
+    $.OPTION4(() => {
       $.SUBRULE($.dims);
     });
   });
@@ -508,10 +520,13 @@ function defineRules($, t) {
       GATE: $.BACKTRACK($.receiverParameter),
       DEF: () => {
         $.SUBRULE($.receiverParameter);
-        $.CONSUME(t.Comma);
+        $.OPTION3({
+          GATE: () => $.LA(1).tokenType !== t.RBrace,
+          DEF: () => $.CONSUME(t.Comma)
+        });
       }
     });
-    $.OPTION3(() => {
+    $.OPTION4(() => {
       $.SUBRULE($.formalParameterList);
     });
     $.CONSUME(t.RBrace);

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -99,4 +99,19 @@ describe("The Java Parser fixed bugs", () => {
       expect(() => javaParser.parse(input, "statement")).to.not.throw();
     });
   });
+
+  it("issue #607 - should support receiver parameter", () => {
+    const input = `
+      class Foo {
+          public Foo(Foo this) {}
+          public Foo(Foo this, int x) {}
+          public void bar(Foo this) {}
+          public void bar(Foo this, int y) {}
+          public void baz(@SomeAnnot Foo this) {}
+          public void baz(@SomeAnnot Foo this, int y) {}
+      }
+    `;
+
+    expect(() => javaParser.parse(input, "classDeclaration")).to.not.throw();
+  });
 });


### PR DESCRIPTION
## What changed with this PR:

As it says on the tin

## Example

```java
    class Foo {
        public void bar(Foo this) {
            // noop
        }
        public void bar(Foo this, int y) {
            // noop
        }
    }
```

## Relative issues or prs:

Fixes #607