### PR TITLE
chore: upgrade pipeline tests to JHipster 8, Java 17, and Node.js 18/20

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -8,17 +8,17 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 14.x
-          - 16.x
           - 18.x
+          - 20.x
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '11.x'
+          java-version: 17.x
+          distribution: zulu
       - name: Install dependencies
         run: yarn
       - name: Run CI
@@ -33,15 +33,16 @@ jobs:
         test_repository:
           - e2e-jhipster1
           - e2e-jhipster2
-        node_version: [14.x]
+        node_version: [18.x]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '11.x'
+          java-version: 17.x
+          distribution: zulu
       - name: Install dependencies
         run: yarn
       - name: Build prettier-plugin-java

--- a/packages/java-parser/scripts/clone-samples.js
+++ b/packages/java-parser/scripts/clone-samples.js
@@ -9,76 +9,76 @@ const samplesDir = path.resolve(__dirname, "../samples");
 const sampleRepos = [
   {
     repoUrl: "https://github.com/iluwatar/java-design-patterns.git",
-    branch: "1.20.0"
+    branch: "1.25.0"
   },
   {
     repoUrl: "https://github.com/spring-projects/spring-boot.git",
-    branch: "v2.1.0.RELEASE"
+    branch: "v3.1.5"
   },
   {
     repoUrl: "https://github.com/google/guava.git",
-    branch: "v27.0.1"
+    branch: "v32.1.3"
   },
   {
     repoUrl: "https://github.com/spring-projects/spring-framework.git",
-    branch: "v5.1.5.RELEASE"
+    branch: "v6.0.13"
   },
   {
-    repoUrl: "https://github.com/jhipster/jhipster",
-    branch: "main"
+    repoUrl: "https://github.com/jhipster/jhipster-bom",
+    branch: "8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-online",
-    branch: "main"
+    branch: "v2.25.0"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-microservice",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-oauth2",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-websocket",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-noi18n",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-hazelcast",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
 
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-elasticsearch",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-dto",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-cassandra",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-mongodb",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-gradle",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-react",
-    branch: "main"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/nipafx/demo-java-x",

--- a/packages/java-parser/test/samples-spec.js
+++ b/packages/java-parser/test/samples-spec.js
@@ -11,7 +11,7 @@ describe("The Java Parser", () => {
   createSampleSpecs("java-design-patterns");
   createSampleSpecs("spring-boot");
   createSampleSpecs("spring-framework");
-  createSampleSpecs("jhipster");
+  createSampleSpecs("jhipster-bom");
   createSampleSpecs("jhipster-online");
   createSampleSpecs("jhipster-sample-app");
   createSampleSpecs("jhipster-sample-app-cassandra");

--- a/packages/prettier-plugin-java/scripts/clone-samples.js
+++ b/packages/prettier-plugin-java/scripts/clone-samples.js
@@ -9,65 +9,65 @@ const samplesDir = path.resolve(__dirname, "../samples");
 const core = [
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
-    repoUrl: "https://github.com/jhipster/jhipster",
-    branch: "main"
+    repoUrl: "https://github.com/jhipster/jhipster-bom",
+    branch: "8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/spring-projects/spring-boot.git",
-    branch: "v2.1.0.RELEASE"
+    branch: "v3.1.5"
   },
   {
     repoUrl: "https://github.com/iluwatar/java-design-patterns.git",
-    branch: "1.20.0"
+    branch: "1.25.0"
   }
 ];
 
 const jhipster1 = [
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-microservice",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-oauth2",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-websocket",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-noi18n",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-hazelcast",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   }
 ];
 
 const jhipster2 = [
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-elasticsearch",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-dto",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-cassandra",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-mongodb",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   },
   {
     repoUrl: "https://github.com/jhipster/jhipster-sample-app-react",
-    branch: "v7.9.3"
+    branch: "v8.0.0-rc.1"
   }
 ];
 

--- a/packages/prettier-plugin-java/test/repository-test/core-test.ts
+++ b/packages/prettier-plugin-java/test/repository-test/core-test.ts
@@ -1,7 +1,7 @@
 import { resolve } from "path";
 import { testRepositorySample } from "../test-utils";
 
-const jhipsterRepository = ["jhipster", "jhipster-sample-app"];
+const jhipsterRepository = ["jhipster-bom", "jhipster-sample-app"];
 
 describe("prettier-java", () => {
   testRepositorySample(
@@ -12,8 +12,8 @@ describe("prettier-java", () => {
 
   testRepositorySample(
     resolve(__dirname, "../../samples/spring-boot"),
-    "./mvnw",
-    ["clean", "install", "-Ddisable.checks", "-DskipTests"]
+    "./gradlew",
+    ["clean", "build", "-Ddisable.checks", "-xtest", "--no-scan"]
   );
 
   jhipsterRepository.forEach(repository => {

--- a/packages/prettier-plugin-java/test/test-utils.ts
+++ b/packages/prettier-plugin-java/test/test-utils.ts
@@ -115,7 +115,8 @@ export function testRepositorySample(
       });
       if (code.status !== 0) {
         expect.fail(
-          `Cannot build ${testFolder}, please check the output below:\n ${code.stdout.toString()}`
+          `Cannot build ${testFolder}, please check the output below:\n` +
+            code.error ?? code.stderr
         );
       }
     });


### PR DESCRIPTION
## What changed with this PR:

Upgrades the pipeline tests to JHipster 8, Java 17, and Node.js 18/20. Also upgraded GitHub Actions and repos used for testing to their latest versions (some were necessary upgrades, such as Spring Boot/Framework, others were not).

## Relative issues or prs:

Closes #609