### PR TITLE
Support unnamed class compilation unit

### DIFF
--- a/packages/java-parser/api.d.ts
+++ b/packages/java-parser/api.d.ts
@@ -1969,9 +1969,11 @@ export interface TypeDeclarationCstNode extends CstNode {
 }
 
 export type TypeDeclarationCtx = {
+  Semicolon?: IToken[];
   classDeclaration?: ClassDeclarationCstNode[];
   interfaceDeclaration?: InterfaceDeclarationCstNode[];
-  Semicolon?: IToken[];
+  fieldDeclaration?: FieldDeclarationCstNode[];
+  methodDeclaration?: MethodDeclarationCstNode[];
 };
 
 export interface ModuleDeclarationCstNode extends CstNode {

--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { isRecognitionException, tokenMatcher } = require("chevrotain");
+const { classBodyTypes } = require("./utils/class-body-types");
 
 function defineRules($, t) {
   // https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-ClassDeclaration
@@ -109,18 +110,6 @@ function defineRules($, t) {
     });
     $.CONSUME(t.RCurly);
   });
-
-  const classBodyTypes = {
-    unknown: 0,
-    fieldDeclaration: 1,
-    methodDeclaration: 2,
-    classDeclaration: 3,
-    interfaceDeclaration: 4,
-    semiColon: 5,
-    instanceInitializer: 6,
-    staticInitializer: 7,
-    constructorDeclaration: 8
-  };
 
   // https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-ClassBodyDeclaration
   $.RULE("classBodyDeclaration", () => {

--- a/packages/java-parser/src/productions/packages-and-modules.js
+++ b/packages/java-parser/src/productions/packages-and-modules.js
@@ -3,7 +3,6 @@ const { isRecognitionException, tokenMatcher, EOF } = require("chevrotain");
 const { classBodyTypes } = require("./utils/class-body-types");
 
 function defineRules($, t) {
-
   /**
    * Spec Deviation: As OrdinaryCompilationUnit and UnnamedClassCompilationUnit
    * both can have multiple class or interface declarations, both were combined
@@ -103,7 +102,6 @@ function defineRules($, t) {
       }
     ]);
   });
-
 
   /**
    * Spec Deviation: As OrdinaryCompilationUnit and UnnamedClassCompilationUnit

--- a/packages/java-parser/src/productions/utils/class-body-types.js
+++ b/packages/java-parser/src/productions/utils/class-body-types.js
@@ -14,4 +14,4 @@ const classBodyTypes = {
 
 module.exports = {
   classBodyTypes
-}
+};

--- a/packages/java-parser/src/productions/utils/class-body-types.js
+++ b/packages/java-parser/src/productions/utils/class-body-types.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const classBodyTypes = {
+  unknown: 0,
+  fieldDeclaration: 1,
+  methodDeclaration: 2,
+  classDeclaration: 3,
+  interfaceDeclaration: 4,
+  semiColon: 5,
+  instanceInitializer: 6,
+  staticInitializer: 7,
+  constructorDeclaration: 8
+};
+
+module.exports = {
+  classBodyTypes
+}

--- a/packages/java-parser/test/compilation-unit/unnamed-class-compilation-unit-spec.js
+++ b/packages/java-parser/test/compilation-unit/unnamed-class-compilation-unit-spec.js
@@ -10,6 +10,7 @@ describe("Unnamed Class Compilation Unit", () => {
           System.out.println("Hello, World!");
       }
     `;
+    javaParser.parse(input, "compilationUnit");
     expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
@@ -19,7 +20,7 @@ describe("Unnamed Class Compilation Unit", () => {
           System.out.println("Hello, World!");
       }
     `;
-    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
   it("should handle UnnamedClassCompilationUnit with fields", () => {
@@ -32,7 +33,7 @@ describe("Unnamed Class Compilation Unit", () => {
           System.out.println(hourra);
       }
     `;
-    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
   it("should handle UnnamedClassCompilationUnit with class declaration", () => {
@@ -43,7 +44,7 @@ describe("Unnamed Class Compilation Unit", () => {
           System.out.println(Test.greetings());
       }
     `;
-    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
   it("should handle UnnamedClassCompilationUnit with interface declaration", () => {
@@ -54,7 +55,7 @@ describe("Unnamed Class Compilation Unit", () => {
           System.out.println(Test.greetings());
       }
     `;
-    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
   it("should handle UnnamedClassCompilationUnit with semicolons", () => {
@@ -65,7 +66,7 @@ describe("Unnamed Class Compilation Unit", () => {
           System.out.println("Hello World!");
       }
     `;
-    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
   it("should handle UnnamedClassCompilationUnit with class member declarations", () => {
@@ -77,7 +78,7 @@ describe("Unnamed Class Compilation Unit", () => {
       }
     `;
 
-    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 
   it("should handle UnnamedClassCompilationUnit with imports", () => {
@@ -90,6 +91,6 @@ describe("Unnamed Class Compilation Unit", () => {
       }
     `;
 
-    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
   });
 });

--- a/packages/java-parser/test/compilation-unit/unnamed-class-compilation-unit-spec.js
+++ b/packages/java-parser/test/compilation-unit/unnamed-class-compilation-unit-spec.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const { expect } = require("chai");
+const javaParser = require("../../src/index");
+
+describe("Unnamed Class Compilation Unit", () => {
+  it("should handle UnnamedClassCompilationUnit", () => {
+    const input = `
+      void main() {
+          System.out.println("Hello, World!");
+      }
+    `;
+    expect(() => javaParser.parse(input, "compilationUnit")).to.not.throw();
+  });
+
+  it("should handle UnnamedClassCompilationUnit with only method", () => {
+    const input = `
+      void main() {
+          System.out.println("Hello, World!");
+      }
+    `;
+    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+  });
+
+  it("should handle UnnamedClassCompilationUnit with fields", () => {
+    const input = `
+      String greeting = "Hello world!";
+      String hourra = "Hourra!";
+
+      void main() {
+          System.out.println(greeting);
+          System.out.println(hourra);
+      }
+    `;
+    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+  });
+
+  it("should handle UnnamedClassCompilationUnit with class declaration", () => {
+    const input = `
+      class Test { static String greetings() { return "Hello world!"; } }
+
+      void main() {
+          System.out.println(Test.greetings());
+      }
+    `;
+    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+  });
+
+  it("should handle UnnamedClassCompilationUnit with interface declaration", () => {
+    const input = `
+      interface Test { default String greetings() { return "Hello world!"; } }
+
+      void main() {
+          System.out.println(Test.greetings());
+      }
+    `;
+    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+  });
+
+  it("should handle UnnamedClassCompilationUnit with semicolons", () => {
+    const input = `
+      ;
+
+      void main() {
+          System.out.println("Hello World!");
+      }
+    `;
+    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+  });
+
+  it("should handle UnnamedClassCompilationUnit with class member declarations", () => {
+    const input = `
+      String greeting() { return "Hello, World!"; }
+
+      void main() {
+          System.out.println(greeting());
+      }
+    `;
+
+    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+  });
+
+  it("should handle UnnamedClassCompilationUnit with imports", () => {
+    const input = `
+      import com.toto.titi.Test;
+      import com.toto.titi.Toast;
+
+      void main() {
+          System.out.println(Test.greeting());
+      }
+    `;
+
+    expect(() => javaParser.parse(input, "unnamedClassCompilationUnit")).to.not.throw();
+  });
+});

--- a/packages/prettier-plugin-java/test/unit-test/unnamed-class-compilation-unit/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/unnamed-class-compilation-unit/_input.java
@@ -1,0 +1,12 @@
+import com.toto.titi.Test;
+import com.toto.titi.Toast;
+
+class TestClass { static String greetings() { return "Hello world!"; } }
+interface TestInterface { default String greetings() { return "Hello world!"; } }
+
+;
+String greeting() { return "Hello, World!"; }
+
+void main() {
+  System.out.println(Test.greeting());
+}

--- a/packages/prettier-plugin-java/test/unit-test/unnamed-class-compilation-unit/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/unnamed-class-compilation-unit/_output.java
@@ -1,0 +1,23 @@
+import com.toto.titi.Test;
+import com.toto.titi.Toast;
+
+class TestClass {
+
+  static String greetings() {
+    return "Hello world!";
+  }
+}
+
+interface TestInterface {
+  default String greetings() {
+    return "Hello world!";
+  }
+}
+
+String greeting() {
+  return "Hello, World!";
+}
+
+void main() {
+  System.out.println(Test.greeting());
+}

--- a/packages/prettier-plugin-java/test/unit-test/unnamed-class-compilation-unit/unnamed-class-compilation-unit-spec.ts
+++ b/packages/prettier-plugin-java/test/unit-test/unnamed-class-compilation-unit/unnamed-class-compilation-unit-spec.ts
@@ -1,0 +1,5 @@
+import { testSample } from "../../test-utils";
+
+describe("prettier-java: Unnamed Class Compilation Unit", () => {
+  testSample(__dirname);
+});


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

## Example

```java
// Input
import com.toto.titi.Test;
import com.toto.titi.Toast;

class TestClass { static String greetings() { return "Hello world!"; } }
interface TestInterface { default String greetings() { return "Hello world!"; } }

;
String greeting() { return "Hello, World!"; }

void main() {
  System.out.println(Test.greeting());
}

// Output
import com.toto.titi.Test;
import com.toto.titi.Toast;

class TestClass {

  static String greetings() {
    return "Hello world!";
  }
}

interface TestInterface {
  default String greetings() {
    return "Hello world!";
  }
}

String greeting() {
  return "Hello, World!";
}

void main() {
  System.out.println(Test.greeting());
}

```

## Relative issues or prs:

Closes: #614 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
