### PR TITLE
chore: use specific version for demo-java-x repo parsing

### DIFF
--- a/packages/java-parser/scripts/clone-samples.js
+++ b/packages/java-parser/scripts/clone-samples.js
@@ -82,7 +82,8 @@ const sampleRepos = [
   },
   {
     repoUrl: "https://github.com/nipafx/demo-java-x",
-    branch: "main"
+    branch: "main",
+    commitHash: "b9facd7bae57512793af4e197446d8064318bf04"
   }
 ];
 
@@ -90,10 +91,21 @@ fs.emptyDirSync(samplesDir);
 
 sampleRepos.forEach(cloneRepo);
 
-function cloneRepo({ repoUrl, branch }) {
+function cloneRepo({ repoUrl, branch, commitHash }) {
   console.log(`cloning ${repoUrl}`);
-  cp.execSync(`git clone ${repoUrl} --branch ${branch} --depth 1`, {
-    cwd: samplesDir,
-    stdio: [0, 1, 2]
-  });
+  if (commitHash) {
+    cp.execSync(`git clone ${repoUrl} --branch ${branch}`, {
+      cwd: samplesDir,
+      stdio: [0, 1, 2]
+    });
+    cp.execSync(`git checkout ${commitHash}`, {
+      cwd: path.resolve(samplesDir, repoUrl.split("/").pop()),
+      stdio: [0, 1, 2]
+    });
+  } else {
+    cp.execSync(`git clone ${repoUrl} --branch ${branch} --depth 1`, {
+      cwd: samplesDir,
+      stdio: [0, 1, 2]
+    });
+  }
 }


### PR DESCRIPTION
Use same fix as @jtkiesel in #616 to avoid errors in demo-java-x repo (string templates)