### PR TITLE
Draft: supports template strings

### DIFF
--- a/packages/java-parser/src/tokens.js
+++ b/packages/java-parser/src/tokens.js
@@ -229,12 +229,42 @@ createToken({
 
 createToken({
   name: "TextBlock",
-  pattern: /"""\s*\n(\\"|\s|.)*?"""/
+  pattern: MAKE_PATTERN('"""\\s*\\n(?:[^\\\\]|{{StringCharacter}})*"""')
+});
+
+createToken({
+  name: "TextBlockTemplateBegin",
+  pattern: MAKE_PATTERN('"""\\s*\\n(?:[^\\\\]|{{StringCharacter}})*\\\\\\{')
+});
+
+createToken({
+  name: "TextBlockTemplateEnd",
+  pattern: MAKE_PATTERN('\\}(?:[^\\\\]|{{StringCharacter}})*"""')
 });
 
 createToken({
   name: "StringLiteral",
   pattern: MAKE_PATTERN('"(?:[^\\\\"]|{{StringCharacter}})*"')
+});
+
+createToken({
+  name: "StringTemplateBegin",
+  pattern: MAKE_PATTERN('"(?:[^\\\\"]|{{StringCharacter}})*\\\\\\{')
+});
+
+createToken({
+  name: "StringTemplateMid",
+  pattern: MAKE_PATTERN('\\}(?:[^\\\\"]|{{StringCharacter}})*\\\\\\{')
+});
+
+createToken({
+  name: "TextBlockTemplateMid",
+  pattern: MAKE_PATTERN('\\}(?:[^\\\\]|{{StringCharacter}})*\\\\\\{')
+});
+
+createToken({
+  name: "StringTemplateEnd",
+  pattern: MAKE_PATTERN('\\}(?:[^\\\\"]|{{StringCharacter}})*"')
 });
 
 // https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.9

--- a/packages/java-parser/test/template-expressions-spec.js
+++ b/packages/java-parser/test/template-expressions-spec.js
@@ -1,0 +1,100 @@
+"use strict";
+
+const { expect } = require("chai");
+const javaParser = require("../src/index");
+const JavaLexer = require("../src/lexer");
+
+describe("Template expressions", () => {
+  it("should parse template expression with string literals", () => {
+    const input = `
+    STR."{firstName}"
+    `;
+    expect(() => javaParser.parse(input, "templateExpression")).to.not.throw();
+  });
+
+  it("should parse template expression with text blocks", () => {
+    const input = `
+    STR."""
+      toto
+    """
+    `;
+    expect(() => javaParser.parse(input, "templateExpression")).to.not.throw();
+  });
+
+  it("should tokenise string template fragments", () => {
+    const input = `"begin\\{alpha} mid \\{beta} end"`;
+
+    const { tokens } = JavaLexer.tokenize(input);
+
+    expect(tokens).to.have.length(5);
+    expect(tokens.map(token => token.image)).to.have.members(["\"begin\\{", "alpha", "} mid \\{", "beta", "} end\""]);
+  });
+
+  it("should parse template expression with string templates", () => {
+    const input = `STR."begin\\{alpha} mid \\{beta} end"`;
+
+    expect(() => javaParser.parse(input, "templateExpression")).to.not.throw();
+  });
+
+  it("should tokenise text block templates fragments", () => {
+    const input = `"""
+      begin
+      \\{alpha}
+      mid "
+      \\{beta}
+
+      end
+      """`;
+
+    const { tokens } = JavaLexer.tokenize(input);
+
+    expect(tokens).to.have.length(5);
+    expect(tokens.map(token => token.image)).to.have.members([
+      '"""\n      begin\n      \\{',
+      "alpha",
+      '}\n      mid "\n      \\{',
+      "beta",
+      '}\n\n      end\n      """'
+    ]);
+  });
+
+  it("should parse template expression with text block templates", () => {
+    const input = `STR."""
+      begin
+      \\{alpha}
+      mid "
+      \\{beta}
+
+      end
+      """`;
+
+    expect(() => javaParser.parse(input, "templateExpression")).to.not.throw();
+  });
+
+  it("should parse template expression with text block templates without quote inside", () => {
+    const input = `STR."""
+      begin
+      \\{alpha}
+      mid
+      \\{beta}
+
+      end
+      """`;
+
+    expect(() => javaParser.parse(input, "templateExpression")).to.not.throw();
+  });
+
+  it("should still parse simple if/else", () => {
+    const input = `
+      String formatted = "unknown";
+      if (o instanceof Integer i) {
+          formatted = String.format("int %d", i);
+      } else if (o instanceof Double d) {
+          formatted = String.format("double %f", d);
+      }
+      `;
+
+    javaParser.parse(input, "methodDeclaration");
+    expect(() => javaParser.parse(input, "methodDeclaration")).to.not.throw();
+  });
+});


### PR DESCRIPTION
## What changed with this PR:

There are some issues with tokenization as some control structures like if/else are recognized as string template fragments

## Relative issues or prs:

#618 
<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
