### PR TITLE
Add information on how to change indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,7 @@ For using four spaces:
 tabWidth: 4
 ```
 
-For using tabs:
-
-```yaml
-useTabs: true
-```
-
-For more details see <https://prettier.io/docs/en/configuration.html>.
+For more configuration options such as using tabs, maximum line length, and more see <https://prettier.io/docs/en/configuration.html>.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,24 @@ You can directly import the config into IntelliJ Idea for instance:
 
 ![Import Checkstyle configuration](./docs/checkstyle/import-checkstyle-configuration.gif)
 
+## Indent configuration
+
+In `.prettierrc.yaml`, you can configure the indent:
+
+For using four spaces:
+
+```yaml
+tabWidth: 4
+```
+
+For using tabs:
+
+```yaml
+useTabs: true
+```
+
+For more details see <https://prettier.io/docs/en/configuration.html>.
+
 ## Contributing
 
 Contributions are very welcome.


### PR DESCRIPTION
## What changed with this PR:

More beginner-friendly documentation.

When coming from google-java-format --ASOP or palantir-java-format, it is not that obvious how to use prettier-java. Adding some lines of documentation makes it obvious (and thus this project is more beginner-friendly)

## Relative issues or prs:

Fixes https://github.com/jhipster/prettier-java/issues/495.