### PR TITLE
java-parser: New entrypoint `lexAndParse` to return both tokens and CST.

### DIFF
--- a/packages/java-parser/api.d.ts
+++ b/packages/java-parser/api.d.ts
@@ -30,6 +30,14 @@ export declare type CstChildrenDictionary = {
   [identifier: string]: CstElement[];
 };
 
+export function lexAndParse(
+  text: string,
+  startProduction?: string
+): {
+  tokens: IToken[];
+  cst: CstNode;
+};
+
 export function parse(text: string, startProduction?: string): CstNode;
 
 export const BaseJavaCstVisitor: JavaCstVisitorConstructor<any, any>;

--- a/packages/java-parser/src/index.js
+++ b/packages/java-parser/src/index.js
@@ -9,7 +9,7 @@ const BaseJavaCstVisitor = parser.getBaseCstVisitorConstructor();
 const BaseJavaCstVisitorWithDefaults =
   parser.getBaseCstVisitorConstructorWithDefaults();
 
-function parse(inputText, entryPoint = "compilationUnit") {
+function lexAndParse(inputText, entryPoint = "compilationUnit") {
   // Lex
   const lexResult = JavaLexer.tokenize(inputText);
 
@@ -25,7 +25,8 @@ function parse(inputText, entryPoint = "compilationUnit") {
     );
   }
 
-  parser.input = lexResult.tokens;
+  const tokens = lexResult.tokens;
+  parser.input = tokens;
   parser.mostEnclosiveCstNodeByStartOffset = {};
   parser.mostEnclosiveCstNodeByEndOffset = {};
 
@@ -51,16 +52,21 @@ function parse(inputText, entryPoint = "compilationUnit") {
   }
 
   attachComments(
-    lexResult.tokens,
+    tokens,
     lexResult.groups.comments,
     parser.mostEnclosiveCstNodeByStartOffset,
     parser.mostEnclosiveCstNodeByEndOffset
   );
 
-  return cst;
+  return { cst, tokens };
+}
+
+function parse(inputText, entryPoint = "compilationUnit") {
+  return lexAndParse(inputText, entryPoint).cst;
 }
 
 module.exports = {
+  lexAndParse,
   parse,
   BaseJavaCstVisitor,
   BaseJavaCstVisitorWithDefaults


### PR DESCRIPTION
## What changed with this PR:

Provide an entrypoint that exposes both the CST and the underlying token array.

## Alternatives

The token array could also be accessed through the `parser` object, which we could export instead, but that seems like an internal implementation detail which perhaps shouldn't be part of the API.

Finally, we could consider exporting the lexer, but then if I want to get both the CST and the tokens I have to lex twice, which seems wasteful.