### PR TITLE
fix: break between non-block if/else statements

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
@@ -205,7 +205,9 @@ export class BlocksAndStatementPrettierVisitor extends BaseCstPrettierPrinter {
 
       const elseOnSameLine =
         hasTrailingLineComments(ctx.statement[0]) ||
-        hasLeadingLineComments(ctx.Else[0])
+        hasLeadingLineComments(ctx.Else[0]) ||
+        !ctx.statement[0].children.statementWithoutTrailingSubstatement?.[0]
+          .children.block
           ? hardline
           : " ";
 

--- a/packages/prettier-plugin-java/test/unit-test/empty_statement/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/empty_statement/_output.java
@@ -37,7 +37,8 @@ public class EmptyStament {
   }
 
   public void ifElseWithEmptyStatements() {
-    if (test); else {
+    if (test);
+    else {
       System.out.println("one");
     }
 
@@ -45,15 +46,18 @@ public class EmptyStament {
       System.out.println("two");
     } else;
 
-    if (test); else;
+    if (test);
+    else;
   }
 
   public void ifElseWithEmptyStatementsWithComments() {
-    if (test) /*test*/; else {
+    if (test) /*test*/;
+    else {
       System.out.println("one");
     }
 
-    if (test); /*test*/else {
+    if (test);
+    /*test*/else {
       System.out.println("one");
     }
 
@@ -65,9 +69,11 @@ public class EmptyStament {
       System.out.println("two");
     } else;/*test*/
 
-    if (test); /*test*/else;/*test*/
+    if (test);
+    /*test*/else;/*test*/
 
-    if (test) /*test*/; else /*test*/;
+    if (test) /*test*/;
+    else /*test*/;
   }
 
   public void simpleWhileWithEmptyStatement(boolean one) {

--- a/packages/prettier-plugin-java/test/unit-test/sealed/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/sealed/_output.java
@@ -46,11 +46,9 @@ public sealed interface Shape permits Circle, Rectangle, Triangle, Unicorn {
   }
 
   default String areaMessage() {
-    if (this instanceof Circle) return "Circle: " + area(); else if (
-      this instanceof Rectangle
-    ) return "Rectangle: " + area(); else if (
-      this instanceof RightTriangle
-    ) return "Triangle: " + area();
+    if (this instanceof Circle) return "Circle: " + area();
+    else if (this instanceof Rectangle) return "Rectangle: " + area();
+    else if (this instanceof RightTriangle) return "Triangle: " + area();
     // :(
     throw new IllegalArgumentException();
   }


### PR DESCRIPTION
## What changed with this PR:

Non-block if/else statements are now kept on their own lines, like Prettier JavaScript does. This aligns Prettier Java with the Checkstyle config that it provides.

## Example

### Input
```java
class Example {

  void example() {
    if (test); else {
      System.out.println("one");
    }

    if (test); else;

    if (this instanceof Circle) return "Circle: " + area(); else if (
      this instanceof Rectangle
    ) return "Rectangle: " + area(); else if (
      this instanceof RightTriangle
    ) return "Triangle: " + area();
  }
}
```

### Output
```java
class Example {

  void example() {
    if (test);
    else {
      System.out.println("one");
    }

    if (test);
    else;

    if (this instanceof Circle) return "Circle: " + area();
    else if (this instanceof Rectangle) return "Rectangle: " + area();
    else if (this instanceof RightTriangle) return "Triangle: " + area();
  }
}
```

## Relative issues or prs:

Closes #631