### PR TITLE
fix: consistent break after equals

### DIFF
--- a/packages/prettier-plugin-java/src/printers/printer-utils.ts
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.ts
@@ -31,7 +31,13 @@ import {
   getTokenLeadingComments,
   printTokenWithComments
 } from "./comments/format-comments.js";
-import { concat, group, ifBreak, join } from "./prettier-builder.js";
+import {
+  concat,
+  group,
+  ifBreak,
+  indentIfBreak,
+  join
+} from "./prettier-builder.js";
 
 const { indent, hardline, line } = builders;
 
@@ -654,8 +660,16 @@ export function binary(nodes: Doc[], tokens: IToken[], isRoot = false): Doc {
     }
   }
   level.push(nodes.shift()!);
-  const content = group(join(line, level));
-  return levelOperator === "=" ? indent(content) : content;
+  const lineGroupId = Symbol("line");
+  return group(
+    levelOperator === "="
+      ? [
+          level[0],
+          indent(group(line, { id: lineGroupId })),
+          indentIfBreak(level[1], { groupId: lineGroupId })
+        ]
+      : join(line, level)
+  );
 }
 
 function getOperator(tokens: IToken[]) {

--- a/packages/prettier-plugin-java/test/unit-test/variables/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_input.java
@@ -201,5 +201,9 @@ public class Variables {
       bbbbbbbbbbbbbbbbb ? ccccccccccccccccc : ddddddddddddddddd;
 
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = ccccccccccccccccccccccccccccccccccccccc + ddddddddddddddddddddddddddddddddd;
+
+    foo = new Foo("aaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbb", "cccccccccccccccccccc", "dddddddddddddddddddd", "eeeeeeeeeeeeeeeeeeee", "ffffffffffffffffffff");
+
+    final Foo bar = new Foo("aaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbb", "cccccccccccccccccccc", "dddddddddddddddddddd", "eeeeeeeeeeeeeeeeeeee", "ffffffffffffffffffff");
   }
 }

--- a/packages/prettier-plugin-java/test/unit-test/variables/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/variables/_output.java
@@ -326,21 +326,39 @@ public class Variables {
   }
 
   void assignment() {
-    fileSystemDetails =
-      FileHandlerDetails.builder()
-        .fileSystemType(
-          EntityUtils.update(
-            entity.getFileSystemDetails().getFileSystemType(),
-            update.getFileSystemDetails().getFileSystemType()
-          )
-        );
+    fileSystemDetails = FileHandlerDetails.builder()
+      .fileSystemType(
+        EntityUtils.update(
+          entity.getFileSystemDetails().getFileSystemType(),
+          update.getFileSystemDetails().getFileSystemType()
+        )
+      );
 
-    aaaaaaaaaaaaaaaaa =
-      bbbbbbbbbbbbbbbbb ? ccccccccccccccccc : ddddddddddddddddd;
+    aaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbb
+      ? ccccccccccccccccc
+      : ddddddddddddddddd;
 
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
       bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
         ccccccccccccccccccccccccccccccccccccccc +
         ddddddddddddddddddddddddddddddddd;
+
+    foo = new Foo(
+      "aaaaaaaaaaaaaaaaaaaa",
+      "bbbbbbbbbbbbbbbbbbbb",
+      "cccccccccccccccccccc",
+      "dddddddddddddddddddd",
+      "eeeeeeeeeeeeeeeeeeee",
+      "ffffffffffffffffffff"
+    );
+
+    final Foo bar = new Foo(
+      "aaaaaaaaaaaaaaaaaaaa",
+      "bbbbbbbbbbbbbbbbbbbb",
+      "cccccccccccccccccccc",
+      "dddddddddddddddddddd",
+      "eeeeeeeeeeeeeeeeeeee",
+      "ffffffffffffffffffff"
+    );
   }
 }


### PR DESCRIPTION
## What changed with this PR:

Long assignment operations are now consistently broken after equals between variable declarations and binary expressions. Assignment operations now avoid breaking after the equals, the way variable declarations do. This also aligns the formatting of these lines more closely to the way Prettier JavaScript does.

## Example

### Input
```java
class Example {

  void example() {
    foo = new Foo("aaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbb", "cccccccccccccccccccc", "dddddddddddddddddddd", "eeeeeeeeeeeeeeeeeeee", "ffffffffffffffffffff");

    final Foo bar = new Foo("aaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbb", "cccccccccccccccccccc", "dddddddddddddddddddd", "eeeeeeeeeeeeeeeeeeee", "ffffffffffffffffffff");
  }
}
```

### Output
```java
class Example {

  void example() {
    foo = new Foo(
      "aaaaaaaaaaaaaaaaaaaa",
      "bbbbbbbbbbbbbbbbbbbb",
      "cccccccccccccccccccc",
      "dddddddddddddddddddd",
      "eeeeeeeeeeeeeeeeeeee",
      "ffffffffffffffffffff"
    );

    final Foo bar = new Foo(
      "aaaaaaaaaaaaaaaaaaaa",
      "bbbbbbbbbbbbbbbbbbbb",
      "cccccccccccccccccccc",
      "dddddddddddddddddddd",
      "eeeeeeeeeeeeeeeeeeee",
      "ffffffffffffffffffff"
    );
  }
}
```

## Relative issues or prs:

Closes #638