### PR TITLE
fix: constructor and method receiver parameter

### DIFF
--- a/packages/java-parser/api.d.ts
+++ b/packages/java-parser/api.d.ts
@@ -1364,6 +1364,8 @@ export interface MethodDeclaratorCstNode extends CstNode {
 export type MethodDeclaratorCtx = {
   Identifier: IToken[];
   LBrace: IToken[];
+  receiverParameter?: ReceiverParameterCstNode[];
+  Comma?: IToken[];
   formalParameterList?: FormalParameterListCstNode[];
   RBrace: IToken[];
   dims?: DimsCstNode[];

--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -320,13 +320,22 @@ export function defineRules($, t) {
     ]);
   });
 
-  // https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-MethodDeclarator
+  // https://docs.oracle.com/javase/specs/jls/se21/html/jls-8.html#jls-MethodDeclarator
   $.RULE("methodDeclarator", () => {
     $.CONSUME(t.Identifier);
     $.CONSUME(t.LBrace);
-    $.OPTION(() => {
-      $.SUBRULE($.formalParameterList);
-    });
+    $.OR([
+      {
+        ALT: () => {
+          $.SUBRULE($.receiverParameter);
+          $.OPTION(() => {
+            $.CONSUME(t.Comma);
+            $.SUBRULE($.formalParameterList);
+          });
+        }
+      },
+      { ALT: () => $.OPTION1(() => $.SUBRULE1($.formalParameterList)) }
+    ]);
     $.CONSUME(t.RBrace);
     $.OPTION2(() => {
       $.SUBRULE($.dims);
@@ -464,13 +473,18 @@ export function defineRules($, t) {
     });
     $.SUBRULE($.simpleTypeName);
     $.CONSUME(t.LBrace);
-    $.OPTION2(() => {
-      $.SUBRULE($.receiverParameter);
-      $.CONSUME(t.Comma);
-    });
-    $.OPTION3(() => {
-      $.SUBRULE($.formalParameterList);
-    });
+    $.OR([
+      {
+        ALT: () => {
+          $.SUBRULE($.receiverParameter);
+          $.OPTION1(() => {
+            $.CONSUME(t.Comma);
+            $.SUBRULE($.formalParameterList);
+          });
+        }
+      },
+      { ALT: () => $.OPTION2(() => $.SUBRULE1($.formalParameterList)) }
+    ]);
     $.CONSUME(t.RBrace);
   });
 

--- a/packages/java-parser/test/bugs-spec.js
+++ b/packages/java-parser/test/bugs-spec.js
@@ -97,4 +97,19 @@ describe("The Java Parser fixed bugs", () => {
       expect(() => javaParser.parse(input, "statement")).to.not.throw();
     });
   });
+
+  it("issue #607 - should parse receiver parameter", () => {
+    [
+      "class Currency { Currency(Currency this) {} }",
+      "class Currency { Currency(Currency this, Currency other) {} }",
+      "class Currency { Currency(@AnnotatedUsage Currency this, Currency other) {} }",
+      "class Currency { String getCode(Currency this) {} }",
+      "class Currency { int compareTo(Currency this, Currency other) {} }",
+      "class Currency { int compareTo(@AnnotatedUsage Currency this, Currency other) {} }",
+      "class Currency { class Inner { Inner(Currency Currency.this) {} } }",
+      "class Currency { class Inner { String getCode(Currency Currency.this) {} } }"
+    ].forEach(input => {
+      expect(() => javaParser.parse(input, "classDeclaration")).to.not.throw();
+    });
+  });
 });

--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -570,13 +570,17 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
 
   methodDeclarator(ctx: MethodDeclaratorCtx) {
     const identifier = printTokenWithComments(ctx.Identifier[0]);
+    const receiverParameter = this.visit(ctx.receiverParameter);
     const formalParameterList = this.visit(ctx.formalParameterList);
     const dims = this.visit(ctx.dims);
 
     return rejectAndConcat([
       identifier,
       putIntoBraces(
-        formalParameterList,
+        rejectAndJoin(line, [
+          rejectAndConcat([receiverParameter, ctx.Comma?.[0]]),
+          formalParameterList
+        ]),
         softline,
         ctx.LBrace[0],
         ctx.RBrace[0]
@@ -588,15 +592,11 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   receiverParameter(ctx: ReceiverParameterCtx) {
     const annotations = this.mapVisit(ctx.annotation);
     const unannType = this.visit(ctx.unannType);
-    const identifier = ctx.Identifier
-      ? concat([ctx.Identifier[0], ctx.Dot![0]])
-      : "";
 
-    return rejectAndJoin("", [
-      rejectAndJoin(" ", annotations),
+    return rejectAndJoin(" ", [
+      ...annotations,
       unannType,
-      identifier,
-      ctx.This[0]
+      rejectAndConcat([ctx.Identifier?.[0], ctx.Dot?.[0], ctx.This[0]])
     ]);
   }
 
@@ -723,14 +723,16 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
     const simpleTypeName = this.visit(ctx.simpleTypeName);
     const receiverParameter = this.visit(ctx.receiverParameter);
     const formalParameterList = this.visit(ctx.formalParameterList);
-    const commas = ctx.Comma ? ctx.Comma.map(elt => concat([elt, " "])) : [];
 
     return rejectAndJoin(" ", [
       typeParameters,
       concat([
         simpleTypeName,
         putIntoBraces(
-          rejectAndJoinSeps(commas, [receiverParameter, formalParameterList]),
+          rejectAndJoin(line, [
+            rejectAndConcat([receiverParameter, ctx.Comma?.[0]]),
+            formalParameterList
+          ]),
           softline,
           ctx.LBrace[0],
           ctx.RBrace[0]

--- a/packages/prettier-plugin-java/test/unit-test/bug-fixes/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/bug-fixes/_input.java
@@ -8,3 +8,28 @@ class T {
         @NonNull Map<String, Object> context
     ) {}
 }
+
+// Fix for https://github.com/jhipster/prettier-java/issues/607
+class Currency {
+    Currency(Currency this) {}
+
+    Currency(Currency this, Currency other) {}
+
+    Currency(@AnnotatedUsage Currency this, Currency other) {}
+
+    Currency(@AnnotatedUsage Currency this, String aaaaaaaaaa, String bbbbbbbbbb) {}
+
+    String getCode(Currency this) {}
+
+    int compareTo(Currency this, Currency other) {}
+
+    int compareTo(@AnnotatedUsage Currency this, Currency other) {}
+
+    int compareTo(@AnnotatedUsage Currency this, String aaaaaaaaaa, String bbbbbbbbbb) {}
+
+    class Inner {
+        Inner(Currency Currency.this) {}
+
+        String getCode(Currency Currency.this) {}
+    }
+}

--- a/packages/prettier-plugin-java/test/unit-test/bug-fixes/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/bug-fixes/_output.java
@@ -11,3 +11,38 @@ class T {
     @NonNull Map<String, Object> context
   ) {}
 }
+
+// Fix for https://github.com/jhipster/prettier-java/issues/607
+class Currency {
+
+  Currency(Currency this) {}
+
+  Currency(Currency this, Currency other) {}
+
+  Currency(@AnnotatedUsage Currency this, Currency other) {}
+
+  Currency(
+    @AnnotatedUsage Currency this,
+    String aaaaaaaaaa,
+    String bbbbbbbbbb
+  ) {}
+
+  String getCode(Currency this) {}
+
+  int compareTo(Currency this, Currency other) {}
+
+  int compareTo(@AnnotatedUsage Currency this, Currency other) {}
+
+  int compareTo(
+    @AnnotatedUsage Currency this,
+    String aaaaaaaaaa,
+    String bbbbbbbbbb
+  ) {}
+
+  class Inner {
+
+    Inner(Currency Currency.this) {}
+
+    String getCode(Currency Currency.this) {}
+  }
+}


### PR DESCRIPTION
## What changed with this PR:

Fixes some issues with constructor receiver parameters, and added support for method receiver parameters.

## Example

### Input
```java
class Currency {
  Currency(Currency this) {}

  Currency(Currency this, Currency other) {}

  Currency(@AnnotatedUsage Currency this, Currency other) {}

  Currency(@AnnotatedUsage Currency this, String aaaaaaaaaa, String bbbbbbbbbb) {}

  String getCode(Currency this) {}

  int compareTo(Currency this, Currency other) {}

  int compareTo(@AnnotatedUsage Currency this, Currency other) {}

  int compareTo(@AnnotatedUsage Currency this, String aaaaaaaaaa, String bbbbbbbbbb) {}

  class Inner {
    Inner(Currency Currency.this) {}

    String getCode(Currency Currency.this) {}
  }
}
```

### Output
```java
class Currency {

  Currency(Currency this) {}

  Currency(Currency this, Currency other) {}

  Currency(@AnnotatedUsage Currency this, Currency other) {}

  Currency(
    @AnnotatedUsage Currency this,
    String aaaaaaaaaa,
    String bbbbbbbbbb
  ) {}

  String getCode(Currency this) {}

  int compareTo(Currency this, Currency other) {}

  int compareTo(@AnnotatedUsage Currency this, Currency other) {}

  int compareTo(
    @AnnotatedUsage Currency this,
    String aaaaaaaaaa,
    String bbbbbbbbbb
  ) {}

  class Inner {

    Inner(Currency Currency.this) {}

    String getCode(Currency Currency.this) {}
  }
}
```

## Relative issues or prs:

Closes #607