### PR TITLE
fix: hug lambdas without blocks

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -24,6 +24,7 @@ import {
   hasLeadingComments,
   hasLeadingLineComments
 } from "./comments/comments-utils.js";
+import { handleCommentsParameters } from "./comments/handle-comments.js";
 import { builders } from "prettier/doc";
 import { BaseCstPrettierPrinter } from "../base-cst-printer.js";
 import {
@@ -569,6 +570,11 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   }
 
   methodDeclarator(ctx: MethodDeclaratorCtx) {
+    const parameters = [
+      ...(ctx.receiverParameter ?? []),
+      ...(ctx.formalParameterList?.[0].children.formalParameter ?? [])
+    ];
+    handleCommentsParameters(ctx.LBrace[0], parameters, ctx.RBrace[0]);
     const identifier = printTokenWithComments(ctx.Identifier[0]);
     const receiverParameter = this.visit(ctx.receiverParameter);
     const formalParameterList = this.visit(ctx.formalParameterList);
@@ -719,6 +725,11 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
   }
 
   constructorDeclarator(ctx: ConstructorDeclaratorCtx) {
+    const parameters =
+      ctx.receiverParameter ??
+      ctx.formalParameterList?.[0].children.formalParameter ??
+      [];
+    handleCommentsParameters(ctx.LBrace[0], parameters, ctx.RBrace[0]);
     const typeParameters = this.visit(ctx.typeParameters);
     const simpleTypeName = this.visit(ctx.simpleTypeName);
     const receiverParameter = this.visit(ctx.receiverParameter);
@@ -948,6 +959,9 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
     ]);
   }
   recordHeader(ctx: RecordHeaderCtx) {
+    const recordComponents =
+      ctx.recordComponentList?.[0].children.recordComponent ?? [];
+    handleCommentsParameters(ctx.LBrace[0], recordComponents, ctx.RBrace[0]);
     const recordComponentList = this.visit(ctx.recordComponentList);
     return putIntoBraces(
       recordComponentList,

--- a/packages/prettier-plugin-java/src/printers/interfaces.ts
+++ b/packages/prettier-plugin-java/src/printers/interfaces.ts
@@ -1,5 +1,6 @@
 import { concat, group, indent } from "./prettier-builder.js";
 import { printTokenWithComments } from "./comments/format-comments.js";
+import { handleCommentsParameters } from "./comments/handle-comments.js";
 import {
   displaySemicolon,
   getInterfaceBodyDeclarationsSeparator,
@@ -278,6 +279,11 @@ export class InterfacesPrettierVisitor extends BaseCstPrettierPrinter {
 
     let annoArgs: Doc = "";
     if (ctx.LBrace) {
+      const elementValues =
+        ctx.elementValuePairList?.[0].children.elementValuePair ??
+        ctx.elementValue ??
+        [];
+      handleCommentsParameters(ctx.LBrace[0], elementValues, ctx.RBrace![0]);
       if (ctx.elementValuePairList) {
         annoArgs = putIntoBraces(
           this.visit(ctx.elementValuePairList),

--- a/packages/prettier-plugin-java/src/printers/printer-utils.ts
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.ts
@@ -39,7 +39,7 @@ import {
   join
 } from "./prettier-builder.js";
 
-const { indent, hardline, line } = builders;
+const { indent, hardline, line, lineSuffixBoundary, softline } = builders;
 
 const orderedModifiers = [
   "Public",
@@ -583,7 +583,11 @@ export function putIntoBraces(
 
   if (isEmptyDoc(argument)) {
     if (rightBraceLeadingComments.length === 0) {
-      return concat([LBrace, RBrace]);
+      return group([
+        indent(printTokenWithComments(LBrace)),
+        ...(LBrace.trailingComments ? [softline, lineSuffixBoundary] : []),
+        RBrace
+      ]);
     }
     contentInsideBraces = [separator, ...rightBraceLeadingComments];
   } else if (rightBraceLeadingComments.length !== 0) {
@@ -650,11 +654,11 @@ export function binary(nodes: Doc[], tokens: IToken[], isRoot = false): Doc {
         return group(join(line, level));
       }
     } else {
-      const content = indent(binary(nodes, tokens));
+      const content = binary(nodes, tokens);
       nodes.unshift(
         levelOperator !== undefined &&
           needsParentheses(nextOperator, levelOperator)
-          ? concat(["(", content, ")"])
+          ? concat(["(", indent(content), ")"])
           : content
       );
     }

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/end-of-block/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/end-of-block/_output.java
@@ -15,7 +15,8 @@ class D {
   /* gamma */
 }
 
-class E {} // alpha
+class E { // alpha
+}
 
 class F {
   /* alpha */
@@ -59,9 +60,11 @@ class J {
     /* gamma */
   ) {}
 
-  void five() {} // alpha
+  void five( // alpha
+  ) {}
 
-  void fiveBis() { // alpha
+  void fiveBis( // alpha
+  ) {
     int i;
   }
 

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
@@ -209,6 +209,95 @@ public class Lambda {
         }, g);
     }
 
+    void huggableArguments() {
+        aaaaaaaaaaaaaaaaaaaaaaaa((bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccc, dddddddddddddddddddddddd) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff());
+
+        a.b(c -> d -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+
+        a.b(c -> d && eeeeeeeeee.ffffffffff() ? g && hhhhhhhhhh.iiiiiiiiii() : j && kkkkkkkkkk.llllllllll());
+
+        a.b(c -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);
+
+        a.b(c, (c0, c1) -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);
+
+        a.b(c -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);
+
+        a.b(c, (c0, c1) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);
+
+        a.b(c -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+
+        a.b(c, (c0, c1) -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+
+        a.b(c -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+
+        a.b(c -> {
+            eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk);
+        });
+
+        a.b((c0, c1) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+
+        a.b(c, (c0, c1) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+
+        a( // comment
+        (b, c, d) -> e.f());
+
+        a(( // comment
+        b, c, d) -> e.f());
+
+        a((b, // comment
+        c, d) -> e.f());
+
+        a((b, c, d // comment
+        ) -> e.f());
+
+        a((b, c, d
+        // comment
+        ) -> e.f());
+
+        a( /* comment */ (b, c, d) -> e.f());
+
+        a(( /* comment */
+        b, c, d) -> e.f());
+
+        a((b, /* comment */ c, d) -> e.f());
+
+        a((b, c, d /* comment */
+        ) -> e.f());
+
+        a((b, c, d
+        /* comment */
+        ) -> e.f());
+
+        aaaaaaaaaaaaaaaaaaaaaaaa((bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccc, dddddddddddddddddddddddd
+        // comment
+        ) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff());
+
+        aaaaaaaaaaaaaaaaaaaaaaaa( /* comment */
+        (bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccc, dddddddddddddddddddddddd) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff());
+
+        aaaaaaaaaaaaaaaaaaaaaaaa( /* comment */ (bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccc, dddddddddddddddddddddddd) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff());
+
+        a.b(c, (c0, c1
+        // comment
+        ) -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);
+
+        a.b(c, (c0, c1
+        // comment
+        ) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);
+
+        a.b(c, (c0, c1
+        // comment
+        ) -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+
+        a.b((c0, c1
+        // comment
+        ) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+
+        a.b(c, (c0, c1
+        // comment
+        ) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
+    }
+
     void lambdaWithLeadingComments() {
         System.out.println(
             List.of(1, 2, 3).stream().map(

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
@@ -221,6 +221,323 @@ public class Lambda {
     );
   }
 
+  void huggableArguments() {
+    aaaaaaaaaaaaaaaaaaaaaaaa(
+      (
+        bbbbbbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccccccc,
+        dddddddddddddddddddddddd
+      ) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff()
+    );
+
+    a.b(
+      c ->
+        d ->
+          eeeeeeeeee.ffffffffff(
+            gggggggggg,
+            hhhhhhhhhh,
+            iiiiiiiiii,
+            jjjjjjjjjj,
+            kkkkkkkkkk
+          )
+    );
+
+    a.b(c ->
+      d && eeeeeeeeee.ffffffffff()
+        ? g && hhhhhhhhhh.iiiiiiiiii()
+        : j && kkkkkkkkkk.llllllllll()
+    );
+
+    a.b(
+      c ->
+        d &&
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        ) >
+        0
+    );
+
+    a.b(
+      c,
+      (c0, c1) ->
+        d &&
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        ) >
+        0
+    );
+
+    a.b(
+      c ->
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        ) >
+        0
+    );
+
+    a.b(
+      c,
+      (c0, c1) ->
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        ) >
+        0
+    );
+
+    a.b(
+      c ->
+        d &&
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        )
+    );
+
+    a.b(
+      c,
+      (c0, c1) ->
+        d &&
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        )
+    );
+
+    a.b(c ->
+      eeeeeeeeee.ffffffffff(
+        gggggggggg,
+        hhhhhhhhhh,
+        iiiiiiiiii,
+        jjjjjjjjjj,
+        kkkkkkkkkk
+      )
+    );
+
+    a.b(c -> {
+      eeeeeeeeee.ffffffffff(
+        gggggggggg,
+        hhhhhhhhhh,
+        iiiiiiiiii,
+        jjjjjjjjjj,
+        kkkkkkkkkk
+      );
+    });
+
+    a.b((c0, c1) ->
+      eeeeeeeeee.ffffffffff(
+        gggggggggg,
+        hhhhhhhhhh,
+        iiiiiiiiii,
+        jjjjjjjjjj,
+        kkkkkkkkkk
+      )
+    );
+
+    a.b(c, (c0, c1) ->
+      eeeeeeeeee.ffffffffff(
+        gggggggggg,
+        hhhhhhhhhh,
+        iiiiiiiiii,
+        jjjjjjjjjj,
+        kkkkkkkkkk
+      )
+    );
+
+    a(
+      // comment
+      (b, c, d) -> e.f()
+    );
+
+    a(
+      (
+        // comment
+        b,
+        c,
+        d
+      ) -> e.f()
+    );
+
+    a(
+      (
+        b, // comment
+        c,
+        d
+      ) -> e.f()
+    );
+
+    a(
+      (
+        b,
+        c,
+        d // comment
+      ) -> e.f()
+    );
+
+    a(
+      (
+        b,
+        c,
+        d
+        // comment
+      ) -> e.f()
+    );
+
+    a(/* comment */(b, c, d) -> e.f());
+
+    a(
+      (
+        /* comment */
+        b,
+        c,
+        d
+      ) -> e.f()
+    );
+
+    a((b, /* comment */c, d) -> e.f());
+
+    a((b, c, d/* comment */) -> e.f());
+
+    a(
+      (
+        b,
+        c,
+        d
+        /* comment */
+      ) -> e.f()
+    );
+
+    aaaaaaaaaaaaaaaaaaaaaaaa(
+      (
+        bbbbbbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccccccc,
+        dddddddddddddddddddddddd
+        // comment
+      ) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff()
+    );
+
+    aaaaaaaaaaaaaaaaaaaaaaaa(
+      /* comment */
+      (
+        bbbbbbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccccccc,
+        dddddddddddddddddddddddd
+      ) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff()
+    );
+
+    aaaaaaaaaaaaaaaaaaaaaaaa(
+      /* comment */(
+        bbbbbbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccccccc,
+        dddddddddddddddddddddddd
+      ) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff()
+    );
+
+    a.b(
+      c,
+      (
+        c0,
+        c1
+        // comment
+      ) ->
+        d &&
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        ) >
+        0
+    );
+
+    a.b(
+      c,
+      (
+        c0,
+        c1
+        // comment
+      ) ->
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        ) >
+        0
+    );
+
+    a.b(
+      c,
+      (
+        c0,
+        c1
+        // comment
+      ) ->
+        d &&
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        )
+    );
+
+    a.b(
+      (
+        c0,
+        c1
+        // comment
+      ) ->
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        )
+    );
+
+    a.b(
+      c,
+      (
+        c0,
+        c1
+        // comment
+      ) ->
+        eeeeeeeeee.ffffffffff(
+          gggggggggg,
+          hhhhhhhhhh,
+          iiiiiiiiii,
+          jjjjjjjjjj,
+          kkkkkkkkkk
+        )
+    );
+  }
+
   void lambdaWithLeadingComments() {
     System.out.println(
       List.of(1, 2, 3)

--- a/packages/prettier-plugin-java/test/unit-test/unnamed-variables-and-patterns/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/unnamed-variables-and-patterns/_output.java
@@ -39,7 +39,8 @@ class T {
   }
 
   void tryWithResources() {
-    try (var _ = ScopedContext.acquire()) {} // Unnamed variable
+    try (var _ = ScopedContext.acquire()) { // Unnamed variable
+    }
   }
 
   void lambda() {


### PR DESCRIPTION
## What changed with this PR:

Argument "hugging" is now aligned much more closely with Prettier JavaScript. Specifically, lambdas without blocks are "huggable" again.

## Example

### Input
```java
class T {

  public Semver getMaven() {
    return describe()
      .map(v -> null == v ? PRE_VERSION : v)
      .map(Semver::coerce)
      .map(v -> Objects.equals(v.getVersion(), PRE_VERSION) ? v.withPreRelease(SNAPSHOT) : v)
      .map(
        v ->
          v
            .getPreRelease()
            .stream()
            .filter(p -> p.matches("^\\d+-+g\\p{XDigit}{7}$"))
            .findFirst()
            .map(p -> v.withClearedPreRelease().withPreRelease(SNAPSHOT).withBuild(p))
            .orElse(v)
      )
      .map(v -> new MavenSemver(v.getVersion()))
      .get();
  }

  void t() {
    aaaaaaaaaaaaaaaaaaaaaaaa((bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccc, dddddddddddddddddddddddd) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff());

    a.b(c -> d -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));

    a.b(c -> d && eeeeeeeeee.ffffffffff() ? g && hhhhhhhhhh.iiiiiiiiii() : j && kkkkkkkkkk.llllllllll());

    a.b(c -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);

    a.b(c, (c0, c1) -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);

    a.b(c -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);

    a.b(c, (c0, c1) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk) > 0);

    a.b(c -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));

    a.b(c, (c0, c1) -> d && eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));

    a.b(c -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));

    a.b(c -> {
      eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk);
    });

    a.b((c0, c1) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));

    a.b(c, (c0, c1) -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));
  }
}
```

### Output
```java
class T {

  public Semver getMaven() {
    return describe()
      .map(v -> null == v ? PRE_VERSION : v)
      .map(Semver::coerce)
      .map(v ->
        Objects.equals(v.getVersion(), PRE_VERSION)
          ? v.withPreRelease(SNAPSHOT)
          : v
      )
      .map(v ->
        v
          .getPreRelease()
          .stream()
          .filter(p -> p.matches("^\\d+-+g\\p{XDigit}{7}$"))
          .findFirst()
          .map(p ->
            v.withClearedPreRelease().withPreRelease(SNAPSHOT).withBuild(p)
          )
          .orElse(v)
      )
      .map(v -> new MavenSemver(v.getVersion()))
      .get();
  }

  void t() {
    aaaaaaaaaaaaaaaaaaaaaaaa(
      (
        bbbbbbbbbbbbbbbbbbbbbbbb,
        cccccccccccccccccccccccc,
        dddddddddddddddddddddddd
      ) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff()
    );

    a.b(
      c ->
        d ->
          eeeeeeeeee.ffffffffff(
            gggggggggg,
            hhhhhhhhhh,
            iiiiiiiiii,
            jjjjjjjjjj,
            kkkkkkkkkk
          )
    );

    a.b(c ->
      d && eeeeeeeeee.ffffffffff()
        ? g && hhhhhhhhhh.iiiiiiiiii()
        : j && kkkkkkkkkk.llllllllll()
    );

    a.b(
      c ->
        d &&
        eeeeeeeeee.ffffffffff(
          gggggggggg,
          hhhhhhhhhh,
          iiiiiiiiii,
          jjjjjjjjjj,
          kkkkkkkkkk
        ) >
        0
    );

    a.b(
      c,
      (c0, c1) ->
        d &&
        eeeeeeeeee.ffffffffff(
          gggggggggg,
          hhhhhhhhhh,
          iiiiiiiiii,
          jjjjjjjjjj,
          kkkkkkkkkk
        ) >
        0
    );

    a.b(
      c ->
        eeeeeeeeee.ffffffffff(
          gggggggggg,
          hhhhhhhhhh,
          iiiiiiiiii,
          jjjjjjjjjj,
          kkkkkkkkkk
        ) >
        0
    );

    a.b(
      c,
      (c0, c1) ->
        eeeeeeeeee.ffffffffff(
          gggggggggg,
          hhhhhhhhhh,
          iiiiiiiiii,
          jjjjjjjjjj,
          kkkkkkkkkk
        ) >
        0
    );

    a.b(
      c ->
        d &&
        eeeeeeeeee.ffffffffff(
          gggggggggg,
          hhhhhhhhhh,
          iiiiiiiiii,
          jjjjjjjjjj,
          kkkkkkkkkk
        )
    );

    a.b(
      c,
      (c0, c1) ->
        d &&
        eeeeeeeeee.ffffffffff(
          gggggggggg,
          hhhhhhhhhh,
          iiiiiiiiii,
          jjjjjjjjjj,
          kkkkkkkkkk
        )
    );

    a.b(c ->
      eeeeeeeeee.ffffffffff(
        gggggggggg,
        hhhhhhhhhh,
        iiiiiiiiii,
        jjjjjjjjjj,
        kkkkkkkkkk
      )
    );

    a.b(c -> {
      eeeeeeeeee.ffffffffff(
        gggggggggg,
        hhhhhhhhhh,
        iiiiiiiiii,
        jjjjjjjjjj,
        kkkkkkkkkk
      );
    });

    a.b((c0, c1) ->
      eeeeeeeeee.ffffffffff(
        gggggggggg,
        hhhhhhhhhh,
        iiiiiiiiii,
        jjjjjjjjjj,
        kkkkkkkkkk
      )
    );

    a.b(c, (c0, c1) ->
      eeeeeeeeee.ffffffffff(
        gggggggggg,
        hhhhhhhhhh,
        iiiiiiiiii,
        jjjjjjjjjj,
        kkkkkkkkkk
      )
    );
  }
}
```

## Relative issues or prs:

Closes #650