### PR TITLE
Revert "chore: fix lint script"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,3 @@ packages/prettier-plugin-java/test-samples
 node_modules
 packages/prettier-plugin-java/dist
 babel.config.js
-packages/java-parser/api.d.ts

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ci:all": "yarn run ci && yarn run test:prettier-plugin-java test:e2e-jhipster1 && yarn run test:prettier-plugin-java test:e2e-jhipster2",
     "test": "lerna run test --stream",
     "test:prettier-plugin-java": "lerna --stream --scope=prettier-plugin-java run",
-    "lint": "eslint packages/**/*.{js,ts}",
+    "lint": "eslint packages/**/*.js",
     "format:fix": "prettier --write \"**/*.@(js|json|ts)\"",
     "format:validate": "prettier --list-different \"**/*.@(js|json|ts)\"",
     "build": "yarn build:prettier-plugin-java && node packages/java-parser/scripts/unicode.js packages/java-parser/resources/Unicode/UnicodeData.txt && prettier --write packages/java-parser/src/unicodesets.js && node packages/java-parser/scripts/gen-diagrams.js",


### PR DESCRIPTION
This reverts commit ac1a02b2e9179ecfbbd25e9afd0a24933fa33424, which broke the CI build, as it made ESLint attempt to lint TypeScript files, and we do not currently configure ESLint to use the TypeScript parser or use any TypeScript config packages.