### PR TITLE
fix: add es5 as trailingComma option

### DIFF
--- a/packages/prettier-plugin-java/src/options.js
+++ b/packages/prettier-plugin-java/src/options.js
@@ -249,7 +249,7 @@ export default {
     type: "choice",
     category: "Java",
     default: "all",
-    choices: ["all", "none"],
+    choices: ["all", "es5", "none"],
     description: "Print trailing commas wherever possible when multi-line."
   }
 };

--- a/website/src/pages/playground/index.tsx
+++ b/website/src/pages/playground/index.tsx
@@ -17,8 +17,9 @@ interface State {
 }
 
 enum TrailingComma {
-  None = "none",
-  All = "all"
+  All = "all",
+  Es5 = "es5",
+  None = "none"
 }
 
 const codeSample = `public interface MyInterface {
@@ -144,8 +145,9 @@ function Inner() {
                 setTrailingComma(event.target.value as TrailingComma)
               }
             >
-              <option>all</option>
-              <option>none</option>
+              {Object.values(TrailingComma).map(option => (
+                <option>{option}</option>
+              ))}
             </select>
           </label>
         </details>


### PR DESCRIPTION
## What changed with this PR:

Adds `es5` as a valid `trailingComma` option, to align with the Prettier option.

## Relative issues or prs:

Closes #652