### PR TITLE
fix: print comment before first binary operator without failing

### DIFF
--- a/packages/prettier-plugin-java/src/printers/comments/handle-comments.ts
+++ b/packages/prettier-plugin-java/src/printers/comments/handle-comments.ts
@@ -88,12 +88,12 @@ function moveExpressionTrailingCommentsToNextOperator(
   ctx: BinaryExpressionCtx
 ) {
   const binaryOperators = ctx.BinaryOperator;
-  let binaryOperatorIndex = 1;
+  let binaryOperatorIndex = 0;
   if (binaryOperators?.length) {
     ctx.unaryExpression.forEach(unaryExpression => {
       if (hasTrailingComments(unaryExpression)) {
         while (
-          binaryOperatorIndex < binaryOperators.length &&
+          binaryOperatorIndex < binaryOperators.length - 1 &&
           unaryExpression.location.endOffset &&
           binaryOperators[binaryOperatorIndex].startOffset <
             unaryExpression.location.endOffset

--- a/packages/prettier-plugin-java/test/repository-test/core-test.ts
+++ b/packages/prettier-plugin-java/test/repository-test/core-test.ts
@@ -15,7 +15,7 @@ describe("prettier-java", () => {
   testRepositorySample(
     resolve(__dirname, "../../samples/spring-boot"),
     "./gradlew",
-    ["clean", "build", "-Ddisable.checks", "-xtest", "--no-scan"]
+    ["compileJava"]
   );
 
   jhipsterRepository.forEach(repository => {

--- a/packages/prettier-plugin-java/test/test-utils.ts
+++ b/packages/prettier-plugin-java/test/test-utils.ts
@@ -118,8 +118,7 @@ export function testRepositorySample(
       });
       if (code.status !== 0) {
         expect.fail(
-          `Cannot build ${testFolder}, please check the output below:\n` +
-            code.error ?? code.stderr
+          `Cannot build ${testFolder}, please check the output below:\n${code.error ?? code.stderr}`
         );
       }
     });

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-spec.ts
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-spec.ts
@@ -7,6 +7,7 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 describe("prettier-java", () => {
   testSample(path.resolve(__dirname, "./class"));
   testSample(path.resolve(__dirname, "./edge"));
+  testSample(path.resolve(__dirname, "./expression"));
   testSample(path.resolve(__dirname, "./interface"));
   testSample(path.resolve(__dirname, "./package"));
   testSample(

--- a/packages/prettier-plugin-java/test/unit-test/comments/expression/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/expression/_input.java
@@ -1,0 +1,7 @@
+class Example {
+
+  void example() {
+    0 //
+    + 1;
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/comments/expression/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/expression/_output.java
@@ -1,0 +1,7 @@
+class Example {
+
+  void example() {
+    0 + //
+    1;
+  }
+}


### PR DESCRIPTION
## What changed with this PR:

Binary expressions with comments before the first operator no longer fail to print.

## Example

### Input
```java
class Example {

  void example() {
    0 //
    + 1;
  }
}
```

### Output
```java
class Example {

  void example() {
    0 + //
    1;
  }
}
```

## Relative issues or prs:

Closes #685