### PR TITLE
fix: add whitespace between label and statement

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
@@ -175,7 +175,7 @@ export class BlocksAndStatementPrettierVisitor extends BaseCstPrettierPrinter {
     const identifier = ctx.Identifier[0];
     const statement = this.visit(ctx.statement);
 
-    return rejectAndJoin(ctx.Colon[0], [identifier, statement]);
+    return concat([identifier, ctx.Colon[0], " ", statement]);
   }
 
   expressionStatement(ctx: ExpressionStatementCtx) {

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/complex/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/complex/_output.java
@@ -43,7 +43,7 @@ public class PrettierTest {
 
       // Label statement
       //foreach
-      loop:for (int num /* num is every number in arr*/: arr) {
+      loop: for (int num /* num is every number in arr*/: arr) {
         /*switch*/switch (num) { //switch
           case 1:
             System.out.println("One ");

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/labeled-statement/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/labeled-statement/_input.java
@@ -140,5 +140,10 @@ class LabeledStatements {
     for (int num : arr) {
     }
   }
-}
 
+  void labeledBlockStatement() {
+    label:{
+      example();
+    }
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/labeled-statement/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/comments-blocks-and-statements/labeled-statement/_output.java
@@ -3,104 +3,110 @@ class LabeledStatements {
   void commentsLabeledStatementLineComment() {
     // Label statement
     // comment1
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // Label statement
     // comment1
     // comment2
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // Label statement
     // comment1
     // comment2
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // comment1
     // comment2
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // comment1
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // comment1
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
   }
 
   void commentsLabeledStatementBlockComment() {
     /* Label statement */
     /* comment1 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* Label statement */
     /* comment1 */
     /* comment2 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* Label statement */
     /* comment1 */
     /* comment2 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* comment1 */
     /* comment2 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* comment1 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* comment1 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
   }
 
   void commentsLabeledStatementMixedComment() {
     // Label statement
     /* comment1 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* Label statement */
     // comment1
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* Label statement */
     // comment1
     // comment2
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // Label statement
     /* comment1 */
     // comment2
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // Label statement
     // comment1
     /* comment2 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* Label statement */
     // comment1
     /* comment2 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // Label statement
     /* comment1 */
     /* comment2 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* Label statement */
     /* comment1 */
     // comment2
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     // comment1
     /* comment2 */
-    loop:for (int num : arr) {}
+    loop: for (int num : arr) {}
 
     /* comment1 */
     // comment2
-    oop:for (int num : arr) {}
+    oop: for (int num : arr) {}
+  }
+
+  void labeledBlockStatement() {
+    label: {
+      example();
+    }
   }
 }


### PR DESCRIPTION
## What changed with this PR:

Labeled statements are now printed with a space between the label and the statement.

## Example

### Input

```java
class Example {

  void labeledForLoop() {
    label:for (int i = 0; i < 1; i++) {}
  }

  void labeledBlockStatement() {
    label:{
      example();
    }
  }
}
```

### Output

```java
class Example {

  void labeledForLoop() {
    label: for (int i = 0; i < 1; i++) {}
  }

  void labeledBlockStatement() {
    label: {
      example();
    }
  }
}
```

## Relative issues or prs:

Closes #686