### PR TITLE
fix: break and indent assignments like declarations

### DIFF
--- a/packages/prettier-plugin-java/src/printers/printer-utils.ts
+++ b/packages/prettier-plugin-java/src/printers/printer-utils.ts
@@ -1,5 +1,6 @@
 import {
   AnnotationCstNode,
+  BinaryExpressionCtx,
   ClassBodyDeclarationCstNode,
   ConstantModifierCstNode,
   CstElement,
@@ -31,13 +32,7 @@ import {
   getTokenLeadingComments,
   printTokenWithComments
 } from "./comments/format-comments.js";
-import {
-  concat,
-  group,
-  ifBreak,
-  indentIfBreak,
-  join
-} from "./prettier-builder.js";
+import { concat, group, ifBreak, join } from "./prettier-builder.js";
 
 const { indent, hardline, line, lineSuffixBoundary, softline } = builders;
 
@@ -664,16 +659,17 @@ export function binary(nodes: Doc[], tokens: IToken[], isRoot = false): Doc {
     }
   }
   level.push(nodes.shift()!);
-  const lineGroupId = Symbol("line");
-  return group(
-    levelOperator === "="
-      ? [
-          level[0],
-          indent(group(line, { id: lineGroupId })),
-          indentIfBreak(level[1], { groupId: lineGroupId })
-        ]
-      : join(line, level)
-  );
+  return group(join(line, level));
+}
+
+export function getOperators(ctx: BinaryExpressionCtx) {
+  return [
+    ctx.AssignmentOperator,
+    ctx.BinaryOperator,
+    ctx.Greater,
+    ctx.Instanceof,
+    ctx.Less
+  ].filter(token => token !== undefined);
 }
 
 function getOperator(tokens: IToken[]) {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
@@ -60,7 +60,30 @@ public class BinaryOperations {
     }
 
   public void binaryExpressionWithCast() {
-    double availability = (double) successfulCount / (successfulCount + failureCount);
+    double availability12 = (double) successfulCount / (successfulCount + failureCount);
+    availability12 = (double) successfulCount / (successfulCount + failureCount);
+  }
+
+  void declarationVsAssignment() {
+    var lineLengthInAssignmentMoreThanPrintWidth = "1234567890" + "1234567890" + "1234567890" + "1234567890" + "1234567890" + "1234567890";
+    lineLengthInAssignmentMoreThanPrintWidth = "1234567890" + "1234567890" + "1234567890" + "1234567890" + "1234567890" + "1234567890";
+
+    aaaaaaaaaa += bbbbbbbbbbb + ccccccccccc + ddddddddddd + eeeeeeeeee + ffffffffff + gggggggggg;
+    aaaaaaaaaa %= bbbbbbbbbbb + ccccccccccc + ddddddddddd + eeeeeeeeee + ffffffffff + gggggggggg;
+    aaaaaaaaaa <<= bbbbbbbbbbb + ccccccccccc + ddddddddddd + eeeeeeeeee + ffffffffff + gggggggggg;
+    aaaaaaaaaa &= bbbbbbbbbbb + ccccccccccc + ddddddddddd + eeeeeeeeee + ffffffffff + gggggggggg;
+
+    var aaaaaaaaaa = bbbbbbbbbb || cccccccccc ? dddddddddd + eeeeeeeeee : ffffffffff + gggggggggg;
+    aaaaaaaaaa = bbbbbbbbbb || cccccccccc ? dddddddddd + eeeeeeeeee : ffffffffff + gggggggggg;
+
+    var something = MyClass.staticFunction(aaaaaaaaaa, bbbbbbbbbbb, ccccccccccc, ddddddddddd);
+    something = MyClass.staticFunction(aaaaaaaaaa, bbbbbbbbbbb, ccccccccccc, ddddddddddd);
+
+    var something = MyClass.staticFunction(aaaaaaaaaa, bbbbbbbbbbb, ccccccccccc, ddddddddddd) + 0;
+    something = MyClass.staticFunction(aaaaaaaaaa, bbbbbbbbbbb, ccccccccccc, ddddddddddd) + 0;
+
+    var something12 = new MyClass(aaaaaaaaaa, bbbbbbbbbbb, ccccccccccc, ddddddddddd);
+    something12 = new MyClass(aaaaaaaaaa, bbbbbbbbbbb, ccccccccccc, ddddddddddd);
   }
 
   void parentheses() {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -86,8 +86,106 @@ public class BinaryOperations {
   }
 
   public void binaryExpressionWithCast() {
-    double availability =
+    double availability12 =
       (double) successfulCount / (successfulCount + failureCount);
+    availability12 =
+      (double) successfulCount / (successfulCount + failureCount);
+  }
+
+  void declarationVsAssignment() {
+    var lineLengthInAssignmentMoreThanPrintWidth =
+      "1234567890" +
+      "1234567890" +
+      "1234567890" +
+      "1234567890" +
+      "1234567890" +
+      "1234567890";
+    lineLengthInAssignmentMoreThanPrintWidth =
+      "1234567890" +
+      "1234567890" +
+      "1234567890" +
+      "1234567890" +
+      "1234567890" +
+      "1234567890";
+
+    aaaaaaaaaa +=
+      bbbbbbbbbbb +
+      ccccccccccc +
+      ddddddddddd +
+      eeeeeeeeee +
+      ffffffffff +
+      gggggggggg;
+    aaaaaaaaaa %=
+      bbbbbbbbbbb +
+      ccccccccccc +
+      ddddddddddd +
+      eeeeeeeeee +
+      ffffffffff +
+      gggggggggg;
+    aaaaaaaaaa <<=
+      bbbbbbbbbbb +
+      ccccccccccc +
+      ddddddddddd +
+      eeeeeeeeee +
+      ffffffffff +
+      gggggggggg;
+    aaaaaaaaaa &=
+      bbbbbbbbbbb +
+      ccccccccccc +
+      ddddddddddd +
+      eeeeeeeeee +
+      ffffffffff +
+      gggggggggg;
+
+    var aaaaaaaaaa = bbbbbbbbbb || cccccccccc
+      ? dddddddddd + eeeeeeeeee
+      : ffffffffff + gggggggggg;
+    aaaaaaaaaa = bbbbbbbbbb || cccccccccc
+      ? dddddddddd + eeeeeeeeee
+      : ffffffffff + gggggggggg;
+
+    var something = MyClass.staticFunction(
+      aaaaaaaaaa,
+      bbbbbbbbbbb,
+      ccccccccccc,
+      ddddddddddd
+    );
+    something = MyClass.staticFunction(
+      aaaaaaaaaa,
+      bbbbbbbbbbb,
+      ccccccccccc,
+      ddddddddddd
+    );
+
+    var something =
+      MyClass.staticFunction(
+        aaaaaaaaaa,
+        bbbbbbbbbbb,
+        ccccccccccc,
+        ddddddddddd
+      ) +
+      0;
+    something =
+      MyClass.staticFunction(
+        aaaaaaaaaa,
+        bbbbbbbbbbb,
+        ccccccccccc,
+        ddddddddddd
+      ) +
+      0;
+
+    var something12 = new MyClass(
+      aaaaaaaaaa,
+      bbbbbbbbbbb,
+      ccccccccccc,
+      ddddddddddd
+    );
+    something12 = new MyClass(
+      aaaaaaaaaa,
+      bbbbbbbbbbb,
+      ccccccccccc,
+      ddddddddddd
+    );
   }
 
   void parentheses() {


### PR DESCRIPTION
## What changed with this PR:

Assignment expressions with boolean expression righthand sides no longer break/indent poorly, and assignment expressions in general are now printed the same way as variable declarations.

## Example

### Input

```java
class Example {

  void example() {
    double availability12 =
      (double) successfulCount / (successfulCount + failureCount);
    availability12 = (double) successfulCount /
    (successfulCount + failureCount);

    var lineLengthInAssignmentMoreThanPrintWidth =
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890";
    lineLengthInAssignmentMoreThanPrintWidth = "1234567890" +
    "1234567890" +
    "1234567890" +
    "1234567890" +
    "1234567890" +
    "1234567890";

    aaaaaaaaaa +=
    bbbbbbbbbbb +
    ccccccccccc +
    ddddddddddd +
    eeeeeeeeee +
    ffffffffff +
    gggggggggg;
    aaaaaaaaaa %=
    bbbbbbbbbbb +
    ccccccccccc +
    ddddddddddd +
    eeeeeeeeee +
    ffffffffff +
    gggggggggg;
    aaaaaaaaaa <<=
    bbbbbbbbbbb +
    ccccccccccc +
    ddddddddddd +
    eeeeeeeeee +
    ffffffffff +
    gggggggggg;
    aaaaaaaaaa &=
    bbbbbbbbbbb +
    ccccccccccc +
    ddddddddddd +
    eeeeeeeeee +
    ffffffffff +
    gggggggggg;

    var something =
      MyClass.staticFunction(
        aaaaaaaaaa,
        bbbbbbbbbbb,
        ccccccccccc,
        ddddddddddd
      ) +
      0;
    something = MyClass.staticFunction(
      aaaaaaaaaa,
      bbbbbbbbbbb,
      ccccccccccc,
      ddddddddddd
    ) +
    0;
  }
}
```

### Output
```java
class Example {

  void example() {
    double availability12 =
      (double) successfulCount / (successfulCount + failureCount);
    availability12 =
      (double) successfulCount / (successfulCount + failureCount);

    var lineLengthInAssignmentMoreThanPrintWidth =
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890";
    lineLengthInAssignmentMoreThanPrintWidth =
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890" +
      "1234567890";

    aaaaaaaaaa +=
      bbbbbbbbbbb +
      ccccccccccc +
      ddddddddddd +
      eeeeeeeeee +
      ffffffffff +
      gggggggggg;
    aaaaaaaaaa %=
      bbbbbbbbbbb +
      ccccccccccc +
      ddddddddddd +
      eeeeeeeeee +
      ffffffffff +
      gggggggggg;
    aaaaaaaaaa <<=
      bbbbbbbbbbb +
      ccccccccccc +
      ddddddddddd +
      eeeeeeeeee +
      ffffffffff +
      gggggggggg;
    aaaaaaaaaa &=
      bbbbbbbbbbb +
      ccccccccccc +
      ddddddddddd +
      eeeeeeeeee +
      ffffffffff +
      gggggggggg;

    var something =
      MyClass.staticFunction(
        aaaaaaaaaa,
        bbbbbbbbbbb,
        ccccccccccc,
        ddddddddddd
      ) +
      0;
    something =
      MyClass.staticFunction(
        aaaaaaaaaa,
        bbbbbbbbbbb,
        ccccccccccc,
        ddddddddddd
      ) +
      0;
  }
}
```

## Relative issues or prs:

Closes #687