### PR TITLE
fix: move prettier from `dependencies` to `devDependencies`

### DIFF
--- a/packages/prettier-plugin-java/package.json
+++ b/packages/prettier-plugin-java/package.json
@@ -12,8 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "java-parser": "2.3.2",
-    "lodash": "4.17.21",
-    "prettier": "3.2.5"
+    "lodash": "4.17.21"
   },
   "scripts": {
     "test": "yarn run test:unit && yarn run test:e2e-core",
@@ -35,7 +34,11 @@
     "@types/lodash": "4.14.190",
     "@types/node": "18.11.9",
     "@types/sinon": "10.0.13",
+    "prettier": "3.2.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.3"
+  },
+  "peerDependencies": {
+    "prettier": "^3.0.0"
   }
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

This PR moves prettier from `dependencies` to `devDependencies` and adds it to `peerDependencies`.