### PR TITLE
fix(website): prevent playground formatted editor from being empty on navigation

### DIFF
--- a/website/src/components/CodeEditor/index.tsx
+++ b/website/src/components/CodeEditor/index.tsx
@@ -6,7 +6,6 @@ export default function CodeEditor(
   props: Readonly<{
     readOnly?: boolean;
     value?: string;
-    defaultValue?: string;
     onChange?: (value: string | undefined) => void;
   }>
 ) {
@@ -15,7 +14,6 @@ export default function CodeEditor(
   return (
     <div className={styles.editor}>
       <Editor
-        defaultValue={props.defaultValue}
         language="java"
         options={{ readOnly: props.readOnly }}
         theme={colorMode === "dark" ? "vs-dark" : "light"}

--- a/website/src/pages/playground/index.tsx
+++ b/website/src/pages/playground/index.tsx
@@ -146,7 +146,7 @@ function Inner() {
               }
             >
               {Object.values(TrailingComma).map(option => (
-                <option>{option}</option>
+                <option key={option}>{option}</option>
               ))}
             </select>
           </label>
@@ -164,8 +164,10 @@ function Inner() {
         </details>
       </div>
       <div className={styles.editors}>
-        <CodeEditor defaultValue={code} onChange={setCode} />
-        <CodeEditor readOnly value={formattedCode} />
+        <CodeEditor value={code} onChange={setCode} />
+        {isFirstRun.current ? null : (
+          <CodeEditor readOnly value={formattedCode} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed with this PR:

Website's playground no longer displays an empty formatted (read-only) editor when navigating to another page and then back to the playground.

There seems to be a bug in Monaco Editor for React where in certain situations, updating its value prop immediately after rendering the component for the first time causes it to continue rendering the original value. I verified that the component was being passed the formatted code as its value 2nd, after initially setting it to empty, and yet it was rendering empty.

This fix works around that apparent bug by no longer rendering the component at all on the initial render, meaning it will only render the formatted (read-only) editor after Prettier formats it.