### PR TITLE
fix(707): do not throw if the record-pattern contains dims

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 18.x
           - 20.x
+          - 22.x
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -33,7 +33,7 @@ jobs:
         test_repository:
           - e2e-jhipster1
           - e2e-jhipster2
-        node_version: [18.x]
+        node_version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -41,7 +41,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
       - uses: actions/setup-java@v3
         with:
-          java-version: 17.x
+          java-version: 21.x
           distribution: zulu
       - name: Install dependencies
         run: yarn

--- a/packages/java-parser/api.d.ts
+++ b/packages/java-parser/api.d.ts
@@ -171,6 +171,10 @@ export abstract class JavaCstVisitor<IN, OUT> implements ICstVisitor<IN, OUT> {
     param?: IN
   ): OUT;
   isDims(ctx: IsDimsCtx, param?: IN): OUT;
+  isFollowingVariableDeclarator(
+    ctx: IsFollowingVariableDeclaratorCtx,
+    param?: IN
+  ): OUT;
   compilationUnit(ctx: CompilationUnitCtx, param?: IN): OUT;
   ordinaryCompilationUnit(ctx: OrdinaryCompilationUnitCtx, param?: IN): OUT;
   modularCompilationUnit(ctx: ModularCompilationUnitCtx, param?: IN): OUT;
@@ -499,6 +503,10 @@ export abstract class JavaCstVisitorWithDefaults<IN, OUT>
     param?: IN
   ): OUT;
   isDims(ctx: IsDimsCtx, param?: IN): OUT;
+  isFollowingVariableDeclarator(
+    ctx: IsFollowingVariableDeclaratorCtx,
+    param?: IN
+  ): OUT;
   compilationUnit(ctx: CompilationUnitCtx, param?: IN): OUT;
   ordinaryCompilationUnit(ctx: OrdinaryCompilationUnitCtx, param?: IN): OUT;
   modularCompilationUnit(ctx: ModularCompilationUnitCtx, param?: IN): OUT;
@@ -1555,7 +1563,7 @@ export interface SimpleTypeNameCstNode extends CstNode {
 }
 
 export type SimpleTypeNameCtx = {
-  TypeIdentifier: TypeIdentifierCstNode[];
+  typeIdentifier: TypeIdentifierCstNode[];
 };
 
 export interface ConstructorBodyCstNode extends CstNode {
@@ -1792,6 +1800,16 @@ export type IsDimsCtx = {
   elementValuePairList?: ElementValuePairListCstNode[];
   elementValue?: ElementValueCstNode[];
   RBrace?: IToken[];
+};
+
+export interface IsFollowingVariableDeclaratorCstNode extends CstNode {
+  name: "isFollowingVariableDeclarator";
+  children: IsFollowingVariableDeclaratorCtx;
+}
+
+export type IsFollowingVariableDeclaratorCtx = {
+  Comma: IToken[];
+  variableDeclarator: VariableDeclaratorCstNode[];
 };
 
 export interface CompilationUnitCstNode extends CstNode {
@@ -2238,7 +2256,7 @@ export interface ElementValueCstNode extends CstNode {
 }
 
 export type ElementValueCtx = {
-  expression?: ExpressionCstNode[];
+  conditionalExpression?: ConditionalExpressionCstNode[];
   elementValueArrayInitializer?: ElementValueArrayInitializerCstNode[];
   annotation?: AnnotationCstNode[];
 };
@@ -2469,8 +2487,8 @@ export interface SwitchBlockCstNode extends CstNode {
 
 export type SwitchBlockCtx = {
   LCurly: IToken[];
-  switchBlockStatementGroup?: SwitchBlockStatementGroupCstNode[];
   switchRule?: SwitchRuleCstNode[];
+  switchBlockStatementGroup?: SwitchBlockStatementGroupCstNode[];
   RCurly: IToken[];
 };
 
@@ -2492,8 +2510,8 @@ export interface SwitchLabelCstNode extends CstNode {
 
 export type SwitchLabelCtx = {
   Case?: IToken[];
-  Comma?: IToken[];
   Null?: IToken[];
+  Comma?: IToken[];
   Default?: IToken[];
   casePattern?: CasePatternCstNode[];
   guard?: GuardCstNode[];
@@ -2888,11 +2906,11 @@ export interface NormalLambdaParameterListCstNode extends CstNode {
 }
 
 export type NormalLambdaParameterListCtx = {
-  normalLambdaParameter: LambdaParameterCstNode[];
+  normalLambdaParameter: NormalLambdaParameterCstNode[];
   Comma?: IToken[];
 };
 
-export interface LambdaParameterCstNode extends CstNode {
+export interface NormalLambdaParameterCstNode extends CstNode {
   name: "normalLambdaParameter";
   children: LambdaParameterCtx;
 }

--- a/packages/java-parser/scripts/generate-signature.js
+++ b/packages/java-parser/scripts/generate-signature.js
@@ -2,7 +2,12 @@
 import _ from "lodash";
 import path from "path";
 import fs from "fs";
-import JavaParser from "../src/parser";
+import { fileURLToPath } from "url";
+
+import JavaParser from "../src/parser.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const parseRule = rule => {
   const children = {};

--- a/packages/java-parser/scripts/single-sample-runner.js
+++ b/packages/java-parser/scripts/single-sample-runner.js
@@ -1,10 +1,14 @@
 /**
  * This Script is used to debug the parsing of **small** code snippets.
  */
-import javaParserChev from "../src/index";
+import javaParserChev from "../src/index.js";
 
 const input = `
-@Anno byte @Nullable ... test
+public class VariableTypeInference {
+
+ int foo = 0, bar = 1;
+}
+
 `;
 
-javaParserChev.parse(input, "variableArityParameter");
+javaParserChev.parse(input, "compilationUnit");

--- a/packages/java-parser/test/classes-spec.js
+++ b/packages/java-parser/test/classes-spec.js
@@ -1,0 +1,9 @@
+import { expect } from "chai";
+import * as javaParser from "../src/index.js";
+
+describe("The Java Parser fixed bugs", () => {
+  it("should handle multiple variable declaration", () => {
+    const input = `int foo, bar;`;
+    expect(() => javaParser.parse(input, "fieldDeclaration")).to.not.throw();
+  });
+});

--- a/packages/java-parser/test/pattern-matching/pattern-matching-spec.js
+++ b/packages/java-parser/test/pattern-matching/pattern-matching-spec.js
@@ -54,4 +54,34 @@ describe("Pattern matching", () => {
       javaParser.parse(input, "componentPatternList")
     ).to.not.throw();
   });
+
+  it("should parse pattern list with dims", () => {
+    const input = `A a, B[] b`;
+    expect(() =>
+      javaParser.parse(input, "componentPatternList")
+    ).to.not.throw();
+  });
+
+  it("should parse pattern list with nested records", () => {
+    const input =
+      "int a, Location (String name, GPSPoint(int latitude, int longitude))";
+    expect(() =>
+      javaParser.parse(input, "componentPatternList")
+    ).to.not.throw();
+  });
+
+  it("should parse pattern list with var", () => {
+    const input =
+      "int a, Location (var name, GPSPoint(var latitude, var longitude))";
+    expect(() =>
+      javaParser.parse(input, "componentPatternList")
+    ).to.not.throw();
+  });
+
+  it("should parse pattern list with nested records and annotation", () => {
+    const input = "int a, @not Location (String name)";
+    expect(() =>
+      javaParser.parse(input, "componentPatternList")
+    ).to.not.throw();
+  });
 });

--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -56,6 +56,7 @@ import {
   FormalParameterListCtx,
   InstanceInitializerCtx,
   InterfaceTypeListCtx,
+  IsFollowingVariableDeclaratorCtx,
   IToken,
   MethodBodyCtx,
   MethodDeclarationCtx,
@@ -1070,5 +1071,9 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
 
   isDims() {
     return "isDims";
+  }
+
+  isFollowingVariableDeclarator() {
+    return "isFollowingVariableDeclarator";
   }
 }


### PR DESCRIPTION
## What changed with this PR:

<!-- Quick summary of what is the purpose of this PR -->

This piece of code was failing as the java-parser tried to parse `String otherName, String[] otherContent` as a variable declaration list instead of component pattern list

I added backtrack lookahead which fixed the issue but will see if we can avoid it completely.

```java
// Input
public class Foo {
  public void bar() {
    if (!(obj instanceof Project(String otherName, String[] otherContent))) {
      return false;
    }
  }
}
```

## Relative issues or prs:

#707 
<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
