### PR TITLE
Fix/712 handle comments with static invocations

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -392,29 +392,14 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
       shouldBreakBeforeFirstMethodInvocation
     });
 
-    const suffixes = [];
+    const suffixes = this.getPrimarySuffixes(
+      ctx,
+      newExpression,
+      isBreakableNewExpression,
+      shouldBreakBeforeMethodInvocations
+    );
 
     if (ctx.primarySuffix !== undefined) {
-      if (
-        newExpression &&
-        !isBreakableNewExpression &&
-        ctx.primarySuffix[0].children.Dot !== undefined
-      ) {
-        suffixes.push(softline);
-      }
-      suffixes.push(this.visit(ctx.primarySuffix[0]));
-
-      for (let i = 1; i < ctx.primarySuffix.length; i++) {
-        if (
-          shouldBreakBeforeMethodInvocations &&
-          ctx.primarySuffix[i].children.Dot !== undefined &&
-          ctx.primarySuffix[i - 1].children.methodInvocationSuffix !== undefined
-        ) {
-          suffixes.push(softline);
-        }
-        suffixes.push(this.visit(ctx.primarySuffix[i]));
-      }
-
       if (!newExpression && countMethodInvocation === 1) {
         return group(
           rejectAndConcat([
@@ -921,5 +906,39 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
 
     const lastDot = fqnOrRefType.Dot[fqnOrRefType.Dot.length - 1];
     return lastDot;
+  }
+
+  private getPrimarySuffixes(
+    ctx: PrimaryCtx,
+    newExpression: NewExpressionCtx | undefined,
+    isBreakableNewExpression: boolean,
+    shouldBreakBeforeMethodInvocations: NewExpressionCtx | boolean
+  ) {
+    if (ctx.primarySuffix === undefined) {
+      return [];
+    }
+
+    const suffixes = [];
+
+    if (
+      newExpression &&
+      !isBreakableNewExpression &&
+      ctx.primarySuffix[0].children.Dot !== undefined
+    ) {
+      suffixes.push(softline);
+    }
+    suffixes.push(this.visit(ctx.primarySuffix[0]));
+
+    for (let i = 1; i < ctx.primarySuffix.length; i++) {
+      if (
+        shouldBreakBeforeMethodInvocations &&
+        ctx.primarySuffix[i].children.Dot !== undefined &&
+        ctx.primarySuffix[i - 1].children.methodInvocationSuffix !== undefined
+      ) {
+        suffixes.push(softline);
+      }
+      suffixes.push(this.visit(ctx.primarySuffix[i]));
+    }
+    return suffixes;
   }
 }

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -368,8 +368,7 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
 
     const hasFqnRefPart = fqnOrRefType?.fqnOrRefTypePartRest !== undefined;
     const lastFqnRefPartDot = this.lastDot(fqnOrRefType);
-    const isCapitalizedIdentifier =
-      !!this.isCapitalizedIdentifier(fqnOrRefType);
+    const isCapitalizedIdentifier = this.isCapitalizedIdentifier(fqnOrRefType);
     const isCapitalizedIdentifierWithoutTrailingComment =
       isCapitalizedIdentifier &&
       (lastFqnRefPartDot === undefined ||
@@ -894,7 +893,7 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
       fqnOrRefTypeParts[fqnOrRefTypeParts.length - 2]?.children
         .fqnOrRefTypePartCommon[0].children.Identifier?.[0].image;
     return (
-      nextToLastIdentifier &&
+      !!nextToLastIdentifier &&
       /^\p{Uppercase_Letter}/u.test(nextToLastIdentifier)
     );
   }

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -380,7 +380,7 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const shouldBreakBeforeMethodInvocations =
       shouldBreakBeforeFirstMethodInvocation ||
       countMethodInvocation > 2 ||
-      (countMethodInvocation > 1 && newExpression) ||
+      (countMethodInvocation > 1 && !!newExpression) ||
       !firstMethodInvocation?.argumentList;
 
     const primaryPrefix = this.visit(ctx.primaryPrefix, {

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -397,16 +397,14 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
       shouldBreakBeforeMethodInvocations
     );
 
-    if (ctx.primarySuffix !== undefined) {
-      if (!newExpression && countMethodInvocation === 1) {
-        return group(
-          rejectAndConcat([
-            primaryPrefix,
-            suffixes[0],
-            indent(rejectAndConcat(suffixes.slice(1)))
-          ])
-        );
-      }
+    if (!newExpression && countMethodInvocation === 1) {
+      return group(
+        rejectAndConcat([
+          primaryPrefix,
+          suffixes[0],
+          indent(rejectAndConcat(suffixes.slice(1)))
+        ])
+      );
     }
 
     const methodInvocation =

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -367,12 +367,10 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const fqnOrRefType =
       ctx.primaryPrefix[0].children.fqnOrRefType?.[0].children;
     const hasFqnRefPart = fqnOrRefType?.fqnOrRefTypePartRest !== undefined;
-    const lastFqnRefPartDot = this.lastDot(fqnOrRefType);
-    const isCapitalizedIdentifier = this.isCapitalizedIdentifier(fqnOrRefType);
-    const isCapitalizedIdentifierWithoutTrailingComment =
-      isCapitalizedIdentifier &&
-      (lastFqnRefPartDot === undefined ||
-        !hasLeadingComments(lastFqnRefPartDot));
+    const {
+      isCapitalizedIdentifier,
+      isCapitalizedIdentifierWithoutTrailingComment
+    } = this.handleStaticInvocations(fqnOrRefType);
 
     const shouldBreakBeforeFirstMethodInvocation =
       countMethodInvocation > 1 &&
@@ -425,6 +423,20 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
           : concat(suffixes)
       ])
     );
+  }
+
+  private handleStaticInvocations(fqnOrRefType: FqnOrRefTypeCtx | undefined) {
+    const lastFqnRefPartDot = this.lastFqnOrRefDot(fqnOrRefType);
+    const isCapitalizedIdentifier = this.isCapitalizedIdentifier(fqnOrRefType);
+    const isCapitalizedIdentifierWithoutTrailingComment =
+      isCapitalizedIdentifier &&
+      (lastFqnRefPartDot === undefined ||
+        !hasLeadingComments(lastFqnRefPartDot));
+
+    return {
+      isCapitalizedIdentifier,
+      isCapitalizedIdentifierWithoutTrailingComment
+    };
   }
 
   primaryPrefix(ctx: PrimaryPrefixCtx, params: any) {
@@ -895,13 +907,12 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     );
   }
 
-  private lastDot(fqnOrRefType: FqnOrRefTypeCtx | undefined) {
+  private lastFqnOrRefDot(fqnOrRefType: FqnOrRefTypeCtx | undefined) {
     if (fqnOrRefType === undefined || fqnOrRefType.Dot === undefined) {
       return undefined;
     }
 
-    const lastDot = fqnOrRefType.Dot[fqnOrRefType.Dot.length - 1];
-    return lastDot;
+    return fqnOrRefType.Dot[fqnOrRefType.Dot.length - 1];
   }
 
   private getPrimarySuffixes(

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -364,11 +364,15 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const firstMethodInvocation = ctx.primarySuffix
       ?.map(suffix => suffix.children.methodInvocationSuffix?.[0].children)
       .find(methodInvocationSuffix => methodInvocationSuffix);
-    const isCapitalizedIdentifier = this.isCapitalizedIdentifier(fqnOrRefType);
+
+    const hasFqnRefPart = fqnOrRefType?.fqnOrRefTypePartRest !== undefined;
+    const isCapitalizedIdentifier = !!this.isCapitalizedIdentifier(fqnOrRefType);
     const shouldBreakBeforeFirstMethodInvocation =
       countMethodInvocation > 1 &&
-      !(isCapitalizedIdentifier ?? true) &&
+      hasFqnRefPart &&
+      !isCapitalizedIdentifier &&
       firstMethodInvocation !== undefined;
+
     const shouldBreakBeforeMethodInvocations =
       shouldBreakBeforeFirstMethodInvocation ||
       countMethodInvocation > 2 ||

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -2,14 +2,14 @@ import {
   ArgumentListCtx,
   ArrayAccessSuffixCtx,
   ArrayCreationExpressionCtx,
-  ArrayCreationWithInitializerSuffixCtx,
   ArrayCreationExpressionWithoutInitializerSuffixCtx,
+  ArrayCreationWithInitializerSuffixCtx,
   BinaryExpressionCtx,
   CastExpressionCtx,
   ClassLiteralSuffixCtx,
   ClassOrInterfaceTypeToInstantiateCtx,
-  ComponentPatternListCtx,
   ComponentPatternCtx,
+  ComponentPatternListCtx,
   ConciseLambdaParameterCtx,
   ConciseLambdaParameterListCtx,
   ConditionalExpressionCtx,
@@ -395,19 +395,6 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const suffixes = [];
 
     if (ctx.primarySuffix !== undefined) {
-      // edge case: https://github.com/jhipster/prettier-java/issues/381
-      let hasFirstInvocationArg = true;
-
-      if (
-        ctx.primarySuffix.length > 1 &&
-        ctx.primarySuffix[1].children.methodInvocationSuffix &&
-        Object.keys(
-          ctx.primarySuffix[1].children.methodInvocationSuffix[0].children
-        ).length === 2
-      ) {
-        hasFirstInvocationArg = false;
-      }
-
       if (
         newExpression &&
         !isBreakableNewExpression &&
@@ -432,7 +419,7 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
         return group(
           rejectAndConcat([
             primaryPrefix,
-            hasFirstInvocationArg ? suffixes[0] : indent(suffixes[0]),
+            suffixes[0],
             indent(rejectAndConcat(suffixes.slice(1)))
           ])
         );

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -360,12 +360,12 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const isBreakableNewExpression =
       countMethodInvocation <= 1 &&
       this.isBreakableNewExpression(newExpression);
-    const fqnOrRefType =
-      ctx.primaryPrefix[0].children.fqnOrRefType?.[0].children;
     const firstMethodInvocation = ctx.primarySuffix
       ?.map(suffix => suffix.children.methodInvocationSuffix?.[0].children)
       .find(methodInvocationSuffix => methodInvocationSuffix);
 
+    const fqnOrRefType =
+      ctx.primaryPrefix[0].children.fqnOrRefType?.[0].children;
     const hasFqnRefPart = fqnOrRefType?.fqnOrRefTypePartRest !== undefined;
     const lastFqnRefPartDot = this.lastDot(fqnOrRefType);
     const isCapitalizedIdentifier = this.isCapitalizedIdentifier(fqnOrRefType);
@@ -377,8 +377,7 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const shouldBreakBeforeFirstMethodInvocation =
       countMethodInvocation > 1 &&
       hasFqnRefPart &&
-      !isCapitalizedIdentifierWithoutTrailingComment &&
-      firstMethodInvocation !== undefined;
+      !isCapitalizedIdentifierWithoutTrailingComment;
 
     const shouldBreakBeforeMethodInvocations =
       shouldBreakBeforeFirstMethodInvocation ||

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_input.java
@@ -57,6 +57,9 @@ public class BinaryOperations {
     public void method() {
         new Foo(stuff, thing, "auaaaaaaaaa some very long stuff", "some more").bar(10);
         foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more").bar(10);
+
+        // Issue 381
+        new MethodWrappingFollowingContstructor().aLongEnoughMethodNameToForceThingsToWrap();
     }
 
   public void binaryExpressionWithCast() {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/_output.java
@@ -83,6 +83,10 @@ public class BinaryOperations {
     foo(stuff, thing, "some very longuuuuuuuuuuuuuu stuff", "some more").bar(
       10
     );
+
+    // Issue 381
+    new MethodWrappingFollowingContstructor()
+      .aLongEnoughMethodNameToForceThingsToWrap();
   }
 
   public void binaryExpressionWithCast() {

--- a/packages/prettier-plugin-java/test/unit-test/member_chain/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/member_chain/_input.java
@@ -4,6 +4,42 @@ public class BreakLongFunctionCall {
 		return new Object().something().more();
 	}
 
+    public void doSomethingNewWithComment() {
+        return new Object()
+            // comment
+            .something().more();
+    }
+
+    public void doSomethingWithComment() {
+        return Object
+            // comment
+            .something().more();
+    }
+
+    public void doSomethingWithComment() {
+        return object
+            // comment
+            .something().more();
+    }
+
+    public void doSomethingNewWithComment() {
+        return new Object()
+            /* comment */
+            .something().more();
+    }
+
+    public void doSomethingWithComment() {
+        return Object
+            /* comment */
+            .something().more();
+    }
+
+    public void doSomethingWithComment() {
+        return object
+            /* comment */
+            .something().more();
+    }
+
 	public void doSomethingLongNew() {
 		return something().more().and().that().as().well().but().not().something().something();
     }

--- a/packages/prettier-plugin-java/test/unit-test/member_chain/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/member_chain/_output.java
@@ -4,6 +4,48 @@ public class BreakLongFunctionCall {
     return new Object().something().more();
   }
 
+  public void doSomethingNewWithComment() {
+    return new Object()
+      // comment
+      .something()
+      .more();
+  }
+
+  public void doSomethingWithComment() {
+    return Object
+      // comment
+      .something()
+      .more();
+  }
+
+  public void doSomethingWithComment() {
+    return object
+      // comment
+      .something()
+      .more();
+  }
+
+  public void doSomethingNewWithComment() {
+    return new Object()
+      /* comment */
+      .something()
+      .more();
+  }
+
+  public void doSomethingWithComment() {
+    return Object
+      /* comment */
+      .something()
+      .more();
+  }
+
+  public void doSomethingWithComment() {
+    return object
+      /* comment */
+      .something()
+      .more();
+  }
+
   public void doSomethingLongNew() {
     return something()
       .more()


### PR DESCRIPTION
## What changed with this PR:

Always break in method invocations if last dot has leading comments

## Example

```java
// Input
class Main {

  public static void main(String[] args) {
    return MyClass
        // comment
        .doSomething();
  }
}

// Previous Output
class Main {

    public static void main(String[] args) {
        return MyClass// comment
        .doSomething();
    }
}

// Output
class Main {

  public static void main(String[] args) {
    return MyClass
        // comment
        .doSomething();
  }
}
```

## Relative issues or prs:

Fix #712 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
