### PR TITLE
fix: restore require support for VS Code compatibility

### DIFF
--- a/packages/prettier-plugin-java/package.json
+++ b/packages/prettier-plugin-java/package.json
@@ -4,10 +4,8 @@
   "description": "Prettier Java Plugin",
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./dist/index.js"
-    }
+    "types": "./index.d.ts",
+    "default": "./dist/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## What changed with this PR:

Support for require is restored for compatibility with the Prettier VS Code plugin.

## Relative issues or prs:

Closes #711