### PR TITLE
Fix/712 handle comments with static invocations

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -467,8 +467,9 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
           : concat([softline, dots[0]]);
         return rejectAndConcat([
           indent(
-            rejectAndJoin(separator, [
+            rejectAndConcat([
               fqnOrRefTypePartFirst,
+              separator,
               rejectAndJoinSeps(dots.slice(1), fqnOrRefTypePartRest),
               dims
             ])

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -367,15 +367,10 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const fqnOrRefType =
       ctx.primaryPrefix[0].children.fqnOrRefType?.[0].children;
     const hasFqnRefPart = fqnOrRefType?.fqnOrRefTypePartRest !== undefined;
-    const {
-      isCapitalizedIdentifier,
-      isCapitalizedIdentifierWithoutTrailingComment
-    } = this.handleStaticInvocations(fqnOrRefType);
+    const isCapitalizedIdentifier = this.isCapitalizedIdentifier(fqnOrRefType);
 
     const shouldBreakBeforeFirstMethodInvocation =
-      countMethodInvocation > 1 &&
-      hasFqnRefPart &&
-      !isCapitalizedIdentifierWithoutTrailingComment;
+      countMethodInvocation > 1 && hasFqnRefPart && !isCapitalizedIdentifier;
 
     const shouldBreakBeforeMethodInvocations =
       shouldBreakBeforeFirstMethodInvocation ||
@@ -425,20 +420,6 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     );
   }
 
-  private handleStaticInvocations(fqnOrRefType: FqnOrRefTypeCtx | undefined) {
-    const lastFqnRefPartDot = this.lastFqnOrRefDot(fqnOrRefType);
-    const isCapitalizedIdentifier = this.isCapitalizedIdentifier(fqnOrRefType);
-    const isCapitalizedIdentifierWithoutTrailingComment =
-      isCapitalizedIdentifier &&
-      (lastFqnRefPartDot === undefined ||
-        !hasLeadingComments(lastFqnRefPartDot));
-
-    return {
-      isCapitalizedIdentifier,
-      isCapitalizedIdentifierWithoutTrailingComment
-    };
-  }
-
   primaryPrefix(ctx: PrimaryPrefixCtx, params: any) {
     if (ctx.This || ctx.Void) {
       return printTokenWithComments(this.getSingle(ctx) as IToken);
@@ -468,18 +449,25 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
     const fqnOrRefTypePartFirst = this.visit(ctx.fqnOrRefTypePartFirst);
     const fqnOrRefTypePartRest = this.mapVisit(ctx.fqnOrRefTypePartRest);
     const dims = this.visit(ctx.dims);
-    const dots = ctx.Dot ? ctx.Dot : [];
+    const dots = ctx.Dot
+      ? ctx.Dot.map(dot => {
+          if (hasLeadingComments(dot)) {
+            return concat([softline, dot]);
+          }
+          return dot;
+        })
+      : [];
     const isMethodInvocation = ctx.Dot && ctx.Dot.length === 1;
 
-    if (
-      params !== undefined &&
-      params.shouldBreakBeforeFirstMethodInvocation === true
-    ) {
+    if (params?.shouldBreakBeforeFirstMethodInvocation === true) {
       // when fqnOrRefType is a method call from an object
       if (isMethodInvocation) {
+        const separator = hasLeadingComments(ctx.Dot![0])
+          ? dots[0]
+          : concat([softline, dots[0]]);
         return rejectAndConcat([
           indent(
-            rejectAndJoin(concat([softline, dots[0]]), [
+            rejectAndJoin(separator, [
               fqnOrRefTypePartFirst,
               rejectAndJoinSeps(dots.slice(1), fqnOrRefTypePartRest),
               dims
@@ -488,27 +476,34 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
         ]);
         // otherwise it is a fully qualified name but we need to exclude when it is just a method call
       } else if (ctx.Dot) {
+        const lastDot = ctx.Dot[ctx.Dot.length - 1];
+        const separator = hasLeadingComments(lastDot)
+          ? dots[dots.length - 1]
+          : concat([softline, lastDot]);
+
         return indent(
           rejectAndConcat([
             rejectAndJoinSeps(dots.slice(0, dots.length - 1), [
               fqnOrRefTypePartFirst,
               ...fqnOrRefTypePartRest.slice(0, fqnOrRefTypePartRest.length - 1)
             ]),
-            softline,
-            rejectAndConcat([
-              dots[dots.length - 1],
-              fqnOrRefTypePartRest[fqnOrRefTypePartRest.length - 1]
-            ]),
+            separator,
+            fqnOrRefTypePartRest[fqnOrRefTypePartRest.length - 1],
             dims
           ])
         );
       }
     }
 
-    return rejectAndConcat([
-      rejectAndJoinSeps(dots, [fqnOrRefTypePartFirst, ...fqnOrRefTypePartRest]),
-      dims
-    ]);
+    return indent(
+      rejectAndConcat([
+        rejectAndJoinSeps(dots, [
+          fqnOrRefTypePartFirst,
+          ...fqnOrRefTypePartRest
+        ]),
+        dims
+      ])
+    );
   }
 
   fqnOrRefTypePartFirst(ctx: FqnOrRefTypePartFirstCtx) {
@@ -905,14 +900,6 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
       !!nextToLastIdentifier &&
       /^\p{Uppercase_Letter}/u.test(nextToLastIdentifier)
     );
-  }
-
-  private lastFqnOrRefDot(fqnOrRefType: FqnOrRefTypeCtx | undefined) {
-    if (fqnOrRefType === undefined || fqnOrRefType.Dot === undefined) {
-      return undefined;
-    }
-
-    return fqnOrRefType.Dot[fqnOrRefType.Dot.length - 1];
   }
 
   private getPrimarySuffixes(

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -457,43 +457,12 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
           return dot;
         })
       : [];
-    const isMethodInvocation = ctx.Dot && ctx.Dot.length === 1;
 
-    if (params?.shouldBreakBeforeFirstMethodInvocation === true) {
-      // when fqnOrRefType is a method call from an object
-      if (isMethodInvocation) {
-        const separator = hasLeadingComments(ctx.Dot![0])
-          ? dots[0]
-          : concat([softline, dots[0]]);
-        return rejectAndConcat([
-          indent(
-            rejectAndConcat([
-              fqnOrRefTypePartFirst,
-              separator,
-              rejectAndJoinSeps(dots.slice(1), fqnOrRefTypePartRest),
-              dims
-            ])
-          )
-        ]);
-        // otherwise it is a fully qualified name but we need to exclude when it is just a method call
-      } else if (ctx.Dot) {
-        const lastDot = ctx.Dot[ctx.Dot.length - 1];
-        const separator = hasLeadingComments(lastDot)
-          ? dots[dots.length - 1]
-          : concat([softline, lastDot]);
-
-        return indent(
-          rejectAndConcat([
-            rejectAndJoinSeps(dots.slice(0, dots.length - 1), [
-              fqnOrRefTypePartFirst,
-              ...fqnOrRefTypePartRest.slice(0, fqnOrRefTypePartRest.length - 1)
-            ]),
-            separator,
-            fqnOrRefTypePartRest[fqnOrRefTypePartRest.length - 1],
-            dims
-          ])
-        );
-      }
+    if (
+      params?.shouldBreakBeforeFirstMethodInvocation === true &&
+      ctx.Dot !== undefined
+    ) {
+      dots[dots.length - 1] = concat([softline, ctx.Dot[ctx.Dot.length - 1]]);
     }
 
     return indent(

--- a/packages/prettier-plugin-java/test/unit-test/member_chain/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/member_chain/_input.java
@@ -1,35 +1,93 @@
 public class BreakLongFunctionCall {
 
-	public void doSomething() {
-		return new Object().something().more();
-	}
+    public void doSomething() {
+        return new Object().something().more();
+    }
+
+    public void doSomethingNewWithComment() {
+        new Object()
+            // comment
+            .something().more();
+
+        new Object().something()
+            // comment
+            .more();
+    }
+
+    public void doSomethingWithComment() {
+        Object
+            // comment
+            .something().more();
+
+        java.Object
+            // comment
+            .something().more();
+
+        java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
+            // comment
+            .something().more();
+
+        java
+            // comment
+            .averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
+            .something().more();
+
+        java
+            .averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong
+            // comment
+            .Object
+            .something().more();
+
+        java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
+            .something().more();
+
+        Object.something()
+            // comment
+            .more();
+
+        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+            // comment
+            .util()
+            .java.java();
+
+        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong
+            // comment
+            .java
+            .util()
+            .java.java();
+
+        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+            /* comment */
+            .util()
+            .java.java();
+
+        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java/* comment */
+            .util()
+            .java.java();
+
+        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+            /* comment */.util()
+            .java.java();
+    }
+
+    public void doSomethingWithComment() {
+        object
+            // comment
+            .something().more();
+
+        object.something()
+            // comment
+            .more();
+    }
 
     public void doSomethingNewWithComment() {
         return new Object()
-            // comment
+            /* comment */
             .something().more();
     }
 
     public void doSomethingWithComment() {
         return Object
-            // comment
-            .something().more();
-    }
-
-    public void doSomethingWithComment() {
-        return object
-            // comment
-            .something().more();
-    }
-
-    public void doSomethingNewWithComment() {
-        return new Object()
-            /* comment */
-            .something().more();
-    }
-
-    public void doSomethingWithComment() {
-        return Object
             /* comment */
             .something().more();
     }
@@ -40,28 +98,28 @@ public class BreakLongFunctionCall {
             .something().more();
     }
 
-	public void doSomethingLongNew() {
-		return something().more().and().that().as().well().but().not().something().something();
+    public void doSomethingLongNew() {
+        return something().more().and().that().as().well().but().not().something().something();
     }
 
     public void doSomethingLongWithArgument() {
         return something().more(firstArgument, secondArgument).and(firstArgument, secondArgument, thirdArgument, fourthArgument, fifthArgument);
     }
 
-	public void doSomethingLongNew2() {
-		return new Object().something().more().and().that().as().well().but().not().something();
-	}
+    public void doSomethingLongNew2() {
+        return new Object().something().more().and().that().as().well().but().not().something();
+    }
 
-	public void doSomethingLongStatic() {
-		return Object.something().more().and().that().as().well().but().not().something();
-  }
+    public void doSomethingLongStatic() {
+        return Object.something().more().and().that().as().well().but().not().something();
+    }
 
-  public void singleInvocationOnNewExpression() {
-    new Instance(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).invocation(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
-  }
+    public void singleInvocationOnNewExpression() {
+        new Instance(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).invocation(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
+    }
 
-  public void multipleInvocationsOnNewExpression() {
-    new Instance(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).invocation(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).andAnother();
-  }
+    public void multipleInvocationsOnNewExpression() {
+        new Instance(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).invocation(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).andAnother();
+    }
 
 }

--- a/packages/prettier-plugin-java/test/unit-test/member_chain/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/member_chain/_output.java
@@ -5,23 +5,84 @@ public class BreakLongFunctionCall {
   }
 
   public void doSomethingNewWithComment() {
-    return new Object()
+    new Object()
       // comment
       .something()
+      .more();
+
+    new Object()
+      .something()
+      // comment
       .more();
   }
 
   public void doSomethingWithComment() {
-    return Object
+    Object
       // comment
       .something()
       .more();
+
+    java.Object
+      // comment
+      .something()
+      .more();
+
+    java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
+      // comment
+      .something()
+      .more();
+
+    java
+      // comment
+      .averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object.something()
+      .more();
+
+    java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong
+      // comment
+      .Object.something()
+      .more();
+
+    java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object.something()
+      .more();
+
+    Object.something()
+      // comment
+      .more();
+
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+      // comment
+      .util()
+      .java.java();
+
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong
+      // comment
+      .java
+      .util()
+      .java.java();
+
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+      /* comment */
+      .util()
+      .java.java();
+
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java/* comment */
+      .util()
+      .java.java();
+
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+      /* comment */.util()
+      .java.java();
   }
 
   public void doSomethingWithComment() {
-    return object
+    object
       // comment
       .something()
+      .more();
+
+    object
+      .something()
+      // comment
       .more();
   }
 


### PR DESCRIPTION
## What changed with this PR:

Fix unstable formattings with comments inside fqn parts. 
#713 was an attempt to fix the #712 issue but I realized afterwards that some other edge cases were remaining

## Example

See modified unit test files to see some examples

## Relative issues or prs:

Fix #712 

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
