### PR TITLE
test case for weird formatting of wildcard type variable

### DIFF
--- a/packages/prettier-plugin-java/test/unit-test/type_variable/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/type_variable/_input.java
@@ -1,0 +1,8 @@
+public class Cast {
+
+    void should_cast_with_single_element() {
+
+        for(SomeClass<?> elem : elements) for(SomeClass<?> elem : elements) for(SomeClass<?> elem : elements)
+            doSomeThing();
+    }
+}

--- a/packages/prettier-plugin-java/test/unit-test/type_variable/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/type_variable/_output.java
@@ -1,0 +1,8 @@
+public class Cast {
+
+  void should_cast_with_single_element() {
+    for (SomeClass<?> elem : elements) for (SomeClass<
+      ?
+    > elem : elements) for (SomeClass<?> elem : elements) doSomeThing();
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/type_variable/type_variable-spec.ts
+++ b/packages/prettier-plugin-java/test/unit-test/type_variable/type_variable-spec.ts
@@ -1,0 +1,9 @@
+import path from "path";
+import url from "url";
+import { testSample } from "../../test-utils.js";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+describe("type variable", () => {
+  testSample(__dirname);
+});


### PR DESCRIPTION
## What changed with this PR:

Added tests as a show case of a bug.

## Example

```java
// Input

for(SomeClass<?> elem : elements) for(SomeClass<?> elem : elements) for(SomeClass<?> elem : elements)
            doSomeThing();

// Output
for (SomeClass<?> elem : elements) for (SomeClass<
      ?
    > elem : elements) for (SomeClass<?> elem : elements) doSomeThing();

```

