### PR TITLE
fix: break hugged lambda body when closing parenthesis wraps

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -120,7 +120,7 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
       ctx.Arrow[0],
       ...(isLambdaBodyABlock
         ? [" ", lambdaBody]
-        : [group(indent([line, lambdaBody]))])
+        : [group([indent([line, lambdaBody]), params?.hug ? softline : ""])])
     ];
     if (params?.hug) {
       return willBreak(lambdaParameters)
@@ -649,14 +649,7 @@ export class ExpressionsPrettierVisitor extends BaseCstPrettierPrinter {
           shouldBreak: true
         });
       }
-      const suffix = lastExpression?.children.lambdaExpression?.[0].children
-        .lambdaBody[0].children.block
-        ? ""
-        : line;
-      const hugged = [
-        ...headArgs,
-        group([huggedLastArg, suffix], { shouldBreak: true })
-      ];
+      const hugged = [...headArgs, group(huggedLastArg, { shouldBreak: true })];
       const expanded = group([indent([line, ...headArgs, lastArg]), line], {
         shouldBreak: true
       });

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
@@ -48,6 +48,8 @@ public class Lambda {
   public void lambdaWithoutBracesWhichBreak() {
     call(x -> foo.isVeryVeryVeryLongConditionTrue() &&
     foo.isAnotherVeryVeryLongConditionTrue());
+    aaaaaaaaaa(bbbbbbbbbb -> "123456789012345678901234567890123456789012345678");
+    aaaaaaaaaa(bbbbbbbbbb -> cccccccccc("123456789012345678901234567890123456"));
   }
 
   public void chainCallWithLambda() {

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
@@ -51,6 +51,12 @@ public class Lambda {
         foo.isVeryVeryVeryLongConditionTrue() &&
         foo.isAnotherVeryVeryLongConditionTrue()
     );
+    aaaaaaaaaa(bbbbbbbbbb ->
+      "123456789012345678901234567890123456789012345678"
+    );
+    aaaaaaaaaa(bbbbbbbbbb ->
+      cccccccccc("123456789012345678901234567890123456")
+    );
   }
 
   public void chainCallWithLambda() {


### PR DESCRIPTION
## What changed with this PR:

The bodies of lambdas used as hugged arguments are now broken when the closing parenthesis of the enclosing argument list is wrapped.

## Example

### Input
```java
class Example {

  void example() {
    aaaaaaaaaa(bbbbbbbbbb -> cccccccccc("123456789012345678901234567890123456"));
    aaaaaaaaaa(bbbbbbbbbb -> "123456789012345678901234567890123456789012345678");
  }
}
```

### Output
```java
class Example {

  void example() {
    aaaaaaaaaa(bbbbbbbbbb ->
      "123456789012345678901234567890123456789012345678"
    );
    aaaaaaaaaa(bbbbbbbbbb ->
      cccccccccc("123456789012345678901234567890123456")
    );
  }
}
```

## Relative issues or prs:

Closes #718