### PR TITLE
fix: limit TypePattern's VariableDeclaratorList to a single VariableDeclarator

### DIFF
--- a/packages/java-parser/api.d.ts
+++ b/packages/java-parser/api.d.ts
@@ -171,10 +171,6 @@ export abstract class JavaCstVisitor<IN, OUT> implements ICstVisitor<IN, OUT> {
     param?: IN
   ): OUT;
   isDims(ctx: IsDimsCtx, param?: IN): OUT;
-  isFollowingVariableDeclarator(
-    ctx: IsFollowingVariableDeclaratorCtx,
-    param?: IN
-  ): OUT;
   compilationUnit(ctx: CompilationUnitCtx, param?: IN): OUT;
   ordinaryCompilationUnit(ctx: OrdinaryCompilationUnitCtx, param?: IN): OUT;
   modularCompilationUnit(ctx: ModularCompilationUnitCtx, param?: IN): OUT;
@@ -503,10 +499,6 @@ export abstract class JavaCstVisitorWithDefaults<IN, OUT>
     param?: IN
   ): OUT;
   isDims(ctx: IsDimsCtx, param?: IN): OUT;
-  isFollowingVariableDeclarator(
-    ctx: IsFollowingVariableDeclaratorCtx,
-    param?: IN
-  ): OUT;
   compilationUnit(ctx: CompilationUnitCtx, param?: IN): OUT;
   ordinaryCompilationUnit(ctx: OrdinaryCompilationUnitCtx, param?: IN): OUT;
   modularCompilationUnit(ctx: ModularCompilationUnitCtx, param?: IN): OUT;
@@ -1800,16 +1792,6 @@ export type IsDimsCtx = {
   elementValuePairList?: ElementValuePairListCstNode[];
   elementValue?: ElementValueCstNode[];
   RBrace?: IToken[];
-};
-
-export interface IsFollowingVariableDeclaratorCstNode extends CstNode {
-  name: "isFollowingVariableDeclarator";
-  children: IsFollowingVariableDeclaratorCtx;
-}
-
-export type IsFollowingVariableDeclaratorCtx = {
-  Comma: IToken[];
-  variableDeclarator: VariableDeclaratorCstNode[];
 };
 
 export interface CompilationUnitCstNode extends CstNode {

--- a/packages/java-parser/src/productions/blocks-and-statements.js
+++ b/packages/java-parser/src/productions/blocks-and-statements.js
@@ -41,12 +41,12 @@ export function defineRules($, t) {
   });
 
   // https://docs.oracle.com/javase/specs/jls/se22/html/jls-14.html#jls-LocalVariableDeclaration
-  $.RULE("localVariableDeclaration", () => {
+  $.RULE("localVariableDeclaration", isSingleDeclarator => {
     $.MANY(() => {
       $.SUBRULE($.variableModifier);
     });
     $.SUBRULE($.localVariableType);
-    $.SUBRULE($.variableDeclaratorList);
+    $.SUBRULE($.variableDeclaratorList, { ARGS: [isSingleDeclarator] });
   });
 
   // https://docs.oracle.com/javase/specs/jls/se22/html/jls-14.html#jls-LocalVariableType

--- a/packages/java-parser/src/productions/classes.js
+++ b/packages/java-parser/src/productions/classes.js
@@ -154,11 +154,12 @@ export function defineRules($, t) {
   });
 
   // https://docs.oracle.com/javase/specs/jls/se22/html/jls-8.html#jls-VariableDeclaratorList
-  $.RULE("variableDeclaratorList", () => {
+  $.RULE("variableDeclaratorList", isSingleDeclarator => {
     $.SUBRULE($.variableDeclarator);
     $.MANY({
-      // required to distinguish from patternList
-      GATE: () => this.BACKTRACK_LOOKAHEAD($.isFollowingVariableDeclarator),
+      // TypePattern has a semantic requirement that its VariableDeclaratorList
+      // consists of a single VariableDeclarator
+      GATE: () => !isSingleDeclarator,
       DEF: () => {
         $.CONSUME(t.Comma);
         $.SUBRULE2($.variableDeclarator);
@@ -728,24 +729,5 @@ export function defineRules($, t) {
     return (
       tokenMatcher(this.LA(1), t.LSquare) && tokenMatcher(this.LA(2), t.RSquare)
     );
-  });
-
-  /*
-   * The following sequence can either be a variable declarator or a component pattern if next token is a comma
-   * This check if the following sequence is **not** a component pattern sequence
-   */
-  $.RULE("isFollowingVariableDeclarator", () => {
-    const hasDims =
-      tokenMatcher(this.LA(3), t.LSquare) &&
-      tokenMatcher(this.LA(4), t.RSquare);
-    const offset = hasDims ? 2 : 0;
-    if (
-      tokenMatcher(this.LA(offset + 3), t.Identifier) ||
-      tokenMatcher(this.LA(offset + 3), t.Underscore)
-    ) {
-      return false;
-    }
-
-    return !tokenMatcher(this.LA(3), t.LBrace);
   });
 }

--- a/packages/java-parser/src/productions/expressions.js
+++ b/packages/java-parser/src/productions/expressions.js
@@ -595,7 +595,7 @@ export function defineRules($, t) {
 
   // https://docs.oracle.com/javase/specs/jls/se22/html/jls-14.html#jls-TypePattern
   $.RULE("typePattern", () => {
-    $.SUBRULE($.localVariableDeclaration);
+    $.SUBRULE($.localVariableDeclaration, { ARGS: [true] });
   });
 
   // https://docs.oracle.com/javase/specs/jls/se22/html/jls-14.html#jls-RecordPattern

--- a/packages/java-parser/test/pattern-matching/pattern-matching-spec.js
+++ b/packages/java-parser/test/pattern-matching/pattern-matching-spec.js
@@ -84,4 +84,9 @@ describe("Pattern matching", () => {
       javaParser.parse(input, "componentPatternList")
     ).to.not.throw();
   });
+
+  it("should parse switch label with multiple qualified case patterns", () => {
+    const input = "case b.B _, c.C _";
+    expect(() => javaParser.parse(input, "switchLabel")).to.not.throw();
+  });
 });

--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -56,7 +56,6 @@ import {
   FormalParameterListCtx,
   InstanceInitializerCtx,
   InterfaceTypeListCtx,
-  IsFollowingVariableDeclaratorCtx,
   IToken,
   MethodBodyCtx,
   MethodDeclarationCtx,
@@ -1071,9 +1070,5 @@ export class ClassesPrettierVisitor extends BaseCstPrettierPrinter {
 
   isDims() {
     return "isDims";
-  }
-
-  isFollowingVariableDeclarator() {
-    return "isFollowingVariableDeclarator";
   }
 }


### PR DESCRIPTION
## What changed with this PR:

There exists some ambiguity in the parser within comma-separated `TypePattern`s, because `TypePattern` contains a `VariableDeclaratorList`, which is comma-separated `VariableDeclarator`s. The parser cannot currently determine where the `VariableDeclaratorList` ends and the next `TypePattern` begins. This was previously realized in #707, within `ComponentPatternList`, and is now experienced in #733, within `SwitchLabel`.

I realized that the JLS specifically mentions semantic restrictions that make it easy to resolve this ambiguity. From [14.30.1. Kinds of Patterns](https://docs.oracle.com/javase/specs/jls/se24/html/jls-14.html#jls-14.30.1) (emphasis mine):
> The rules for a local variable declared in a type pattern are specified in [§14.4](https://docs.oracle.com/javase/specs/jls/se24/html/jls-14.html#jls-14.4). In addition, all of the following must be true, or a compile-time error occurs:
> * The _LocalVariableType_ in a top level type pattern denotes a reference type (and furthermore is not var).
> * **The _VariableDeclaratorList_ consists of a single _VariableDeclarator_.**
> * The _VariableDeclarator_ has no initializer.
> * The _VariableDeclaratorId_ has no bracket pairs.

As such, this PR limits `TypePattern`'s `VariableDeclaratorList` to a single `VariableDeclarator` in our parser. That change also allowed me to remove the patch that was added in #708, as this fix also resolves the ambiguity for the issue seen in #707.

## Example

### Input

```java
public class Fail {

  private Function<ShootResult, ShootResult.Miss> missed() {
    return lastResult -> switch (lastResult) {
      case ShootResult.Miss(int fails) -> new ShootResult.Miss(fails + 1);
      case ShootResult.Many _ ,ShootResult.One _ -> new ShootResult.Miss(0); // crash on this line
             
    };
  }

  private sealed interface ShootResult {
    record One(Pin pin) implements ShootResult {}
    record Many(int number) implements ShootResult {}
    record Miss(int timesInRow) implements ShootResult {}
  }
}
```

### Output

```java
public class Fail {

  private Function<ShootResult, ShootResult.Miss> missed() {
    return lastResult ->
      switch (lastResult) {
        case ShootResult.Miss(int fails) -> new ShootResult.Miss(fails + 1);
        case ShootResult.Many _, ShootResult.One _ -> new ShootResult.Miss(0); // crash on this line
      };
  }

  private sealed interface ShootResult {
    record One(Pin pin) implements ShootResult {}

    record Many(int number) implements ShootResult {}

    record Miss(int timesInRow) implements ShootResult {}
  }
}
```

## Relative issues or prs:

Closes #733