### PR TITLE
fix: do not add a blank line at the end on non-java files

### DIFF
--- a/packages/prettier-plugin-java/src/printers/packages-and-modules.ts
+++ b/packages/prettier-plugin-java/src/printers/packages-and-modules.ts
@@ -22,8 +22,15 @@ import {
 const { group, hardline, indent, join, line } = builders;
 
 export default {
-  compilationUnit(path, print) {
-    return [...printDanglingComments(path), printSingle(path, print), hardline];
+  compilationUnit(path, print, options) {
+    const danglingComments = printDanglingComments(path);
+    const content = printSingle(path, print);
+    // If no filepath is provided (e.g., in tests), assume it's Java code
+    // Only skip the trailing newline for explicitly non-Java files like Markdown
+    const isNonJavaFile = options.filepath && !options.filepath.endsWith(".java");
+    return isNonJavaFile
+      ? [...danglingComments, content]
+      : [...danglingComments, content, hardline];
   },
 
   ordinaryCompilationUnit(path, print) {


### PR DESCRIPTION
## What changed with this PR:

Do not add a blank line at the end of code blocks. Close #737

## Example

**Input:**

````md
# Java

```java
public class Test {

  public static void main(String[] args) {
    System.out.println("Hello, World!");
  }
}
```

# JavaScript

```javascript
function main() {
  console.log("Hello, World!");
}
```
````

**Output (this PR):**

````md
# Java

```java
public class Test {

  public static void main(String[] args) {
    System.out.println("Hello, World!");
  }
}
```

# JavaScript

```javascript
function main() {
  console.log("Hello, World!");
}
```
````

**Output (before):**

````md
# Java

```java
public class Test {

  public static void main(String[] args) {
    System.out.println("Hello, World!");
  }
}

```

# JavaScript

```javascript
function main() {
  console.log("Hello, World!");
}
```
````