### PR TITLE
Fix update-test-outputs script to use test-specific prettier options.

### DIFF
--- a/packages/prettier-plugin-java/scripts/update-test-output.js
+++ b/packages/prettier-plugin-java/scripts/update-test-output.js
@@ -51,12 +51,20 @@ const updateTestOutput = async () => {
       try {
         console.log(`Reading <${fileDesc.path}>`);
         let newExpectedText = javaFileText;
+
+        const testDir = path.dirname(fileDesc.path);
+        const optionsPath = path.join(testDir, ".prettierrc.json");
+        const testOptions = fs.existsSync(optionsPath)
+          ? fs.readJsonSync(optionsPath)
+          : {};
+
         for (let i = 0; i < numberOfTime; i++) {
           newExpectedText = await prettier.format(newExpectedText, {
             parser: "java",
             plugins: [path.resolve(__dirname, "../dist/index.js")],
             tabWidth: 2,
-            endOfLine: "lf"
+            endOfLine: "lf",
+            ...testOptions
           });
         }
         let outputFilePath = fileDesc.path.replace(

--- a/packages/prettier-plugin-java/test/test-utils.ts
+++ b/packages/prettier-plugin-java/test/test-utils.ts
@@ -14,12 +14,10 @@ const { readFileSync, existsSync, removeSync, copySync } = fs;
 const __dirname = dirname(url.fileURLToPath(import.meta.url));
 export function testSampleWithOptions({
   testFolder,
-  exclusive,
-  prettierOptions = {}
+  exclusive
 }: {
   testFolder: string;
   exclusive?: boolean;
-  prettierOptions?: any;
 }) {
   const itOrItOnly = exclusive ? it.only : it;
   const inputPath = resolve(testFolder, "_input.java");
@@ -28,6 +26,11 @@ export function testSampleWithOptions({
 
   let inputContents: string;
   let expectedContents: string;
+
+  const prettierrcPath = resolve(testFolder, ".prettierrc.json");
+  const prettierOptions = existsSync(prettierrcPath)
+    ? fs.readJsonSync(prettierrcPath)
+    : {};
 
   // @ts-ignore
   before(() => {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/binary_expressions-spec.ts
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/binary_expressions-spec.ts
@@ -6,12 +6,11 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 describe("prettier-java", () => {
   testSampleWithOptions({
-    testFolder: path.resolve(__dirname, "operator-position-start"),
-    prettierOptions: { experimentalOperatorPosition: "start" }
+    testFolder: path.resolve(__dirname, "operator-position-start")
   });
+
   testSampleWithOptions({
-    testFolder: path.resolve(__dirname, "operator-position-end"),
-    prettierOptions: { experimentalOperatorPosition: "end" }
+    testFolder: path.resolve(__dirname, "operator-position-end")
   });
   testSample(path.resolve(__dirname, "operator-position-end"));
 });

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/.prettierrc.json
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "experimentalOperatorPosition": "end"
+}

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/.prettierrc.json
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "experimentalOperatorPosition": "start"
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/format-pragma/.prettierrc.json
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/format-pragma/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "requirePragma": true
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/invalid-pragma/.prettierrc.json
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/invalid-pragma/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "requirePragma": true
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/prettier-pragma/.prettierrc.json
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/prettier-pragma/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "requirePragma": true
+}

--- a/packages/prettier-plugin-java/test/unit-test/require-pragma/require-pragma-spec.ts
+++ b/packages/prettier-plugin-java/test/unit-test/require-pragma/require-pragma-spec.ts
@@ -9,10 +9,9 @@ describe("prettier-java: require-pragma option", () => {
     path.resolve(__dirname, "./format-pragma"),
     path.resolve(__dirname, "./prettier-pragma"),
     path.resolve(__dirname, "./invalid-pragma")
-  ].forEach(testFolder =>
+  ].forEach(testFolder => {
     testSampleWithOptions({
-      testFolder,
-      prettierOptions: { requirePragma: true }
-    })
-  );
+      testFolder
+    });
+  });
 });


### PR DESCRIPTION
Before this change, checking out the project and running update-test-outputs would make changes to the test outputs.

```
❯ npm run build && npm run update-test-outputs
❯ git status
HEAD detached at upstream/main
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
        modified:   packages/prettier-plugin-java/test/unit-test/require-pragma/invalid-pragma/_output.java

no changes added to commit (use "git add" and/or "git commit -a")
```

The change here is to use the test-specific configuration while recording tests. With this change, running npm run update-test-outputs doesn't make any changes to any files.