### PR TITLE
chore: add packageManager field to package.json for corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
     "mocha": "10.8.2",
     "prettier": "^3.0.0",
     "sinon": "19.0.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## What changed with this PR:

Add packageManager field for corepack support.
See https://github.com/nodejs/corepack
<!-- Quick summary of what is the purpose of this PR -->

## Example

```sh
corepack install
corepack enable
```

## Relative issues or prs:

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
-->
