### PR TITLE
fix: align arrowParens option's default with Prettier

### DIFF
--- a/packages/prettier-plugin-java/src/options.ts
+++ b/packages/prettier-plugin-java/src/options.ts
@@ -256,7 +256,7 @@ export default {
   arrowParens: {
     type: "choice",
     category: "Java",
-    default: "avoid",
+    default: "always",
     choices: [
       { value: "always", description: "" },
       { value: "avoid", description: "" }

--- a/website/src/pages/playground/index.tsx
+++ b/website/src/pages/playground/index.tsx
@@ -76,7 +76,7 @@ function Inner() {
   const [tabWidth, setTabWidth] = useState(initialState.tabWidth ?? 2);
   const [useTabs, setUseTabs] = useState(initialState.useTabs ?? false);
   const [arrowParens, setArrowParens] = useState(
-    initialState.arrowParens ?? ArrowParens.Avoid
+    initialState.arrowParens ?? ArrowParens.Always
   );
   const [trailingComma, setTrailingComma] = useState(
     initialState.trailingComma ?? TrailingComma.All


### PR DESCRIPTION
## What changed with this PR:

The `arrowParens` option's default was set to `avoid`, while Prettier's own default is `always`. Apparently, the result is that using `prettier-plugin-java` causes Prettier's own default to be changed. This PR changes the default to `always` to align with Prettier's default to avoid causing changes to non-Java files by overriding default values of common options.

This was the best temporary solution I could come up with. Going forward we may need to find some other solution for this to avoid having to try to keep these common options in lockstep with Prettier's.

## Relative issues or prs:

Closes #748