### PR TITLE
fix: print class type arguments and dots in the proper order

### DIFF
--- a/packages/prettier-plugin-java/test/unit-test/types/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/types/_input.java
@@ -23,4 +23,8 @@ public class Types {
     String stringVariable;
   }
 
+  public void complexTypes() {
+    @A B.C<D>.@E @F G.H h;
+  }
+
 }

--- a/packages/prettier-plugin-java/test/unit-test/types/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/types/_output.java
@@ -22,4 +22,9 @@ public class Types {
     Boolean booleanVariable;
     String stringVariable;
   }
+
+  public void complexTypes() {
+    @A
+    B.C<D>.@E @F G.H h;
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

Class types with type arguments followed by a dot (`.`) are printed in that order, rather than moving the dot before the type arguments.

## Example

### Input

```java
class Example {
  @A B.C<D>.@E @F G.H h;
}
```

### Output

```java
class Example {

  @A
  B.C<D>.@E @F G.H h;
}
```

## Relative issues or prs:

Closes #752