### PR TITLE
fix: revert connection of trailing semicolon to trailingComma option

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
@@ -394,9 +394,9 @@ export default {
     return join(" ", blocks);
   },
 
-  resourceSpecification(path, print, options) {
+  resourceSpecification(path, print) {
     const resources = [call(path, print, "resourceList")];
-    if (options.trailingComma !== "none") {
+    if (path.node.children.Semicolon) {
       resources.push(ifBreak(";"));
     }
     return indentInParentheses(resources);

--- a/packages/prettier-plugin-java/test/unit-test/try_catch/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/try_catch/_input.java
@@ -62,4 +62,14 @@ public class TryCatch {
     }
   }
 
+  void multiResourceTryWithTrailingSemi() {
+    try (
+      FirstResource firstResource = new FirstResource();
+      SecondResource secondResource = new SecondResource();
+    ) {
+      return br.readLine();
+    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
+      System.out.println("Warning: Not breaking multi exceptions");
+    }
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/try_catch/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/try_catch/_output.java
@@ -61,6 +61,17 @@ public class TryCatch {
   void multiResourceTry() {
     try (
       FirstResource firstResource = new FirstResource();
+      SecondResource secondResource = new SecondResource()
+    ) {
+      return br.readLine();
+    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
+      System.out.println("Warning: Not breaking multi exceptions");
+    }
+  }
+
+  void multiResourceTryWithTrailingSemi() {
+    try (
+      FirstResource firstResource = new FirstResource();
       SecondResource secondResource = new SecondResource();
     ) {
       return br.readLine();


### PR DESCRIPTION
## What changed with this PR:

Reverts the connection of trailing semicolon printing (in ResourceSpecification) to the `trailingComma` option (which was done in #731). This is a bit of an edge case, and it isn't at all intuitive that an option named `trailingComma` would also control whether a trailing semicolon would be printed in this case. The optional trailing semicolon will now be left as-is (printed if it exists, omitted if not), as it used to be.

## Example

### Input

```java
class Example {

  void multiResourceTry() {
    try (FirstResource firstResource = new FirstResource(); SecondResource secondResource = new SecondResource()) {
      return br.readLine();
    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
      System.out.println("Warning: Not breaking multi exceptions");
    }
  }

  void multiResourceTryWithTrailingSemi() {
    try (
      FirstResource firstResource = new FirstResource();
      SecondResource secondResource = new SecondResource();
    ) {
      return br.readLine();
    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
      System.out.println("Warning: Not breaking multi exceptions");
    }
  }
}
```

### Output

```java
class Example {

  void multiResourceTry() {
    try (
      FirstResource firstResource = new FirstResource();
      SecondResource secondResource = new SecondResource()
    ) {
      return br.readLine();
    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
      System.out.println("Warning: Not breaking multi exceptions");
    }
  }

  void multiResourceTryWithTrailingSemi() {
    try (
      FirstResource firstResource = new FirstResource();
      SecondResource secondResource = new SecondResource();
    ) {
      return br.readLine();
    } catch (ArithmeticException | ArrayIndexOutOfBoundsException e) {
      System.out.println("Warning: Not breaking multi exceptions");
    }
  }
}
```

## Relative issues or prs:

Closes #750