### PR TITLE
docs: fix website edit URLs

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,7 +10,7 @@ const { origin: url, pathname: baseUrl } = new URL(homepage);
 const [, organizationName, projectName] = new URL(repository).pathname.split(
   "/"
 );
-const editUrl = `${repository}/tree/docs/create-website/website/`;
+const editUrl = `${repository}/tree/main/website/`;
 
 export default {
   title: "Prettier Java",


### PR DESCRIPTION
## What changed with this PR:

Website's edit URLs are corrected to point to the proper source paths so that they no longer resolve to a 404 page.