### PR TITLE
fix: eliminate repeated printer function execution from our naively-implemented 'call' helper

### DIFF
--- a/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
+++ b/packages/prettier-plugin-java/src/printers/blocks-and-statements.ts
@@ -84,10 +84,11 @@ export default {
   ifStatement(path, print) {
     const { children } = path.node;
     const hasEmptyStatement = isEmptyStatement(children.statement[0]);
+    const statements = map(path, print, "statement");
     const statement: Doc[] = [
       "if ",
       indentInParentheses(call(path, print, "expression")),
-      hasEmptyStatement ? ";" : [" ", call(path, print, "statement", 0)]
+      hasEmptyStatement ? ";" : [" ", statements[0]]
     ];
     if (children.Else) {
       const danglingComments = printDanglingComments(path);
@@ -103,7 +104,7 @@ export default {
       const elseHasEmptyStatement = isEmptyStatement(children.statement[1]);
       statement.push(
         "else",
-        elseHasEmptyStatement ? ";" : [" ", call(path, print, "statement", 1)]
+        elseHasEmptyStatement ? ";" : [" ", statements[1]]
       );
     }
     return statement;

--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -115,13 +115,14 @@ export default {
 
   conditionalExpression(path, print) {
     const binaryExpression = call(path, print, "binaryExpression");
+    const expressions = map(path, print, "expression");
     return path.node.children.QuestionMark
       ? group(
           indent(
             join(line, [
               binaryExpression,
-              ["? ", call(path, print, "expression", 0)],
-              [": ", call(path, print, "expression", 1)]
+              ["? ", expressions[0]],
+              [": ", expressions[1]]
             ])
           )
         )
@@ -468,9 +469,9 @@ export default {
       return allArgsExpandable;
     }
     const headArgs = args.slice(0, -1);
-    const huggedLastArg = call(
-      path,
+    const huggedLastArg = path.call(
       argPath => print(argPath, { hug: true }),
+      "children",
       "expression",
       args.length - 1
     );
@@ -756,7 +757,6 @@ function printTemplate<
   T extends StringTemplateCstNode | TextBlockTemplateCstNode,
   C extends Exclude<IterProperties<T["children"]>, "embeddedExpression">
 >(path: AstPath<T>, print: JavaPrintFn, beginKey: C, midKey: C, endKey: C) {
-  const { children } = path.node;
   const begin = call(path, ({ node }) => node.image, beginKey);
   const mids = map(path, ({ node }) => node.image, midKey);
   const end = call(path, ({ node }) => node.image, endKey);

--- a/packages/prettier-plugin-java/src/printers/helpers.ts
+++ b/packages/prettier-plugin-java/src/printers/helpers.ts
@@ -122,10 +122,9 @@ export function call<
 >(
   path: AstPath<T>,
   callback: MapCallback<IndexValue<IndexValue<T, "children">, P>, U>,
-  child: P,
-  index = 0
+  child: P
 ) {
-  return path.map(callback, "children", child)[index];
+  return path.map(callback, "children", child)[0];
 }
 
 export function each<
@@ -318,7 +317,7 @@ export function printClassType(
       const node = children[child]![childIndex];
       const next = array.at(index + 1);
       const nextNode = next && children[next.child]![next.index];
-      const docs = [call(path, print, child, childIndex)];
+      const docs = [path.call(print, "children", child, childIndex)];
       if (nextNode) {
         if (isNonTerminal(node)) {
           docs.push(node.name === "annotation" ? " " : ".");

--- a/packages/prettier-plugin-java/test/unit-test/if/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/if/_input.java
@@ -40,4 +40,47 @@ public class If {
     }
   }
 
+  void longIfElseChain() {
+    if (1) {
+      // 1
+    } else if (2) {
+      // 2
+    } else if (3) {
+      // 3
+    } else if (4) {
+      // 4
+    } else if (5) {
+      // 5
+    } else if (6) {
+      // 6
+    } else if (7) {
+      // 7
+    } else if (8) {
+      // 8
+    } else if (9) {
+      // 9
+    } else if (10) {
+      // 10
+    } else if (11) {
+      // 11
+    } else if (12) {
+      // 12
+    } else if (13) {
+      // 13
+    } else if (14) {
+      // 14
+    } else if (15) {
+      // 15
+    } else if (16) {
+      // 16
+    } else if (17) {
+      // 17
+    } else if (18) {
+      // 18
+    } else if (19) {
+      // 19
+    } else if (20) {
+      // 20
+    }
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/if/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/if/_output.java
@@ -39,4 +39,48 @@ public class If {
       System.out.println("not on or two or three");
     }
   }
+
+  void longIfElseChain() {
+    if (1) {
+      // 1
+    } else if (2) {
+      // 2
+    } else if (3) {
+      // 3
+    } else if (4) {
+      // 4
+    } else if (5) {
+      // 5
+    } else if (6) {
+      // 6
+    } else if (7) {
+      // 7
+    } else if (8) {
+      // 8
+    } else if (9) {
+      // 9
+    } else if (10) {
+      // 10
+    } else if (11) {
+      // 11
+    } else if (12) {
+      // 12
+    } else if (13) {
+      // 13
+    } else if (14) {
+      // 14
+    } else if (15) {
+      // 15
+    } else if (16) {
+      // 16
+    } else if (17) {
+      // 17
+    } else if (18) {
+      // 18
+    } else if (19) {
+      // 19
+    } else if (20) {
+      // 20
+    }
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

Our `call` helper is implemented by calling AstPath's `map` method and indexing into the returned array. This PR removes the ability to index to anything other than `0`, to prevent it from being used to execute individual calls to individual path indices, which was causing all indices to be re-processed each time `call` was executed, which in some cases (such as long if-else statement chains) was causing printer functions to be executed an exponential number of times (according to the number of if-else statements in the chain). Anything that was previously using the indexing feature of `call` is now updated to either use the `map` helper once, and index into the results, or use `AstPath.call` directly, which is a bit more verbose, but it's a rare use-case in our printer to begin with.

## Example

# Input

```java
class Example {

  void example() {
    if (1) {
      // 1
    } else if (2) {
      // 2
    } else if (3) {
      // 3
    } else if (4) {
      // 4
    } else if (5) {
      // 5
    } else if (6) {
      // 6
    } else if (7) {
      // 7
    } else if (8) {
      // 8
    } else if (9) {
      // 9
    } else if (10) {
      // 10
    } else if (11) {
      // 11
    } else if (12) {
      // 12
    } else if (13) {
      // 13
    } else if (14) {
      // 14
    } else if (15) {
      // 15
    } else if (16) {
      // 16
    } else if (17) {
      // 17
    } else if (18) {
      // 18
    } else if (19) {
      // 19
    } else if (20) {
      // 20
    }
  }
}
```

# Output

The same, but it no longer takes an exponential amount of time to print.

## Relative issues or prs:

Closes #757