### PR TITLE
fix: correct indentation of some method argument lists containing lambda bodies

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -12,6 +12,7 @@ import {
   each,
   findBaseIndent,
   flatMap,
+  hasLeadingComments,
   indentInParentheses,
   isBinaryExpression,
   isNonTerminal,
@@ -276,8 +277,11 @@ export default {
       },
       "primarySuffix"
     );
+    const hasSuffixComments = children.primarySuffix.some(suffix =>
+      hasLeadingComments(suffix)
+    );
     return group(
-      canBreakForCallExpressions || willBreak(suffixes)
+      canBreakForCallExpressions || hasSuffixComments
         ? [prefix, indent(suffixes)]
         : [prefix, ...suffixes]
     );
@@ -766,7 +770,7 @@ function printTemplate<
   const parts = [begin, ...mids, end].map(image =>
     join(hardline, image.split(prefix))
   );
-  return [
+  return indent([
     parts[0],
     ...map(
       path,
@@ -780,5 +784,5 @@ function printTemplate<
       "embeddedExpression" as IterProperties<T["children"]>
     ),
     parts.at(-1)!
-  ];
+  ]);
 }

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
@@ -185,6 +185,16 @@ public class Lambda {
                 return f;
             }
         );
+
+        this.a(
+            aaaaaaaaaaaaaaaaaaaaaaaaaa,
+            bbbbbbbbbbbbbbbbbbbbbbbbbb,
+            cccccccccccccccccccccccccc,
+            dddddddddddddddddddddddddd,
+            e -> {
+                return f;
+            }
+        );
     }
 
     void singleLambdaWithBlockLastArgumentAndLongLambdaArgument() {
@@ -212,6 +222,10 @@ public class Lambda {
     }
 
     void huggableArguments() {
+        A.b().c(() -> {
+            return d;
+        });
+
         aaaaaaaaaaaaaaaaaaaaaaaa((bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccc, dddddddddddddddddddddddd) -> eeeeeeeeeeeeeeeeeeeeeeee.ffffffffffffffffffffffff());
 
         a.b(c -> d -> eeeeeeeeee.ffffffffff(gggggggggg, hhhhhhhhhh, iiiiiiiiii, jjjjjjjjjj, kkkkkkkkkk));

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
@@ -179,6 +179,16 @@ public class Lambda {
         return f;
       }
     );
+
+    this.a(
+      aaaaaaaaaaaaaaaaaaaaaaaaaa,
+      bbbbbbbbbbbbbbbbbbbbbbbbbb,
+      cccccccccccccccccccccccccc,
+      dddddddddddddddddddddddddd,
+      e -> {
+        return f;
+      }
+    );
   }
 
   void singleLambdaWithBlockLastArgumentAndLongLambdaArgument() {
@@ -228,6 +238,10 @@ public class Lambda {
   }
 
   void huggableArguments() {
+    A.b().c(() -> {
+      return d;
+    });
+
     aaaaaaaaaaaaaaaaaaaaaaaa(
       (
         bbbbbbbbbbbbbbbbbbbbbbbb,

--- a/packages/prettier-plugin-java/test/unit-test/template-expression/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/template-expression/_output.java
@@ -7,8 +7,8 @@ class TemplateExpression {
   String s = STR."You have a \{getOfferType()} waiting for you!";
 
   String msg = STR."The file \{filePath} \{
-    file.exists() ? "does" : "does not"
-  } exist";
+      file.exists() ? "does" : "does not"
+    } exist";
 
   String time = STR."The time is \{
       // The java.time.format package is very useful
@@ -55,6 +55,6 @@ class TemplateExpression {
     """;
 
   PreparedStatement ps = DB."SELECT * FROM Person p WHERE p.last_name = \{
-    name
-  }";
+      name
+    }";
 }


### PR DESCRIPTION
## What changed with this PR:

Certain method invocations containing lambda arguments with bodies no longer have their arguments double-indented.

This includes a minor change to templates as well, but those were a preview feature and are no longer supported by Java, plus the change makes the formatting of them more consistent.

## Example

### Input

```java
class Example {

  void example() {
    A.b().c(() -> {
      return d;
    });

    this.a(
      aaaaaaaaaaaaaaaaaaaaaaaaaa,
      bbbbbbbbbbbbbbbbbbbbbbbbbb,
      cccccccccccccccccccccccccc,
      dddddddddddddddddddddddddd,
      e -> {
        return f;
      }
    );
  }
}
```

### Output

```java
class Example {

  void example() {
    A.b().c(() -> {
      return d;
    });

    this.a(
      aaaaaaaaaaaaaaaaaaaaaaaaaa,
      bbbbbbbbbbbbbbbbbbbbbbbbbb,
      cccccccccccccccccccccccccc,
      dddddddddddddddddddddddddd,
      e -> {
        return f;
      }
    );
  }
}
```

## Relative issues or prs:

Closes #760
Closes #764 