### PR TITLE
fix: correct indentation of non-root instanceof expressions

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -684,7 +684,10 @@ function binary(
     }
   }
   level.push(operands.shift()!);
-  if (!levelOperator || !isAssignmentOperator(levelOperator)) {
+  if (
+    !levelOperator ||
+    (!isAssignmentOperator(levelOperator) && levelOperator !== "instanceof")
+  ) {
     return group(level);
   }
   if (!isRoot || hasNonAssignmentOperators) {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_input.java
@@ -132,4 +132,17 @@ public class BinaryOperations {
 
     if (aaaaaaaaaa + bbbbbbbbbb == cccccccccc + dddddddddd && eeeeeeeeee + ffffffffff == gggggggggg + hhhhhhhhhh || iiiiiiiiii + jjjjjjjjjj == kkkkkkkkkk + llllllllll && mmmmmmmmmm + nnnnnnnnnn == oooooooooo + pppppppppp || qqqqqqqqqq + rrrrrrrrrr == ssssssssss + tttttttttt && uuuuuuuuuu + vvvvvvvvvv == wwwwwwwwww + xxxxxxxxxxx) {}
   }
+
+  void instanceOf() {
+    var a =
+      a &&
+      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
+      NumberNumberNumberNumber n &&
+      n.foo();
+
+    var a =
+      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
+      NumberNumberNumberNumber n &&
+      n.foo();
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_output.java
@@ -252,4 +252,17 @@ public class BinaryOperations {
         uuuuuuuuuu + vvvvvvvvvv == wwwwwwwwww + xxxxxxxxxxx)
     ) {}
   }
+
+  void instanceOf() {
+    var a =
+      a &&
+      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
+        NumberNumberNumberNumber n &&
+      n.foo();
+
+    var a =
+      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
+        NumberNumberNumberNumber n &&
+      n.foo();
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_input.java
@@ -132,4 +132,17 @@ public class BinaryOperations {
 
     if (aaaaaaaaaa + bbbbbbbbbb == cccccccccc + dddddddddd && eeeeeeeeee + ffffffffff == gggggggggg + hhhhhhhhhh || iiiiiiiiii + jjjjjjjjjj == kkkkkkkkkk + llllllllll && mmmmmmmmmm + nnnnnnnnnn == oooooooooo + pppppppppp || qqqqqqqqqq + rrrrrrrrrr == ssssssssss + tttttttttt && uuuuuuuuuu + vvvvvvvvvv == wwwwwwwwww + xxxxxxxxxxx) {}
   }
+
+  void instanceOf() {
+    var a =
+      a &&
+      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
+      NumberNumberNumberNumber n &&
+      n.foo();
+
+    var a =
+      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
+      NumberNumberNumberNumber n &&
+      n.foo();
+  }
 }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
@@ -245,4 +245,17 @@ public class BinaryOperations {
         && uuuuuuuuuu + vvvvvvvvvv == wwwwwwwwww + xxxxxxxxxxx)
     ) {}
   }
+
+  void instanceOf() {
+    var a =
+      a
+      && Foo.get(longlinelonglinelonglinelonglinelongline)
+        instanceof NumberNumberNumberNumber n
+      && n.foo();
+
+    var a =
+      Foo.get(longlinelonglinelonglinelonglinelongline)
+        instanceof NumberNumberNumberNumber n
+      && n.foo();
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

`instanceof` expressions not at the root of the binary expression are now properly indented, like those at the root.

## Example

### Input

```java
class Example {

  void example() {
    var a =
      a &&
      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
      NumberNumberNumberNumber n &&
      n.foo();

    var a =
      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
      NumberNumberNumberNumber n &&
      n.foo();
  }
}
```

### Output

```java
class Example {

  void example() {
    var a =
      a &&
      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
        NumberNumberNumberNumber n &&
      n.foo();

    var a =
      Foo.get(longlinelonglinelonglinelonglinelongline) instanceof
        NumberNumberNumberNumber n &&
      n.foo();
  }
}
```

## Relative issues or prs:

Closes #762