### PR TITLE
fix: indent binary expressions in annotation element value or argument lists

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -167,8 +167,12 @@ export default {
       (operators.length > 0 && !children.AssignmentOperator) ||
       (children.expression !== undefined &&
         isBinaryExpression(children.expression[0]));
+    const isInList =
+      (path.getNode(4) as JavaNonTerminal | null)?.name === "elementValue" ||
+      (path.getNode(6) as JavaNonTerminal | null)?.name === "argumentList";
     return binary(operands, operators, {
       hasNonAssignmentOperators,
+      isInList,
       isRoot: true,
       operatorPosition: options.experimentalOperatorPosition
     });
@@ -627,10 +631,12 @@ function binary(
   operators: { image: string; doc: Doc }[],
   {
     hasNonAssignmentOperators = false,
+    isInList = false,
     isRoot = false,
     operatorPosition
   }: {
     hasNonAssignmentOperators?: boolean;
+    isInList?: boolean;
     isRoot?: boolean;
     operatorPosition: "end" | "start";
   }
@@ -686,7 +692,9 @@ function binary(
   level.push(operands.shift()!);
   if (
     !levelOperator ||
-    (!isAssignmentOperator(levelOperator) && levelOperator !== "instanceof")
+    (!isInList &&
+      !isAssignmentOperator(levelOperator) &&
+      levelOperator !== "instanceof")
   ) {
     return group(level);
   }

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_output.java
@@ -7,12 +7,12 @@ public class BinaryOperations {
 
   @Annotation(
     "This operation with two very long string should break" +
-    "in a very nice way"
+      "in a very nice way"
   )
   public String binaryOperationThatShouldBreak() {
     System.out.println(
       "This operation with two very long string should break" +
-      "in a very nice way"
+        "in a very nice way"
     );
     return (
       "This operation with two very long string should break" +

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
@@ -7,12 +7,12 @@ public class BinaryOperations {
 
   @Annotation(
     "This operation with two very long string should break"
-    + "in a very nice way"
+      + "in a very nice way"
   )
   public String binaryOperationThatShouldBreak() {
     System.out.println(
       "This operation with two very long string should break"
-      + "in a very nice way"
+        + "in a very nice way"
     );
     return (
       "This operation with two very long string should break"


### PR DESCRIPTION
## What changed with this PR:

Binary expressions within annotation element value lists or argument lists are now indented, as is done in Prettier TypeScript.

## Example

### Input

```java
class Example {

  @Annotation(
    "This operation with two very long string should break" +
    "in a very nice way"
  )
  void example() {
    System.out.println(
      "This operation with two very long string should break" +
      "in a very nice way"
    );
  }
}
```

### Output

```java
class Example {

  @Annotation(
    "This operation with two very long string should break" +
      "in a very nice way"
  )
  void example() {
    System.out.println(
      "This operation with two very long string should break" +
        "in a very nice way"
    );
  }
}
```

## Relative issues or prs:

Closes #761