### PR TITLE
fix: break nested ternaries together

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -116,18 +116,21 @@ export default {
 
   conditionalExpression(path, print) {
     const binaryExpression = call(path, print, "binaryExpression");
+    if (!path.node.children.QuestionMark) {
+      return binaryExpression;
+    }
     const expressions = map(path, print, "expression");
-    return path.node.children.QuestionMark
-      ? group(
-          indent(
-            join(line, [
-              binaryExpression,
-              ["? ", expressions[0]],
-              [": ", expressions[1]]
-            ])
-          )
-        )
-      : binaryExpression;
+    const contents = indent(
+      join(line, [
+        binaryExpression,
+        ["? ", expressions[0]],
+        [": ", expressions[1]]
+      ])
+    );
+    const isNestedTernary =
+      (path.getNode(4) as JavaNonTerminal | null)?.name ===
+      "conditionalExpression";
+    return isNestedTernary ? contents : group(contents);
   },
 
   binaryExpression(path, print, options) {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_input.java
@@ -32,6 +32,10 @@ public class BinaryOperations {
     return b ? b : c;
   }
 
+  void nestedTernary() {
+    aaaaaaaaaa ? bbbbbbbbbb : cccccccccc ? dddddddddd : eeeeeeeeee ? ffffffffff : gggggggggg;
+  }
+
   public boolean binaryOperationWithComments() {
     boolean a = one || two >> 1 // one
       // two

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_output.java
@@ -49,6 +49,16 @@ public class BinaryOperations {
     return b ? b : c;
   }
 
+  void nestedTernary() {
+    aaaaaaaaaa
+      ? bbbbbbbbbb
+      : cccccccccc
+        ? dddddddddd
+        : eeeeeeeeee
+          ? ffffffffff
+          : gggggggggg;
+  }
+
   public boolean binaryOperationWithComments() {
     boolean a =
       one ||

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_input.java
@@ -32,6 +32,10 @@ public class BinaryOperations {
     return b ? b : c;
   }
 
+  void nestedTernary() {
+    aaaaaaaaaa ? bbbbbbbbbb : cccccccccc ? dddddddddd : eeeeeeeeee ? ffffffffff : gggggggggg;
+  }
+
   public boolean binaryOperationWithComments() {
     boolean a = one || two >> 1 // one
       // two

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
@@ -49,6 +49,16 @@ public class BinaryOperations {
     return b ? b : c;
   }
 
+  void nestedTernary() {
+    aaaaaaaaaa
+      ? bbbbbbbbbb
+      : cccccccccc
+        ? dddddddddd
+        : eeeeeeeeee
+          ? ffffffffff
+          : gggggggggg;
+  }
+
   public boolean binaryOperationWithComments() {
     boolean a =
       one


### PR DESCRIPTION
## What changed with this PR:

Nested ternaries are now broken together as a single group, rather than individually, as Prettier TypeScript does.

## Example

### Input

```java
class Example {

  void example() {
    aaaaaaaaaa ? bbbbbbbbbb : cccccccccc ? dddddddddd : eeeeeeeeee ? ffffffffff : gggggggggg;
  }
}
```

### Output

```java
class Example {

  void example() {
    aaaaaaaaaa
      ? bbbbbbbbbb
      : cccccccccc
        ? dddddddddd
        : eeeeeeeeee
          ? ffffffffff
          : gggggggggg;
  }
}
```

## Relative issues or prs:

Closes #769