### PR TITLE
feat: improve class/enum/interface/record clause wrapping/indentation

### DIFF
--- a/packages/prettier-plugin-java/src/printers/helpers.ts
+++ b/packages/prettier-plugin-java/src/printers/helpers.ts
@@ -293,10 +293,7 @@ export function printClassPermits(
   path: AstPath<ClassPermitsCstNode | InterfacePermitsCstNode>,
   print: JavaPrintFn
 ) {
-  return group([
-    "permits",
-    indent([line, group(printList(path, print, "typeName"))])
-  ]);
+  return group(["permits", indent([line, printList(path, print, "typeName")])]);
 }
 
 export function printClassType(

--- a/packages/prettier-plugin-java/test/unit-test/classes/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/classes/_input.java
@@ -21,3 +21,46 @@ class ClassWithSemicolon {
   ;
   private FieldOneClass fieldOne;
 }
+
+class Aaaaaaaaaa<Bbbbbbbbbb> extends Cccccccccc implements Dddddddddd {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd implements Eeeeeeeeee {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd implements Eeeeeeeeee {}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff, Gggggggggg, Hhhhhhhhhh, Iiiiiiiiii> {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> implements Gggggggggg, Hhhhhhhhhh {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> implements Gggggggggg, Hhhhhhhhhh {}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj> implements Kkkkkkkkkk, Llllllllll {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj> implements Kkkkkkkkkk, Llllllllll {}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj, Kkkkkkkkkk, Llllllllll, Mmmmmmmmmm, Nnnnnnnnnn> implements Oooooooooo, Pppppppppp, Qqqqqqqqqq, Rrrrrrrrrr, Ssssssssss, Tttttttttt, Uuuuuuuuuu {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj, Kkkkkkkkkk, Llllllllll, Mmmmmmmmmm, Nnnnnnnnnn> implements Oooooooooo, Pppppppppp, Qqqqqqqqqq, Rrrrrrrrrr, Ssssssssss, Tttttttttt, Uuuuuuuuuu {}

--- a/packages/prettier-plugin-java/test/unit-test/classes/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/classes/_output.java
@@ -15,3 +15,134 @@ class ClassWithSemicolon {
 
   private FieldOneClass fieldOne;
 }
+
+class Aaaaaaaaaa<Bbbbbbbbbb> extends Cccccccccc implements Dddddddddd {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
+  extends Dddddddddd
+  implements Eeeeeeeeee
+{
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
+  extends Dddddddddd
+  implements Eeeeeeeeee {}
+
+class Aaaaaaaaaa<
+  Bbbbbbbbbb,
+  Cccccccccc
+> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<
+  Bbbbbbbbbb,
+  Cccccccccc
+> extends Dddddddddd<
+  Eeeeeeeeee,
+  Ffffffffff,
+  Gggggggggg,
+  Hhhhhhhhhh,
+  Iiiiiiiiii
+> {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
+  extends Dddddddddd<Eeeeeeeeee, Ffffffffff>
+  implements Gggggggggg, Hhhhhhhhhh
+{
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
+  extends Dddddddddd<Eeeeeeeeee, Ffffffffff>
+  implements Gggggggggg, Hhhhhhhhhh {}
+
+class Aaaaaaaaaa<
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+  >
+  extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj>
+  implements Kkkkkkkkkk, Llllllllll
+{
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+  >
+  extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj>
+  implements Kkkkkkkkkk, Llllllllll {}
+
+class Aaaaaaaaaa<
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+  >
+  extends Hhhhhhhhhh<
+    Iiiiiiiiii,
+    Jjjjjjjjjj,
+    Kkkkkkkkkk,
+    Llllllllll,
+    Mmmmmmmmmm,
+    Nnnnnnnnnn
+  >
+  implements
+    Oooooooooo,
+    Pppppppppp,
+    Qqqqqqqqqq,
+    Rrrrrrrrrr,
+    Ssssssssss,
+    Tttttttttt,
+    Uuuuuuuuuu
+{
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+  >
+  extends Hhhhhhhhhh<
+    Iiiiiiiiii,
+    Jjjjjjjjjj,
+    Kkkkkkkkkk,
+    Llllllllll,
+    Mmmmmmmmmm,
+    Nnnnnnnnnn
+  >
+  implements
+    Oooooooooo,
+    Pppppppppp,
+    Qqqqqqqqqq,
+    Rrrrrrrrrr,
+    Ssssssssss,
+    Tttttttttt,
+    Uuuuuuuuuu {}

--- a/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/class/_output.java
@@ -81,7 +81,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @GwtCompatible(emulated = true)
 public final class ArrayTable<R, C, V>
   extends AbstractTable<R, C, V>
-  implements Serializable {
+  implements Serializable
+{
 
   /**
    * Returns the square of a given number
@@ -198,8 +199,10 @@ public final class ArrayTable<R, C, V>
     }
   }
 
-  private abstract static class ArrayMap<K, V>
-    extends IteratorBasedAbstractMap<K, V> {
+  private abstract static class ArrayMap<
+    K,
+    V
+  > extends IteratorBasedAbstractMap<K, V> {
 
     private final ImmutableMap<K, Integer> keyIndex;
 

--- a/packages/prettier-plugin-java/test/unit-test/comments/interface/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/comments/interface/_output.java
@@ -5,7 +5,8 @@ import com.other.interfaces.RequiredI;
  * This is the comment describing the interface
  */
 public /*a*/ interface /*b*/ MyInterface
-  /*a*/ extends /*b*/ /*a*/ OfferedI /*b*/ /*a*/, /*b*/ /*a*/ RequiredI /*b*/ {
+  /*a*/ extends /*b*/ /*a*/ OfferedI /*b*/ /*a*/, /*b*/ /*a*/ RequiredI
+/*b*/ {
   // comment
   /**
    * Javadoc

--- a/packages/prettier-plugin-java/test/unit-test/enum/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_input.java
@@ -147,3 +147,19 @@ enum PrettierErrors {
     System.out.println("Hey there");
   }
 }
+
+enum Aaaaaaaaaa implements Bbbbbbbbbb {
+  A
+}
+
+enum Aaaaaaaaaa implements Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff {
+  A
+}
+
+enum Aaaaaaaaaa implements Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff {}
+
+enum Aaaaaaaaaa implements Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg {
+  A
+}
+
+enum Aaaaaaaaaa implements Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg {}

--- a/packages/prettier-plugin-java/test/unit-test/enum/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/enum/_output.java
@@ -162,3 +162,37 @@ enum PrettierErrors {
     System.out.println("Hey there");
   }
 }
+
+enum Aaaaaaaaaa implements Bbbbbbbbbb {
+  A,
+}
+
+enum Aaaaaaaaaa
+  implements Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff
+{
+  A,
+}
+
+enum Aaaaaaaaaa
+  implements Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff {}
+
+enum Aaaaaaaaaa
+  implements
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+{
+  A,
+}
+
+enum Aaaaaaaaaa
+  implements
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg {}

--- a/packages/prettier-plugin-java/test/unit-test/extends_abstract_class_and_implements_interfaces/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/extends_abstract_class_and_implements_interfaces/_output.java
@@ -1,6 +1,7 @@
 public class ExtendsAbstractClassAndImplementsInterfaces
   extends AbstractClass
-  implements Interface1, Interface2, Interface3, Interface4 {
+  implements Interface1, Interface2, Interface3, Interface4
+{
 
   @Override
   public void abstractMethod() {

--- a/packages/prettier-plugin-java/test/unit-test/generic_class/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/generic_class/_output.java
@@ -20,8 +20,7 @@ public class ComplexGenericClass<
   BEAN extends AbstractBean & BeanItemSelect<BEANTYPE>,
   BEANTYPE,
   CONFIG extends BeanConfig<BEAN, BEANTYPE, CONFIG>
->
-  extends AbstractBeanConfig<BEAN, CONFIG> {
+> extends AbstractBeanConfig<BEAN, CONFIG> {
 
   public <BEAN> List<? super BEAN> getBean(final Class<BEAN> beanClass) {
     return new ArrayList<>();

--- a/packages/prettier-plugin-java/test/unit-test/interface/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/interface/_input.java
@@ -48,3 +48,39 @@ public interface InterfaceWithSemicolon {
   ;
   String STRING_1 = "STRING_1";
 }
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb> extends Cccccccccc permits Dddddddddd {
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd permits Eeeeeeeeee {
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd permits Eeeeeeeeee {}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff, Gggggggggg, Hhhhhhhhhh, Iiiiiiiiii> {
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj> permits Kkkkkkkkkk, Llllllllll {
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj> permits Kkkkkkkkkk, Llllllllll {}
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj, Kkkkkkkkkk, Llllllllll, Mmmmmmmmmm, Nnnnnnnnnn> permits Oooooooooo, Pppppppppp, Qqqqqqqqqq, Rrrrrrrrrr, Ssssssssss, Tttttttttt, Uuuuuuuuuu {
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj, Kkkkkkkkkk, Llllllllll, Mmmmmmmmmm, Nnnnnnnnnn> permits Oooooooooo, Pppppppppp, Qqqqqqqqqq, Rrrrrrrrrr, Ssssssssss, Tttttttttt, Uuuuuuuuuu {}

--- a/packages/prettier-plugin-java/test/unit-test/interface/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/interface/_output.java
@@ -5,7 +5,8 @@ public interface Interfaces {
 }
 
 public interface Interfaces
-  extends Interface1, Interface2, Interface3, Interface4 {
+  extends Interface1, Interface2, Interface3, Interface4
+{
   boolean isAvailable(Object propertyId);
 
   public static final Method METHOD = SomeStatic.findMethod();
@@ -20,7 +21,8 @@ public interface Interfaces
     Interface5,
     Interface6,
     Interface7,
-    Interface8 {
+    Interface8
+{
   boolean isAvailable(Object propertyId);
 
   public static final Method METHOD = SomeStatic.findMethod();
@@ -60,3 +62,122 @@ public interface EmptyInterface {}
 public interface InterfaceWithSemicolon {
   String STRING_1 = "STRING_1";
 }
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb> extends Cccccccccc permits Dddddddddd {
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
+  extends Dddddddddd
+  permits Eeeeeeeeee
+{
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
+  extends Dddddddddd
+  permits Eeeeeeeeee {}
+
+class Aaaaaaaaaa<
+  Bbbbbbbbbb,
+  Cccccccccc
+> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> {
+
+  void a() {}
+}
+
+class Aaaaaaaaaa<
+  Bbbbbbbbbb,
+  Cccccccccc
+> extends Dddddddddd<
+  Eeeeeeeeee,
+  Ffffffffff,
+  Gggggggggg,
+  Hhhhhhhhhh,
+  Iiiiiiiiii
+> {
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+  >
+  extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj>
+  permits Kkkkkkkkkk, Llllllllll
+{
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+  >
+  extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj>
+  permits Kkkkkkkkkk, Llllllllll {}
+
+sealed class Aaaaaaaaaa<
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+  >
+  extends Hhhhhhhhhh<
+    Iiiiiiiiii,
+    Jjjjjjjjjj,
+    Kkkkkkkkkk,
+    Llllllllll,
+    Mmmmmmmmmm,
+    Nnnnnnnnnn
+  >
+  permits
+    Oooooooooo,
+    Pppppppppp,
+    Qqqqqqqqqq,
+    Rrrrrrrrrr,
+    Ssssssssss,
+    Tttttttttt,
+    Uuuuuuuuuu
+{
+
+  void a() {}
+}
+
+sealed class Aaaaaaaaaa<
+    Bbbbbbbbbb,
+    Cccccccccc,
+    Dddddddddd,
+    Eeeeeeeeee,
+    Ffffffffff,
+    Gggggggggg
+  >
+  extends Hhhhhhhhhh<
+    Iiiiiiiiii,
+    Jjjjjjjjjj,
+    Kkkkkkkkkk,
+    Llllllllll,
+    Mmmmmmmmmm,
+    Nnnnnnnnnn
+  >
+  permits
+    Oooooooooo,
+    Pppppppppp,
+    Qqqqqqqqqq,
+    Rrrrrrrrrr,
+    Ssssssssss,
+    Tttttttttt,
+    Uuuuuuuuuu {}

--- a/packages/prettier-plugin-java/test/unit-test/records/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_input.java
@@ -161,3 +161,27 @@ public record Record(
     @Schema(type = "integer", description = "A longer description  ") Status status
     )
 {}
+
+record Aaaaaaaaaa<Bbbbbbbbbb>(Cccccccccc cccccccccc) implements Dddddddddd {
+
+  void a() {}
+}
+
+record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>(Dddddddddd dddddddddd) implements Eeeeeeeeee {
+
+  void a() {}
+}
+
+record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>(Dddddddddd dddddddddd) implements Eeeeeeeeee {}
+
+record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg>(Hhhhhhhhhh Hhhhhhhhhh) implements Iiiiiiiiii {
+
+  void a() {}
+}
+
+record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg>(Hhhhhhhhhh Hhhhhhhhhh) implements Iiiiiiiiii {}
+
+record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg>(Hhhhhhhhhh Hhhhhhhhhh) implements Iiiiiiiiii, Jjjjjjjjjj, Kkkkkkkkkk, Llllllllll, Mmmmmmmmmm, Nnnnnnnnnn {
+
+  void a() {}
+}

--- a/packages/prettier-plugin-java/test/unit-test/records/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/records/_output.java
@@ -157,3 +157,61 @@ public record Record(
   @Schema(type = "integer", description = "A longer description  ")
   Status status
 ) {}
+
+record Aaaaaaaaaa<Bbbbbbbbbb>(Cccccccccc cccccccccc) implements Dddddddddd {
+  void a() {}
+}
+
+record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>(
+  Dddddddddd dddddddddd
+) implements Eeeeeeeeee {
+  void a() {}
+}
+
+record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>(
+  Dddddddddd dddddddddd
+) implements Eeeeeeeeee {}
+
+record Aaaaaaaaaa<
+  Bbbbbbbbbb,
+  Cccccccccc,
+  Dddddddddd,
+  Eeeeeeeeee,
+  Ffffffffff,
+  Gggggggggg
+>(
+  Hhhhhhhhhh Hhhhhhhhhh
+) implements Iiiiiiiiii {
+  void a() {}
+}
+
+record Aaaaaaaaaa<
+  Bbbbbbbbbb,
+  Cccccccccc,
+  Dddddddddd,
+  Eeeeeeeeee,
+  Ffffffffff,
+  Gggggggggg
+>(
+  Hhhhhhhhhh Hhhhhhhhhh
+) implements Iiiiiiiiii {}
+
+record Aaaaaaaaaa<
+  Bbbbbbbbbb,
+  Cccccccccc,
+  Dddddddddd,
+  Eeeeeeeeee,
+  Ffffffffff,
+  Gggggggggg
+>(
+  Hhhhhhhhhh Hhhhhhhhhh
+) implements
+  Iiiiiiiiii,
+  Jjjjjjjjjj,
+  Kkkkkkkkkk,
+  Llllllllll,
+  Mmmmmmmmmm,
+  Nnnnnnnnnn
+{
+  void a() {}
+}


### PR DESCRIPTION
## What changed with this PR:

Class/enum/interface/record declarations now have their extends/implements/permits clauses wrapped/indented more similarly to the way Prettier TypeScript does.

## Example

### Input

```java
class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd implements Eeeeeeeeee {

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd implements Eeeeeeeeee {}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> {

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff, Gggggggggg, Hhhhhhhhhh, Iiiiiiiiii> {

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> implements Gggggggggg, Hhhhhhhhhh {

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> implements Gggggggggg, Hhhhhhhhhh {}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj> implements Kkkkkkkkkk, Llllllllll {

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj> implements Kkkkkkkkkk, Llllllllll {}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj, Kkkkkkkkkk, Llllllllll, Mmmmmmmmmm, Nnnnnnnnnn> implements Oooooooooo, Pppppppppp, Qqqqqqqqqq, Rrrrrrrrrr, Ssssssssss, Tttttttttt, Uuuuuuuuuu {

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg> extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj, Kkkkkkkkkk, Llllllllll, Mmmmmmmmmm, Nnnnnnnnnn> implements Oooooooooo, Pppppppppp, Qqqqqqqqqq, Rrrrrrrrrr, Ssssssssss, Tttttttttt, Uuuuuuuuuu {}

record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>(Dddddddddd dddddddddd) implements Eeeeeeeeee {

  void a() {}
}

record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>(Dddddddddd dddddddddd) implements Eeeeeeeeee {}

record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg>(Hhhhhhhhhh Hhhhhhhhhh) implements Iiiiiiiiii {

  void a() {}
}

record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg>(Hhhhhhhhhh Hhhhhhhhhh) implements Iiiiiiiiii {}

record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg>(Hhhhhhhhhh Hhhhhhhhhh) implements Iiiiiiiiii, Jjjjjjjjjj, Kkkkkkkkkk, Llllllllll, Mmmmmmmmmm, Nnnnnnnnnn {

  void a() {}
}
```

### Output

```java
class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
  extends Dddddddddd
  implements Eeeeeeeeee
{

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
  extends Dddddddddd
  implements Eeeeeeeeee {}

class Aaaaaaaaaa<
  Bbbbbbbbbb,
  Cccccccccc
> extends Dddddddddd<Eeeeeeeeee, Ffffffffff> {

  void a() {}
}

class Aaaaaaaaaa<
  Bbbbbbbbbb,
  Cccccccccc
> extends Dddddddddd<
  Eeeeeeeeee,
  Ffffffffff,
  Gggggggggg,
  Hhhhhhhhhh,
  Iiiiiiiiii
> {

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
  extends Dddddddddd<Eeeeeeeeee, Ffffffffff>
  implements Gggggggggg, Hhhhhhhhhh
{

  void a() {}
}

class Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>
  extends Dddddddddd<Eeeeeeeeee, Ffffffffff>
  implements Gggggggggg, Hhhhhhhhhh {}

class Aaaaaaaaaa<
    Bbbbbbbbbb,
    Cccccccccc,
    Dddddddddd,
    Eeeeeeeeee,
    Ffffffffff,
    Gggggggggg
  >
  extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj>
  implements Kkkkkkkkkk, Llllllllll
{

  void a() {}
}

class Aaaaaaaaaa<
    Bbbbbbbbbb,
    Cccccccccc,
    Dddddddddd,
    Eeeeeeeeee,
    Ffffffffff,
    Gggggggggg
  >
  extends Hhhhhhhhhh<Iiiiiiiiii, Jjjjjjjjjj>
  implements Kkkkkkkkkk, Llllllllll {}

class Aaaaaaaaaa<
    Bbbbbbbbbb,
    Cccccccccc,
    Dddddddddd,
    Eeeeeeeeee,
    Ffffffffff,
    Gggggggggg
  >
  extends Hhhhhhhhhh<
    Iiiiiiiiii,
    Jjjjjjjjjj,
    Kkkkkkkkkk,
    Llllllllll,
    Mmmmmmmmmm,
    Nnnnnnnnnn
  >
  implements
    Oooooooooo,
    Pppppppppp,
    Qqqqqqqqqq,
    Rrrrrrrrrr,
    Ssssssssss,
    Tttttttttt,
    Uuuuuuuuuu
{

  void a() {}
}

class Aaaaaaaaaa<
    Bbbbbbbbbb,
    Cccccccccc,
    Dddddddddd,
    Eeeeeeeeee,
    Ffffffffff,
    Gggggggggg
  >
  extends Hhhhhhhhhh<
    Iiiiiiiiii,
    Jjjjjjjjjj,
    Kkkkkkkkkk,
    Llllllllll,
    Mmmmmmmmmm,
    Nnnnnnnnnn
  >
  implements
    Oooooooooo,
    Pppppppppp,
    Qqqqqqqqqq,
    Rrrrrrrrrr,
    Ssssssssss,
    Tttttttttt,
    Uuuuuuuuuu {}

record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>(
  Dddddddddd dddddddddd
) implements Eeeeeeeeee {
  void a() {}
}

record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc>(
  Dddddddddd dddddddddd
) implements Eeeeeeeeee {}

record Aaaaaaaaaa<
  Bbbbbbbbbb,
  Cccccccccc,
  Dddddddddd,
  Eeeeeeeeee,
  Ffffffffff,
  Gggggggggg
>(
  Hhhhhhhhhh Hhhhhhhhhh
) implements Iiiiiiiiii {
  void a() {}
}

record Aaaaaaaaaa<
  Bbbbbbbbbb,
  Cccccccccc,
  Dddddddddd,
  Eeeeeeeeee,
  Ffffffffff,
  Gggggggggg
>(
  Hhhhhhhhhh Hhhhhhhhhh
) implements Iiiiiiiiii {}

record Aaaaaaaaaa<
  Bbbbbbbbbb,
  Cccccccccc,
  Dddddddddd,
  Eeeeeeeeee,
  Ffffffffff,
  Gggggggggg
>(
  Hhhhhhhhhh Hhhhhhhhhh
) implements
  Iiiiiiiiii,
  Jjjjjjjjjj,
  Kkkkkkkkkk,
  Llllllllll,
  Mmmmmmmmmm,
  Nnnnnnnnnn
{
  void a() {}
}
```

## Relative issues or prs:

Closes #781