### PR TITLE
fix: avoid unwrapping empty array initializer with comments

### DIFF
--- a/packages/prettier-plugin-java/src/printers/helpers.ts
+++ b/packages/prettier-plugin-java/src/printers/helpers.ts
@@ -249,14 +249,16 @@ export function printArrayInitializer<
   T extends JavaNonTerminal,
   P extends IterProperties<T["children"]>
 >(path: AstPath<T>, print: JavaPrintFn, options: JavaParserOptions, child: P) {
-  const list: Doc[] = [];
-  if (child && child in path.node.children) {
-    list.push(call(path, print, child));
-    if (options.trailingComma !== "none") {
-      list.push(ifBreak(","));
-    }
+  if (!(child && child in path.node.children)) {
+    const danglingComments = printDanglingComments(path);
+    return danglingComments.length
+      ? ["{", indent([hardline, ...danglingComments]), hardline, "}"]
+      : "{}";
   }
-  list.push(...printDanglingComments(path));
+  const list = [call(path, print, child)];
+  if (options.trailingComma !== "none") {
+    list.push(ifBreak(","));
+  }
   return list.length ? group(["{", indent([line, ...list]), line, "}"]) : "{}";
 }
 

--- a/packages/prettier-plugin-java/test/unit-test/arrays/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/arrays/_input.java
@@ -4,4 +4,8 @@ class Array {
     Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa<Bbbbbbbbbbbbbbbb>[1].getClass();
     Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa[1111111111111111111].getClass();
     Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa[]{ new Aaaaaaaaaaaaaaaa() }.getClass();
+
+    String[] DATA = {
+        // nothing yet
+    };
 }

--- a/packages/prettier-plugin-java/test/unit-test/arrays/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/arrays/_output.java
@@ -10,4 +10,8 @@ class Array {
   Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa[] {
     new Aaaaaaaaaaaaaaaa(),
   }.getClass();
+
+  String[] DATA = {
+    // nothing yet
+  };
 }


### PR DESCRIPTION
## What changed with this PR:

Empty array initializers with comments are no longer unwrapped to avoid making code uncompilable.

## Example

### Input

```java
class Example {

  String[] DATA = {
    // nothing yet
  };
}
```

### Output

```java
class Example {

  String[] DATA = {
    // nothing yet
  };
}
```

## Relative issues or prs:

Closes #782