### PR TITLE
fix: remove extra indent from ternary/lambda expressions in parentheses

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -374,13 +374,18 @@ export default {
     const expression = call(path, print, "expression");
     const ancestorName = (path.getNode(14) as JavaNonTerminal | null)?.name;
     const binaryExpression = path.getNode(8) as JavaNonTerminal | null;
+    const { conditionalExpression, lambdaExpression } =
+      path.node.children.expression[0].children;
+    const hasLambda = lambdaExpression !== undefined;
+    const hasTernary =
+      conditionalExpression?.[0].children.QuestionMark !== undefined;
     return ancestorName &&
       ["guard", "returnStatement"].includes(ancestorName) &&
       binaryExpression &&
       binaryExpression.name === "binaryExpression" &&
       Object.keys(binaryExpression.children).length === 1
       ? indentInParentheses(expression)
-      : ["(", indent(expression), ")"];
+      : ["(", hasLambda || hasTernary ? expression : indent(expression), ")"];
   },
 
   castExpression: printSingle,

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_input.java
@@ -38,4 +38,8 @@ class ConditionalExpression {
             ? b // b
             : c; // c
     }
+
+    void ternaryInParentheses() {
+        (aaaaaaaaaa ? bbbbbbbbbb : cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
+    }
 }

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_output.java
@@ -53,4 +53,10 @@ class ConditionalExpression {
             ? b // b
             : c; // c
     }
+
+    void ternaryInParentheses() {
+        (aaaaaaaaaa
+            ? bbbbbbbbbb
+            : cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
+    }
 }

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_input.java
@@ -38,4 +38,8 @@ class ConditionalExpression {
 			? b // b
 			: c; // c
 	}
+
+	void ternaryInParentheses() {
+		(aaaaaaaaaa ? bbbbbbbbbb : cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
+	}
 }

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_output.java
@@ -52,4 +52,10 @@ class ConditionalExpression {
 			? b // b
 			: c; // c
 	}
+
+	void ternaryInParentheses() {
+		(aaaaaaaaaa
+			? bbbbbbbbbb
+			: cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
+	}
 }

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_input.java
@@ -333,6 +333,10 @@ public class Lambda {
             ).collect(Collectors.summingInt(v -> v))
         );
     }
+
+    void lambdaInParentheses() {
+        (aaaaaaaaaa -> bbbbbbbbbb.cccccccccc().dddddddddd().eeeeeeeeee().ffffffffff());
+    }
 }
 
 class T {

--- a/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/lambda/_output.java
@@ -576,6 +576,11 @@ public class Lambda {
         .collect(Collectors.summingInt(v -> v))
     );
   }
+
+  void lambdaInParentheses() {
+    (aaaaaaaaaa ->
+      bbbbbbbbbb.cccccccccc().dddddddddd().eeeeeeeeee().ffffffffff());
+  }
 }
 
 class T {


### PR DESCRIPTION
## What changed with this PR:

The extra indent which was added to wrapped ternary/lambda expressions inside of parentheses is now removed, so that it is only indented once like Prettier JavaScript/TypeScript.

## Example

### Input

```java
class Example {

  void example() {
    (aaaaaaaaaa ? bbbbbbbbbb : cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
    (aaaaaaaaaa -> bbbbbbbbbb.cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
  }
}
```

### Output

```java
class Example {

  void example() {
    (aaaaaaaaaa
      ? bbbbbbbbbb
      : cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
    (aaaaaaaaaa ->
      bbbbbbbbbb.cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
  }
}
```

## Relative issues or prs:

Closes #786