### PR TITLE
feat: support `prettier-ignore-start`/`-end` in addition to `@formatter:off`/`:on`

### DIFF
--- a/packages/prettier-plugin-java/src/parser.ts
+++ b/packages/prettier-plugin-java/src/parser.ts
@@ -1,6 +1,6 @@
 import { parse } from "java-parser";
 import type { Parser } from "prettier";
-import { determineFormatterOffOnRanges } from "./comments.js";
+import { determinePrettierIgnoreRanges } from "./comments.js";
 import {
   isTerminal,
   type JavaNode,
@@ -14,7 +14,7 @@ export default {
     cst.comments?.forEach(comment => {
       comment.value = comment.image;
     });
-    determineFormatterOffOnRanges(cst);
+    determinePrettierIgnoreRanges(cst);
     return cst;
   },
   astFormat: "java",

--- a/packages/prettier-plugin-java/src/printer.ts
+++ b/packages/prettier-plugin-java/src/printer.ts
@@ -3,7 +3,7 @@ import {
   canAttachComment,
   handleLineComment,
   handleRemainingComment,
-  isFullyBetweenFormatterOffOn
+  isFullyBetweenPrettierIgnore
 } from "./comments.js";
 import {
   isNonTerminal,
@@ -26,7 +26,7 @@ export default {
       node.comments?.some(({ image }) =>
         /^(\/\/\s*prettier-ignore|\/\*\s*prettier-ignore\s*\*\/)$/.test(image)
       ) === true ||
-      (canAttachComment(node) && isFullyBetweenFormatterOffOn(path))
+      (canAttachComment(node) && isFullyBetweenPrettierIgnore(path))
     );
   },
   canAttachComment,

--- a/packages/prettier-plugin-java/test/unit-test/formatter-on-off/multiple/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/formatter-on-off/multiple/_input.java
@@ -1,16 +1,16 @@
-// @formatter:off
+// prettier-ignore-start
 public class PrettierIgnoreClass {
   public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {
 
   }
 }
-// @formatter:on
+/* prettier-ignore-end */
 public class PrettierIgnoreClass {
   public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {
 
   }
 }
-// @formatter:off
+/* @formatter:off */
 public class PrettierIgnoreClass {
   public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {
 

--- a/packages/prettier-plugin-java/test/unit-test/formatter-on-off/multiple/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/formatter-on-off/multiple/_output.java
@@ -1,11 +1,11 @@
-// @formatter:off
+// prettier-ignore-start
 public class PrettierIgnoreClass {
   public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {
 
   }
 }
 
-// @formatter:on
+/* prettier-ignore-end */
 public class PrettierIgnoreClass {
 
   public void myMethod(
@@ -22,7 +22,7 @@ public class PrettierIgnoreClass {
   ) {}
 }
 
-// @formatter:off
+/* @formatter:off */
 public class PrettierIgnoreClass {
   public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {
 


### PR DESCRIPTION
## What changed with this PR:

In addition to `@formatter:off`/`@formatter:on` comments, now `prettier-ignore-start`/`prettier-ignore-end` comments are supported as well, much like Prettier supports for [range ignore](https://prettier.io/docs/ignore#range-ignore) in Markdown files. Also fixes a bug that affected proper handling of block-style comments containing the range ignore toggles.

## Example

### Input

```java
// prettier-ignore-start
public class PrettierIgnoreClass {
  public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {

  }
}
/* prettier-ignore-end */
public class PrettierIgnoreClass {
  public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {

  }
}
/* @formatter:off */
public class PrettierIgnoreClass {
  public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {

  }
}
// @formatter:on
public class PrettierIgnoreClass {
  public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {

  }
}
```

### Output

```java
// prettier-ignore-start
public class PrettierIgnoreClass {
  public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {

  }
}

/* prettier-ignore-end */
public class PrettierIgnoreClass {

  public void myMethod(
    int param1,
    int param2,
    int param3,
    int param4,
    int param5,
    int param6,
    int param7,
    int param8,
    int param9,
    int param10
  ) {}
}

/* @formatter:off */
public class PrettierIgnoreClass {
  public void myMethod(int param1, int param2, int param3, int param4, int param5, int param6, int param7, int param8, int param9, int param10) {

  }
}

// @formatter:on
public class PrettierIgnoreClass {

  public void myMethod(
    int param1,
    int param2,
    int param3,
    int param4,
    int param5,
    int param6,
    int param7,
    int param8,
    int param9,
    int param10
  ) {}
}
```

## Relative issues or prs:

Closes #735