### PR TITLE
fix: improve binary expression assignment breaking

### DIFF
--- a/packages/prettier-plugin-java/src/printers/classes.ts
+++ b/packages/prettier-plugin-java/src/printers/classes.ts
@@ -10,8 +10,8 @@ import {
   each,
   hasDeclarationAnnotations,
   hasLeadingComments,
+  hasNonAssignmentOperators,
   indentInParentheses,
-  isBinaryExpression,
   lineEndWithComments,
   lineStartWithComments,
   map,
@@ -154,12 +154,14 @@ export default {
     if (!variableInitializer) {
       return declaratorId;
     }
-    const expression = variableInitializer.children.expression?.[0];
+    const binaryExpression =
+      variableInitializer.children.expression?.[0].children
+        .conditionalExpression?.[0].children.binaryExpression[0];
     const declarator = [declaratorId, " ", call(path, print, "Equals")];
     const initializer = call(path, print, "variableInitializer");
     if (
       hasLeadingComments(variableInitializer) ||
-      (expression && isBinaryExpression(expression))
+      (binaryExpression && hasNonAssignmentOperators(binaryExpression))
     ) {
       declarator.push(group(indent([line, initializer])));
     } else {

--- a/packages/prettier-plugin-java/src/printers/helpers.ts
+++ b/packages/prettier-plugin-java/src/printers/helpers.ts
@@ -1,5 +1,6 @@
 import type {
   AnnotationCstNode,
+  BinaryExpressionCstNode,
   ClassPermitsCstNode,
   ClassTypeCtx,
   CstElement,
@@ -372,16 +373,19 @@ export function isBinaryExpression(expression: ExpressionCstNode) {
   if (isTernary) {
     return false;
   }
-  const hasNonAssignmentOperators = Object.values(
-    conditionalExpression.binaryExpression[0].children
-  ).some(
+  return hasNonAssignmentOperators(conditionalExpression.binaryExpression[0]);
+}
+
+export function hasNonAssignmentOperators(
+  binaryExpression: BinaryExpressionCstNode
+) {
+  return Object.values(binaryExpression.children).some(
     child =>
       isTerminal(child[0]) &&
       !child[0].tokenType.CATEGORIES?.some(
         category => category.name === "AssignmentOperator"
       )
   );
-  return hasNonAssignmentOperators;
 }
 
 export function findBaseIndent(lines: string[]) {

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-end/_output.java
@@ -114,12 +114,14 @@ public class BinaryOperations {
       ffffffffff +
       gggggggggg;
 
-    var aaaaaaaaaa = bbbbbbbbbb || cccccccccc
-      ? dddddddddd + eeeeeeeeee
-      : ffffffffff + gggggggggg;
-    aaaaaaaaaa = bbbbbbbbbb || cccccccccc
-      ? dddddddddd + eeeeeeeeee
-      : ffffffffff + gggggggggg;
+    var aaaaaaaaaa =
+      bbbbbbbbbb || cccccccccc
+        ? dddddddddd + eeeeeeeeee
+        : ffffffffff + gggggggggg;
+    aaaaaaaaaa =
+      bbbbbbbbbb || cccccccccc
+        ? dddddddddd + eeeeeeeeee
+        : ffffffffff + gggggggggg;
 
     var something = MyClass.staticFunction(
       aaaaaaaaaa,

--- a/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/binary_expressions/operator-position-start/_output.java
@@ -117,12 +117,14 @@ public class BinaryOperations {
       + ffffffffff
       + gggggggggg;
 
-    var aaaaaaaaaa = bbbbbbbbbb || cccccccccc
-      ? dddddddddd + eeeeeeeeee
-      : ffffffffff + gggggggggg;
-    aaaaaaaaaa = bbbbbbbbbb || cccccccccc
-      ? dddddddddd + eeeeeeeeee
-      : ffffffffff + gggggggggg;
+    var aaaaaaaaaa =
+      bbbbbbbbbb || cccccccccc
+        ? dddddddddd + eeeeeeeeee
+        : ffffffffff + gggggggggg;
+    aaaaaaaaaa =
+      bbbbbbbbbb || cccccccccc
+        ? dddddddddd + eeeeeeeeee
+        : ffffffffff + gggggggggg;
 
     var something = MyClass.staticFunction(
       aaaaaaaaaa,

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_input.java
@@ -42,4 +42,18 @@ class ConditionalExpression {
     void ternaryInParentheses() {
         (aaaaaaaaaa ? bbbbbbbbbb : cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
     }
+
+    void assignment() {
+        Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+        Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+        Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+        aaaaaaaaaa = bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+        aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+        aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+    }
 }

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_output.java
@@ -59,4 +59,48 @@ class ConditionalExpression {
             ? bbbbbbbbbb
             : cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
     }
+
+    void assignment() {
+        Aaaaaaaaaa aaaaaaaaaa =
+            bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh;
+
+        Aaaaaaaaaa aaaaaaaaaa =
+            bbbbbbbbbb(cccccccccccccccccccc, dddddddddd, eeeeeeeeee) !=
+            ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh;
+
+        Aaaaaaaaaa aaaaaaaaaa =
+            bbbbbbbbbb(
+                cccccccccccccccccccc,
+                dddddddddddddddddddd,
+                eeeeeeeeee
+            ) !=
+            ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh;
+
+        aaaaaaaaaa =
+            bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh;
+
+        aaaaaaaaaa =
+            bbbbbbbbbb(cccccccccccccccccccc, dddddddddd, eeeeeeeeee) !=
+            ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh;
+
+        aaaaaaaaaa =
+            bbbbbbbbbb(
+                cccccccccccccccccccc,
+                dddddddddddddddddddd,
+                eeeeeeeeee
+            ) !=
+            ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh;
+    }
 }

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_input.java
@@ -42,4 +42,18 @@ class ConditionalExpression {
 	void ternaryInParentheses() {
 		(aaaaaaaaaa ? bbbbbbbbbb : cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
 	}
+
+	void assignment() {
+		Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+		Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+		Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+		aaaaaaaaaa = bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+		aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+
+		aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;
+	}
 }

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_output.java
@@ -58,4 +58,38 @@ class ConditionalExpression {
 			? bbbbbbbbbb
 			: cccccccccc.dddddddddd().eeeeeeeeee().ffffffffff());
 	}
+
+	void assignment() {
+		Aaaaaaaaaa aaaaaaaaaa =
+			bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh;
+
+		Aaaaaaaaaa aaaaaaaaaa =
+			bbbbbbbbbb(cccccccccccccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh;
+
+		Aaaaaaaaaa aaaaaaaaaa =
+			bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeee) !=
+			ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh;
+
+		aaaaaaaaaa =
+			bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh;
+
+		aaaaaaaaaa =
+			bbbbbbbbbb(cccccccccccccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh;
+
+		aaaaaaaaaa =
+			bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeee) !=
+			ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh;
+	}
 }


### PR DESCRIPTION
## What changed with this PR:

Assignments with binary expressions (including those within the expression of a ternary) are now broken more similarly to the way Prettier does with JavaScript/TypeScript.

## Example

### Input

```java
Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;

Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;

Aaaaaaaaaa aaaaaaaaaa = bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeeeeeeeeeeeee) != ffffffffff ? gggggggggg : hhhhhhhhhh;

var aaaaaaaaaa = bbbbbbbbbbbb || cccccccccc ? dddddddddd + eeeeeeeeee : ffffffffff + gggggggggg;
```

### Output

```java
Aaaaaaaaaa aaaaaaaaaa =
  bbbbbbbbbb(cccccccccc, dddddddddd, eeeeeeeeee) != ffffffffff
    ? gggggggggg
    : hhhhhhhhhh;

Aaaaaaaaaa aaaaaaaaaa =
  bbbbbbbbbb(cccccccccccccccccccc, dddddddddddddddddddd, eeeeeeeeee) !=
  ffffffffff
    ? gggggggggg
    : hhhhhhhhhh;

Aaaaaaaaaa aaaaaaaaaa =
  bbbbbbbbbb(
    cccccccccccccccccccc,
    dddddddddddddddddddd,
    eeeeeeeeeeeeeeeeeeee
  ) !=
  ffffffffff
    ? gggggggggg
    : hhhhhhhhhh;

var aaaaaaaaaa =
  bbbbbbbbbbbb || cccccccccc
    ? dddddddddd + eeeeeeeeee
    : ffffffffff + gggggggggg;
```

### Output

## Relative issues or prs:

Closes #788