### PR TITLE
fix: proper breaking of parenthesized expressions

### DIFF
--- a/packages/prettier-plugin-java/src/printers/helpers.ts
+++ b/packages/prettier-plugin-java/src/printers/helpers.ts
@@ -376,15 +376,17 @@ export function isBinaryExpression(expression: ExpressionCstNode) {
   return hasNonAssignmentOperators(conditionalExpression.binaryExpression[0]);
 }
 
+export function hasAssignmentOperators(
+  binaryExpression: BinaryExpressionCstNode
+) {
+  return binaryExpression.children.AssignmentOperator !== undefined;
+}
+
 export function hasNonAssignmentOperators(
   binaryExpression: BinaryExpressionCstNode
 ) {
-  return Object.values(binaryExpression.children).some(
-    child =>
-      isTerminal(child[0]) &&
-      !child[0].tokenType.CATEGORIES?.some(
-        category => category.name === "AssignmentOperator"
-      )
+  return Object.keys(binaryExpression.children).some(name =>
+    ["BinaryOperator", "Instanceof", "shiftOperator"].includes(name)
   );
 }
 

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_input.java
@@ -207,5 +207,43 @@ public class Expressions {
   public void typeExpressionsInFqnParts() {
     var myVariable = ImmutableMap.<R, V>of<T>::a();
   }
-}
 
+  void parenthesesWithLeadingAndTrailingBreak() {
+    (aaaaaaaaaa + bbbbbbbbbb + cccccccccc + dddddddddd + eeeeeeeeee).ffffffffff();
+    (aaaaaaaaaa + bbbbbbbbbb + cccccccccc + dddddddddd + eeeeeeeeee)::ffffffffff;
+
+    aaaaaaaaaa = (bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    aaaaaaaaaa = (bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    aaaaaaaaaa = (bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+
+    switch (a) {
+      case Bbbbbbbbbb bbbbbbbbbb when (cccccccccc && dddddddddd && eeeeeeeeee) -> ffffffffff;
+    }
+
+    return (aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff);
+  }
+
+  void parenthesesWithTrailingBreak() {
+    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+  }
+
+  void parenthesesWithoutBreak() {
+    (aaaaaaaaaa -> bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    (aaaaaaaaaa -> bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    (aaaaaaaaaa -> bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+
+    aaaaaaaaaa = (bbbbbbbbbb -> cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    aaaaaaaaaa = (bbbbbbbbbb -> cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    aaaaaaaaaa = (bbbbbbbbbb -> cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb -> cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb -> cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb -> cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+  }
+}

--- a/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/expressions/_output.java
@@ -249,4 +249,94 @@ public class Expressions {
   public void typeExpressionsInFqnParts() {
     var myVariable = ImmutableMap.<R, V>of<T>::a();
   }
+
+  void parenthesesWithLeadingAndTrailingBreak() {
+    (
+      aaaaaaaaaa +
+      bbbbbbbbbb +
+      cccccccccc +
+      dddddddddd +
+      eeeeeeeeee
+    ).ffffffffff();
+    (
+      aaaaaaaaaa +
+      bbbbbbbbbb +
+      cccccccccc +
+      dddddddddd +
+      eeeeeeeeee
+    )::ffffffffff;
+
+    aaaaaaaaaa = (
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
+    ).ffffffffff();
+    aaaaaaaaaa = (
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
+    )::ffffffffff;
+    aaaaaaaaaa = (
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
+    )[ffffffffff];
+
+    Aaaaaaaaaa aaaaaaaaaa = (
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
+    ).ffffffffff();
+    Aaaaaaaaaa aaaaaaaaaa = (
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
+    )::ffffffffff;
+    Aaaaaaaaaa aaaaaaaaaa = (
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
+    )[ffffffffff];
+
+    switch (a) {
+      case Bbbbbbbbbb bbbbbbbbbb when (
+        cccccccccc && dddddddddd && eeeeeeeeee
+      ) -> ffffffffff;
+    }
+
+    return (
+      aaaaaaaaaa &&
+      bbbbbbbbbb &&
+      cccccccccc &&
+      dddddddddd &&
+      eeeeeeeeee &&
+      ffffffffff
+    );
+  }
+
+  void parenthesesWithTrailingBreak() {
+    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
+      ? dddddddddd
+      : eeeeeeeeee
+    ).ffffffffff();
+    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
+      ? dddddddddd
+      : eeeeeeeeee
+    )::ffffffffff;
+    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
+      ? dddddddddd
+      : eeeeeeeeee
+    )[ffffffffff];
+  }
+
+  void parenthesesWithoutBreak() {
+    (aaaaaaaaaa ->
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    (aaaaaaaaaa ->
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    (aaaaaaaaaa ->
+      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+
+    aaaaaaaaaa = (bbbbbbbbbb ->
+      cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    aaaaaaaaaa = (bbbbbbbbbb ->
+      cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    aaaaaaaaaa = (bbbbbbbbbb ->
+      cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb ->
+      cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb ->
+      cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
+    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb ->
+      cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

Fixes breaking of parenthesized expressions to be more similar to the behavior of Prettier JavaScript/TypeScript.

## Example

### Input

```java
class Example {

  void parenthesesWithLeadingAndTrailingBreak() {
    (aaaaaaaaaa +
      bbbbbbbbbb +
      cccccccccc +
      dddddddddd +
      eeeeeeeeee).ffffffffff();
    (aaaaaaaaaa +
      bbbbbbbbbb +
      cccccccccc +
      dddddddddd +
      eeeeeeeeee)::ffffffffff;

    aaaaaaaaaa = (bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee).ffffffffff();
    aaaaaaaaaa = (bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee)::ffffffffff;
    aaaaaaaaaa = (bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee)[ffffffffff];

    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee).ffffffffff();
    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee)::ffffffffff;
    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee)[ffffffffff];

    switch (a) {
      case Bbbbbbbbbb bbbbbbbbbb when (
        cccccccccc && dddddddddd && eeeeeeeeee
      ) -> ffffffffff;
    }

    return (
      aaaaaaaaaa &&
      bbbbbbbbbb &&
      cccccccccc &&
      dddddddddd &&
      eeeeeeeeee &&
      ffffffffff
    );
  }

  void parenthesesWithTrailingBreak() {
    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee).ffffffffff();
    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee)::ffffffffff;
    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee)[ffffffffff];
  }

  void parenthesesWithoutBreak() {
    ((aaaaaaaaaa) ->
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
    ((aaaaaaaaaa) ->
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
    ((aaaaaaaaaa) ->
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];

    aaaaaaaaaa = ((bbbbbbbbbb) ->
      cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
    aaaaaaaaaa = ((bbbbbbbbbb) ->
      cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
    aaaaaaaaaa = ((bbbbbbbbbb) ->
      cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];

    Aaaaaaaaaa aaaaaaaaaa = ((bbbbbbbbbb) ->
      cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
    Aaaaaaaaaa aaaaaaaaaa = ((bbbbbbbbbb) ->
      cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
    Aaaaaaaaaa aaaaaaaaaa = ((bbbbbbbbbb) ->
      cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
  }
}
```

### Output

```java
class Example {

  void parenthesesWithLeadingAndTrailingBreak() {
    (
      aaaaaaaaaa +
      bbbbbbbbbb +
      cccccccccc +
      dddddddddd +
      eeeeeeeeee
    ).ffffffffff();
    (
      aaaaaaaaaa +
      bbbbbbbbbb +
      cccccccccc +
      dddddddddd +
      eeeeeeeeee
    )::ffffffffff;

    aaaaaaaaaa = (
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
    ).ffffffffff();
    aaaaaaaaaa = (
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
    )::ffffffffff;
    aaaaaaaaaa = (
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
    )[ffffffffff];

    Aaaaaaaaaa aaaaaaaaaa = (
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
    ).ffffffffff();
    Aaaaaaaaaa aaaaaaaaaa = (
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
    )::ffffffffff;
    Aaaaaaaaaa aaaaaaaaaa = (
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee
    )[ffffffffff];

    switch (a) {
      case Bbbbbbbbbb bbbbbbbbbb when (
        cccccccccc &&
        dddddddddd &&
        eeeeeeeeee
      ) -> ffffffffff;
    }

    return (
      aaaaaaaaaa &&
      bbbbbbbbbb &&
      cccccccccc &&
      dddddddddd &&
      eeeeeeeeee &&
      ffffffffff
    );
  }

  void parenthesesWithTrailingBreak() {
    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee
    ).ffffffffff();
    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee
    )::ffffffffff;
    (aaaaaaaaaa && bbbbbbbbbb && cccccccccc
      ? dddddddddd
      : eeeeeeeeee
    )[ffffffffff];
  }

  void parenthesesWithoutBreak() {
    (aaaaaaaaaa ->
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
    (aaaaaaaaaa ->
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
    (aaaaaaaaaa ->
      bbbbbbbbbb && cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];

    aaaaaaaaaa = (bbbbbbbbbb ->
      cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
    aaaaaaaaaa = (bbbbbbbbbb ->
      cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
    aaaaaaaaaa = (bbbbbbbbbb ->
      cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];

    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb ->
      cccccccccc ? dddddddddd : eeeeeeeeee).ffffffffff();
    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb ->
      cccccccccc ? dddddddddd : eeeeeeeeee)::ffffffffff;
    Aaaaaaaaaa aaaaaaaaaa = (bbbbbbbbbb ->
      cccccccccc ? dddddddddd : eeeeeeeeee)[ffffffffff];
  }
}
```

## Relative issues or prs:

Closes #765