### PR TITLE
fix: indent ternary binary expressions in return statements

### DIFF
--- a/packages/prettier-plugin-java/src/printers/expressions.ts
+++ b/packages/prettier-plugin-java/src/printers/expressions.ts
@@ -126,6 +126,10 @@ export default {
     if (!path.node.children.QuestionMark) {
       return isInParentheses ? binaryExpression : group(binaryExpression);
     }
+    const isInReturn = grandparentNodeName === "returnStatement";
+    const prefix = group(
+      isInReturn ? indent(binaryExpression) : binaryExpression
+    );
     const [consequent, alternate] = map(path, print, "expression");
     const suffix = [
       line,
@@ -139,9 +143,9 @@ export default {
         ? suffix
         : align(Math.max(0, options.tabWidth - 2), suffix);
     if (isNestedTernary) {
-      return [group(binaryExpression), alignedSuffix];
+      return [prefix, alignedSuffix];
     }
-    const parts = [group(binaryExpression), indent(alignedSuffix)];
+    const parts = [prefix, indent(alignedSuffix)];
     return isInParentheses ? parts : group(parts);
   },
 

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_input.java
@@ -10,6 +10,14 @@ class ConditionalExpression {
         return thisIsAVeryLongInteger ? thisIsAnotherVeryLongOne : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
     }
 
+    void ternaryOperationThatShouldBreak3() {
+        aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
+        var v = aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
+        v = aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
+        f(aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh);
+        return aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
+    }
+
     int ternaryOperationThatShouldNotBreak() {
         int a = b ? b : c;
         return b ? b : c;

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/spaces/_output.java
@@ -19,6 +19,53 @@ class ConditionalExpression {
             : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
     }
 
+    void ternaryOperationThatShouldBreak3() {
+        aaaaaaaaaa &&
+        bbbbbbbbbb &&
+        cccccccccc &&
+        dddddddddd &&
+        eeeeeeeeee &&
+        ffffffffff
+            ? gggggggggg
+            : hhhhhhhhhh;
+        var v =
+            aaaaaaaaaa &&
+            bbbbbbbbbb &&
+            cccccccccc &&
+            dddddddddd &&
+            eeeeeeeeee &&
+            ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh;
+        v =
+            aaaaaaaaaa &&
+            bbbbbbbbbb &&
+            cccccccccc &&
+            dddddddddd &&
+            eeeeeeeeee &&
+            ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh;
+        f(
+            aaaaaaaaaa &&
+                bbbbbbbbbb &&
+                cccccccccc &&
+                dddddddddd &&
+                eeeeeeeeee &&
+                ffffffffff
+                ? gggggggggg
+                : hhhhhhhhhh
+        );
+        return aaaaaaaaaa &&
+            bbbbbbbbbb &&
+            cccccccccc &&
+            dddddddddd &&
+            eeeeeeeeee &&
+            ffffffffff
+            ? gggggggggg
+            : hhhhhhhhhh;
+    }
+
     int ternaryOperationThatShouldNotBreak() {
         int a = b ? b : c;
         return b ? b : c;

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_input.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_input.java
@@ -10,6 +10,14 @@ class ConditionalExpression {
 		return thisIsAVeryLongInteger ? thisIsAnotherVeryLongOne : thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
 	}
 
+	void ternaryOperationThatShouldBreak3() {
+		aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
+		var v = aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
+		v = aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
+		f(aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh);
+		return aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
+	}
+
 	int ternaryOperationThatShouldNotBreak() {
 		int a = b ? b : c;
 		return b ? b : c;

--- a/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_output.java
+++ b/packages/prettier-plugin-java/test/unit-test/conditional-expression/tabs/_output.java
@@ -18,6 +18,53 @@ class ConditionalExpression {
 			: thisIsAnotherVeryLongIntegerThatIsEvenLongerThanFirstOne;
 	}
 
+	void ternaryOperationThatShouldBreak3() {
+		aaaaaaaaaa &&
+		bbbbbbbbbb &&
+		cccccccccc &&
+		dddddddddd &&
+		eeeeeeeeee &&
+		ffffffffff
+			? gggggggggg
+			: hhhhhhhhhh;
+		var v =
+			aaaaaaaaaa &&
+			bbbbbbbbbb &&
+			cccccccccc &&
+			dddddddddd &&
+			eeeeeeeeee &&
+			ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh;
+		v =
+			aaaaaaaaaa &&
+			bbbbbbbbbb &&
+			cccccccccc &&
+			dddddddddd &&
+			eeeeeeeeee &&
+			ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh;
+		f(
+			aaaaaaaaaa &&
+				bbbbbbbbbb &&
+				cccccccccc &&
+				dddddddddd &&
+				eeeeeeeeee &&
+				ffffffffff
+				? gggggggggg
+				: hhhhhhhhhh
+		);
+		return aaaaaaaaaa &&
+			bbbbbbbbbb &&
+			cccccccccc &&
+			dddddddddd &&
+			eeeeeeeeee &&
+			ffffffffff
+			? gggggggggg
+			: hhhhhhhhhh;
+	}
+
 	int ternaryOperationThatShouldNotBreak() {
 		int a = b ? b : c;
 		return b ? b : c;


### PR DESCRIPTION
## What changed with this PR:

Ternaries' binary expressions in return statements are indented properly again.

## Example

### Input

```java
void example() {
  return aaaaaaaaaa && bbbbbbbbbb && cccccccccc && dddddddddd && eeeeeeeeee && ffffffffff ? gggggggggg : hhhhhhhhhh;
}
```

### Output

```java
void example() {
  return aaaaaaaaaa &&
    bbbbbbbbbb &&
    cccccccccc &&
    dddddddddd &&
    eeeeeeeeee &&
    ffffffffff
    ? gggggggggg
    : hhhhhhhhhh;
}
```

## Relative issues or prs:

Closes #802