### PR TITLE
build(deps-dev): bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e-jhipster1": "node scripts/clone-samples e2e-jhipster1 && mocha \"test/repository-test/jhipster-1-test.ts\"",
     "test:e2e-jhipster2": "node scripts/clone-samples e2e-jhipster2 && mocha \"test/repository-test/jhipster-2-test.ts\"",
     "test:unit": "mocha \"test/unit-test/**/*.spec.ts\" \"test/unit-test/**/*-spec.ts\"",
+    "typecheck": "tsc",
     "update-test-outputs": "node scripts/update-test-output.js"
   },
   "lint-staged": {
@@ -57,6 +58,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/chai": "^5.2.3",
+    "@types/emscripten": "^1.41.5",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.5.0",
     "chai": "^6.2.2",
@@ -70,7 +72,7 @@
     "prettier": "^3.8.1",
     "tree-sitter-java-orchard": "0.5.6",
     "tsdown": "^0.21.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.57.1"
   },
   "peerDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2023",
-    "outDir": "dist",
-    "strict": true,
+    "rootDir": "src",
+    "types": ["emscripten"],
+    "allowImportingTsExtensions": true,
     "declaration": true,
-    "esModuleInterop": true,
-    "noImplicitThis": false,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "rewriteRelativeImportExtensions": true
+    "noEmit": true
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,6 +1005,11 @@
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
+"@types/emscripten@^1.41.5":
+  version "1.41.5"
+  resolved "https://registry.yarnpkg.com/@types/emscripten/-/emscripten-1.41.5.tgz#5670e4b52b098691cb844b84ee48c9176699b68d"
+  integrity sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==
+
 "@types/esrecurse@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/esrecurse/-/esrecurse-4.3.1.tgz#6f636af962fbe6191b830bd676ba5986926bccec"
@@ -4857,10 +4862,15 @@ typescript-eslint@^8.57.1:
     "@typescript-eslint/typescript-estree" "8.59.0"
     "@typescript-eslint/utils" "8.59.0"
 
-"typescript@>=3 < 6", typescript@^5.9.3:
+"typescript@>=3 < 6":
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
## What changed with this PR:

TypeScript is upgraded to version 6, typecheck script is added and fixed, and TypeScript options are cleaned up.