### PR TITLE
chore: improve type checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
-    "types": ["emscripten"],
+    "module": "esnext",
+    "types": ["emscripten", "mocha", "node"],
     "allowImportingTsExtensions": true,
     "declaration": true,
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["scripts", "src", "test"]
 }


### PR DESCRIPTION
## What changed with this PR:

The `typecheck` script (and type checking in IDEs) now covers `scripts` and `tests` in addition to `src`.