### PR TITLE
fix: only evaluate simple text block escape sequences

### DIFF
--- a/src/printers/helpers.ts
+++ b/src/printers/helpers.ts
@@ -351,19 +351,12 @@ export function embedTextBlock(path: NamedNodePath<SyntaxType.StringLiteral>) {
     textToDoc: (text: string, options: Options) => Promise<Doc>
   ) => {
     const doc = await textToDoc(text, { parser: language });
-    return printTextBlock(path, escapeDocForTextBlock(doc));
+    return printTextBlock(path, [escapeDocForTextBlock(doc), hardline]);
   };
 }
 
 export function textBlockContents(node: NamedNode<SyntaxType.StringLiteral>) {
-  const lines = node.value
-    .replace(
-      /(?<=^|[^\\])((?:\\\\)*)\\u+([0-9a-fA-F]{4})/g,
-      (_, backslashPairs: string, hex: string) =>
-        backslashPairs + String.fromCharCode(parseInt(hex, 16))
-    )
-    .split("\n")
-    .slice(1);
+  const lines = node.value.split("\n").slice(1);
   const baseIndent = findBaseIndent(lines);
   return lines
     .map(line => line.slice(baseIndent))
@@ -394,39 +387,28 @@ function findEmbeddedLanguage(path: NamedNodePath) {
 function escapeDocForTextBlock(doc: Doc) {
   return mapDoc(doc, currentDoc =>
     typeof currentDoc === "string"
-      ? currentDoc.replace(/\\|"""/g, match => `\\${match}`)
+      ? currentDoc.replace(/\\|"""/g, match =>
+          match === "\\" ? "\\\\" : '""\\"'
+        )
       : currentDoc
   );
 }
 
 function unescapeTextBlockContents(text: string) {
-  return text.replace(
-    /\\(?:([bstnfr"'\\])|\n|\r\n?|([0-3][0-7]{0,2}|[0-7]{1,2}))/g,
-    (_, single, octal) => {
-      if (single) {
-        switch (single) {
-          case "b":
-            return "\b";
-          case "s":
-            return " ";
-          case "t":
-            return "\t";
-          case "n":
-            return "\n";
-          case "f":
-            return "\f";
-          case "r":
-            return "\r";
-          default:
-            return single;
-        }
-      } else if (octal) {
-        return String.fromCharCode(parseInt(octal, 8));
-      } else {
-        return "";
-      }
+  return text.replace(/\\(?:([stnr"'\\])|\n|\r\n?)/g, (_, escaped) => {
+    switch (escaped) {
+      case "s":
+        return " ";
+      case "t":
+        return "\t";
+      case "n":
+        return "\n";
+      case "r":
+        return "\r";
+      default:
+        return escaped ?? "";
     }
-  );
+  });
 }
 
 export type NamedNodePrinters = {

--- a/test/unit-test/text-blocks/_input.java
+++ b/test/unit-test/text-blocks/_input.java
@@ -72,12 +72,12 @@ aoeu
   void json() {
     // language = json
     String someJson = """
-    {"glossary":{"title": "example glossary"}}
+    {"glossary":{"title": "example \'glossary\'"}}
     """;
 
     // language=json
     String config = """
-          {   "name":"example",
+          { \t "name":"example",
       "enabled"   :true,
             "timeout":30}
     """;
@@ -106,6 +106,17 @@ aoeu
     String html = """
       <!DOCTYPE html><html><head><title>Page Title</title></head><body><h1>My First Heading</h1><p>My first paragraph.</p></body></html>
     """;
+  }
+
+  void typescript() {
+    // language=typescript
+    String typescript = """
+      const s = `\"""`;
+    """;
+
+    // language=typescript
+    String typescript = """
+      const s = ""; // \"""";
   }
 
   void unsupported() {

--- a/test/unit-test/text-blocks/_output.java
+++ b/test/unit-test/text-blocks/_output.java
@@ -65,23 +65,26 @@ public class TextBlock {
   String escapes = """
     \n\t\r\f\b\s\\
     \077
-    A""";
+    \u0041""";
 
   void json() {
     // language = json
     String someJson = """
-      { "glossary": { "title": "example glossary" } }""";
+      { "glossary": { "title": "example 'glossary'" } }
+      """;
 
     // language=json
     String config = """
-      { "name": "example", "enabled": true, "timeout": 30 }""";
+      { "name": "example", "enabled": true, "timeout": 30 }
+      """;
 
     /* language = JSON */
     String query = """
       {
         "sql": "SELECT * FROM users WHERE active=1 AND deleted=0",
         "limit": 10
-      }""";
+      }
+      """;
   }
 
   void java() {
@@ -92,7 +95,8 @@ public class TextBlock {
         void method() {
           // comment
         }
-      }""";
+      }
+      """;
   }
 
   void html() {
@@ -107,7 +111,20 @@ public class TextBlock {
           <h1>My First Heading</h1>
           <p>My first paragraph.</p>
         </body>
-      </html>""";
+      </html>
+      """;
+  }
+
+  void typescript() {
+    // language=typescript
+    String typescript = """
+      const s = `""\"`;
+      """;
+
+    // language=typescript
+    String typescript = """
+      const s = ""; // "
+      """;
   }
 
   void unsupported() {


### PR DESCRIPTION
## What changed with this PR:

No longer evaluate unicode escape sequences in text blocks. Also no longer evaluate octal escape sequences, `\b`, and `\f` in embedded language text blocks, in favor of only evaluating "simple" escape sequences working with whitespace, quotes, and `\\`. Finally, fixes some other bugs with embedded language text blocks, such as properly escaping sequences of >3 `"` (for example instead of `""""` being improperly escaped as `\""""`, it will now be escaped as `""\""`), and properly avoiding trailing unescaped `"` from bleeding into the closing `"""`.