### PR TITLE
chore: remove non-type-checking options from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "esnext",
     "types": ["emscripten", "mocha", "node"],
     "allowImportingTsExtensions": true,
-    "declaration": true,
     "noEmit": true
   },
   "include": ["scripts", "src", "test"]


### PR DESCRIPTION
## What changed with this PR:

Any TypeScript compiler options that aren't necessary for type checking are removed from `tsconfig.json`, as we are using tsdown for compilation (so the `tsconfig.json` is only used for type checking).