### PR TITLE
build: fix Lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "yarn",
-  "version": "independent",
-  "$schema": "node_modules/lerna/schemas/lerna-schema.json"
+  "packages": ["."],
+  "version": "independent"
 }


### PR DESCRIPTION
## What changed with this PR:

Lerna configuration is fixed now that the `workspaces` field was removed from the `package.json` with the migration of this repo to produce a single package.