### PR TITLE
fix: rename postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clone-samples": "node scripts/clone-samples.js",
     "format:fix": "prettier --write \"**/*.@(js|json|ts)\"",
     "format:validate": "prettier --list-different \"**/*.@(js|json|ts)\"",
-    "postinstall": "node scripts/generate-node-types.ts && prettier --write src/node-types.ts",
+    "generate-node-types": "node scripts/generate-node-types.ts && prettier --write src/node-types.ts",
     "lerna:publish": "lerna publish from-git --yes",
     "lerna:version": "lerna version --exact --no-private",
     "lint": "eslint src test",


### PR DESCRIPTION
## What changed with this PR:

The `postinstall` script is run after anyone installs this package as a dependency, which was not the intention. This is causing the installation of this package as a dependency to fail. The script has been renamed.