### PR TITLE
fix: restore space between array type and dimension annotations

### DIFF
--- a/src/printers/types-values-and-variables.ts
+++ b/src/printers/types-values-and-variables.ts
@@ -21,10 +21,12 @@ export default {
   },
 
   dimensions(path, print) {
-    return path.map(
-      child => (child.node.isNamed ? [print(child), " "] : child.node.value),
-      "children"
-    );
+    return path.map(child => {
+      if (child.node.isNamed) {
+        return [...(child.isFirst ? [" "] : []), print(child), " "];
+      }
+      return child.node.value;
+    }, "children");
   },
 
   type_parameter(path, print) {

--- a/test/unit-test/arrays/_input.java
+++ b/test/unit-test/arrays/_input.java
@@ -1,13 +1,15 @@
 class Array {
-    boolean[] skip = new boolean[candidates.length];
+  boolean[] skip = new boolean[candidates.length];
 
-    Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa<Bbbbbbbbbbbbbbbb>[1].getClass();
-    Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa[1111111111111111111].getClass();
-    Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa[]{ new Aaaaaaaaaaaaaaaa() }.getClass();
+  Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa<Bbbbbbbbbbbbbbbb>[1].getClass();
+  Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa[1111111111111111111].getClass();
+  Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa[]{ new Aaaaaaaaaaaaaaaa() }.getClass();
 
-    String[] DATA = {
-        // nothing yet
-    };
+  String[] DATA = {
+    // nothing yet
+  };
 
-    Weather currentWeather = enumValues[(currentWeather.ordinal() + 1) % enumValues.length];
+  Weather currentWeather = enumValues[(currentWeather.ordinal() + 1) % enumValues.length];
+
+  int @Nullable [] array;
 }

--- a/test/unit-test/arrays/_output.java
+++ b/test/unit-test/arrays/_output.java
@@ -18,4 +18,6 @@ class Array {
   Weather currentWeather = enumValues[
     (currentWeather.ordinal() + 1) % enumValues.length
   ];
+
+  int @Nullable [] array;
 }


### PR DESCRIPTION
## What changed with this PR:

The space between an array's type and its first dimension annotation is restored. This regression seems to have been introduced by the migration to tree-sitter, which introduced a lot of rearranging of formatting decisions, particularly with annotations.

## Example

### Input

```java
int@Nullable [] array;
```

### Output

```java
int @Nullable [] array;
```

## Relative issues or prs:

Closes #880