### PR TITLE
fix: correct Windows path resolution in parser init

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from "node:url";
 import type Prettier from "prettier";
 import { Language, Parser, type Node } from "web-tree-sitter";
 import { determinePrettierIgnoreRanges } from "./comments.ts";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,7 +42,7 @@ const parser = (async () => {
 
   const parser = new Parser();
   const Java = await Language.load(
-    fileURLToPath(new URL("./tree-sitter-java_orchard.wasm", import.meta.url))
+    new URL("./tree-sitter-java_orchard.wasm", import.meta.url)
   );
   parser.setLanguage(Java);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import type Prettier from "prettier";
 import { Language, Parser, type Node } from "web-tree-sitter";
 import { determinePrettierIgnoreRanges } from "./comments.ts";
@@ -41,7 +42,7 @@ const parser = (async () => {
 
   const parser = new Parser();
   const Java = await Language.load(
-    new URL("./tree-sitter-java_orchard.wasm", import.meta.url).pathname
+    fileURLToPath(new URL("./tree-sitter-java_orchard.wasm", import.meta.url))
   );
   parser.setLanguage(Java);
 


### PR DESCRIPTION
## What changed with this PR:

Fix the invalid path on Windows when loading the treesitter wasm file

## Example
```
 no such file or directory, open 'C:\C:\.....\target\spotless-prettier-node-modules-a419b185f88f4c8243af8729ce04d5c8\node_modules\prettier-plugin-java\dist\tree-sitter-java_orchard.wasm'
```

