### PR TITLE
fix: restore array literal spacing

### DIFF
--- a/src/printers/helpers.ts
+++ b/src/printers/helpers.ts
@@ -141,7 +141,7 @@ export function printArrayInitializer(
     list.push(ifBreak(","));
   }
 
-  return group(["{", indent([softline, ...list]), softline, "}"]);
+  return group(["{", indent([line, ...list]), line, "}"]);
 }
 
 export function printBlock(path: NamedNodePath, contents: Doc[]) {

--- a/test/unit-test/expressions/_output.java
+++ b/test/unit-test/expressions/_output.java
@@ -209,9 +209,9 @@ public class Expressions {
 
   public void unannTypePrimitiveWithMethodReferenceSuffix(String[] args) {
     List.of(
-      new double[][] {1, 2, 3, 4.1, 5.6846465},
-      new double[][] {1, 2, 3, 4.1, 5.6846465},
-      new double[][] {1, 2, 3, 4.1, 5.6846465}
+      new double[][] { 1, 2, 3, 4.1, 5.6846465 },
+      new double[][] { 1, 2, 3, 4.1, 5.6846465 },
+      new double[][] { 1, 2, 3, 4.1, 5.6846465 }
     ).toArray(double[][]::new);
   }
 

--- a/test/unit-test/marker_annotations/_output.java
+++ b/test/unit-test/marker_annotations/_output.java
@@ -29,7 +29,7 @@ public class MarkerAnnotations {
     System.out.println("post construct");
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
+  @SuppressWarnings({ "rawtypes", "unchecked" })
   @SuppressWarnings2({
     "rawtypes",
     "unchecked",
@@ -43,9 +43,9 @@ public class MarkerAnnotations {
   }
 
   @ArrayInitializersWithKey(
-    key = {"abc", "def"},
-    key2 = {"ghi", "jkl"},
-    key3 = {"mno", "pqr"}
+    key = { "abc", "def" },
+    key2 = { "ghi", "jkl" },
+    key3 = { "mno", "pqr" }
   )
   public void arrayInitializerWithKey() {
     System.out.println("element value array initializer with key");

--- a/test/unit-test/snippets/classes/variableDeclarator/test.spec.ts
+++ b/test/unit-test/snippets/classes/variableDeclarator/test.spec.ts
@@ -14,7 +14,7 @@ describe("VariableDeclarator", () => {
     const snippet = "int[]i={alpha};";
 
     const formattedText = await formatJavaSnippet({ snippet });
-    const expectedContents = "int[] i = {alpha};\n";
+    const expectedContents = "int[] i = { alpha };\n";
     expect(formattedText).to.equal(expectedContents);
   });
 

--- a/test/unit-test/variables/_output.java
+++ b/test/unit-test/variables/_output.java
@@ -40,7 +40,7 @@ public class Variables {
   private Object[] arrayVariable1 = new Object[3];
   private Object[][] arrayVariable2 = new Object[3][3];
   private Object[] arrayVariable3 = new Object[] {};
-  private Object[] arrayVariable4 = new Object[] {"abc", "def", "ghi"};
+  private Object[] arrayVariable4 = new Object[] { "abc", "def", "ghi" };
   private Object[] arrayVariable5 = new Object[] {
     "abc",
     "def",
@@ -48,7 +48,7 @@ public class Variables {
     "jkl",
     "mno",
   };
-  private Object[] arrayVariable6 = {"abc", "def", "ghi"};
+  private Object[] arrayVariable6 = { "abc", "def", "ghi" };
 
   private Range creator1 = this.dateRangeField.new Range(from, to);
   private Range creator2 = this.dateRangeField.new <Integer>Range(from, to);
@@ -221,7 +221,7 @@ public class Variables {
       new Object[10];
 
     Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
-      new Object[] {new Object(), new Object()};
+      new Object[] { new Object(), new Object() };
 
     Object[] aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
       new Object[] {


### PR DESCRIPTION
## What changed with this PR:

The spacing within the braces of an array literal have been restored. They were removed improperly due to semantic similarity to JS array literals. In the future we may decide to support the `bracketSpacing` option, though Prettier includes that option in a list that "are not the type of options we’re happy to have" ([source](https://prettier.io/docs/option-philosophy/)).

## Example

### Input

```java
String[] array = {"a", "b", "c"};
```

### Output

```java
String[] array = { "a", "b", "c" };
```

## Relative issues or prs:

Closes #882