### PR TITLE
fix: keep member chain line-end comments on the same line

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -191,18 +191,11 @@ function handleMemberChainComments(commentNode: CommentNode) {
   const { enclosingNode, precedingNode, followingNode } = commentNode;
   if (
     (enclosingNode?.type === SyntaxType.FieldAccess ||
-      enclosingNode?.type === SyntaxType.MethodInvocation) &&
+      (enclosingNode?.type === SyntaxType.MethodInvocation &&
+        precedingNode?.end.row !== commentNode.start.row)) &&
     followingNode?.type === SyntaxType.Identifier
   ) {
     util.addLeadingComment(enclosingNode, commentNode);
-    return true;
-  } else if (
-    followingNode &&
-    isMember(followingNode) &&
-    precedingNode !== enclosingNode &&
-    !isPrettierIgnore(commentNode)
-  ) {
-    util.addDanglingComment(followingNode, commentNode, undefined);
     return true;
   }
   return false;
@@ -373,11 +366,11 @@ function printTrailingComment(
     hasNewline(originalText, parser.locStart(comment), { backwards: true })
   ) {
     // This allows comments at the end of nested structures:
-    // f(
+    // {
     //   1,
     //   2
     //   // A comment
-    // );
+    // }
     // Those kinds of comments are almost always leading comments, but
     // here it doesn't go "outside" the block and turns it into a
     // trailing comment for `2`. We can simulate the above by checking

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -43,16 +43,16 @@ export function testSampleWithOptions({
   });
 
   it(`Performs a stable formatting for <${relativeInputPath}>`, async () => {
-    const onePass = await formatJavaSnippet({
+    const firstPass = await formatJavaSnippet({
       snippet: inputContents,
       prettierOptions
     });
 
     const secondPass = await formatJavaSnippet({
-      snippet: onePass,
+      snippet: firstPass,
       prettierOptions
     });
-    expect(onePass).to.equal(secondPass);
+    expect(secondPass).to.equal(firstPass);
   });
 }
 
@@ -85,9 +85,9 @@ export function testRepositorySample(
             "utf8"
           );
 
-          const onePass = await formatJavaSnippet({ snippet: javaFileText });
-          const secondPass = await formatJavaSnippet({ snippet: onePass });
-          expect(onePass).to.equal(secondPass);
+          const firstPass = await formatJavaSnippet({ snippet: javaFileText });
+          const secondPass = await formatJavaSnippet({ snippet: firstPass });
+          expect(secondPass).to.equal(firstPass);
         });
       });
 

--- a/test/unit-test/member_chain/_input.java
+++ b/test/unit-test/member_chain/_input.java
@@ -5,13 +5,27 @@ public class BreakLongFunctionCall {
     }
 
     public void doSomethingNewWithComment() {
+        // comment
+        new Object().something().more();
+
+        new Object() // comment
+            .something().more();
+
         new Object()
             // comment
             .something().more();
 
+        new Object().something() // comment
+            .more();
+
         new Object().something()
             // comment
             .more();
+
+        new Object().something().more(); // comment
+
+        new Object().something().more();
+        // comment
     }
 
     public void doSomethingWithComment() {

--- a/test/unit-test/member_chain/_output.java
+++ b/test/unit-test/member_chain/_output.java
@@ -5,15 +5,31 @@ public class BreakLongFunctionCall {
   }
 
   public void doSomethingNewWithComment() {
+    // comment
+    new Object().something().more();
+
+    new Object() // comment
+      .something()
+      .more();
+
     new Object()
       // comment
       .something()
       .more();
 
     new Object()
+      .something() // comment
+      .more();
+
+    new Object()
       .something()
       // comment
       .more();
+
+    new Object().something().more(); // comment
+
+    new Object().something().more();
+    // comment
   }
 
   public void doSomethingWithComment() {
@@ -61,8 +77,7 @@ public class BreakLongFunctionCall {
       .util()
       .java.java();
 
-    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
-      /* comment */
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java /* comment */
       .util()
       .java.java();
 

--- a/test/unit-test/template-expression/_output.java
+++ b/test/unit-test/template-expression/_output.java
@@ -10,9 +10,9 @@ class TemplateExpression {
     file.exists() ? "does" : "does not"
   } exist";
 
-  String time =
-    STR."The time is \{// The java.time.format package is very useful
-    DateTimeFormatter.ofPattern("HH:mm:ss").format(LocalTime.now())} right now";
+  String time = STR."The time is \{DateTimeFormatter.ofPattern("HH:mm:ss")
+    // The java.time.format package is very useful
+    .format(LocalTime.now())} right now";
 
   String data = STR."\{index++}, \{index++}, \{index++}, \{index++}";
 


### PR DESCRIPTION
## What changed with this PR:

Member chain trailing comments that are not own-line comments are kept on the same line as the member they follow.

## Example

### Input

```java
a() // comment
  .b()
  .c();

a()
  .b() // comment
  .c();
```

### Output

```java
a() // comment
  .b()
  .c();

a()
  .b() // comment
  .c();
```

## Relative issues or prs:

Closes #883