### PR TITLE
fix: keep generic method call leading comments on their own line

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -193,7 +193,8 @@ function handleMemberChainComments(commentNode: CommentNode) {
     (enclosingNode?.type === SyntaxType.FieldAccess ||
       (enclosingNode?.type === SyntaxType.MethodInvocation &&
         precedingNode?.end.row !== commentNode.start.row)) &&
-    followingNode?.type === SyntaxType.Identifier
+    (followingNode?.type === SyntaxType.Identifier ||
+      followingNode?.type === SyntaxType.TypeArguments)
   ) {
     util.addLeadingComment(enclosingNode, commentNode);
     return true;

--- a/test/unit-test/member_chain/_input.java
+++ b/test/unit-test/member_chain/_input.java
@@ -112,6 +112,14 @@ public class BreakLongFunctionCall {
             .something().more();
     }
 
+    public void genericMethodWithLeadingComment() {
+        a
+            // 1
+            .b()
+            // 2
+            .<C>c();
+    }
+
     public void doSomethingLongNew() {
         return something().more().and().that().as().well().but().not().something().something();
     }

--- a/test/unit-test/member_chain/_output.java
+++ b/test/unit-test/member_chain/_output.java
@@ -119,6 +119,14 @@ public class BreakLongFunctionCall {
       .more();
   }
 
+  public void genericMethodWithLeadingComment() {
+    a
+      // 1
+      .b()
+      // 2
+      .<C>c();
+  }
+
   public void doSomethingLongNew() {
     return something()
       .more()


### PR DESCRIPTION
## What changed with this PR:

Leading comments on generic method invocations are now kept on their own line.

## Example

### Input

```java
a
  // 1
  .b()
  // 2
  .<C>c();
```

### Output

```java
a
  // 1
  .b()
  // 2
  .<C>c();
```

## Relative issues or prs:

Closes #884