### PR TITLE
fix: prevent forced wrapping of annotated records

### DIFF
--- a/src/printers/classes.ts
+++ b/src/printers/classes.ts
@@ -399,9 +399,8 @@ export default {
   },
 
   record_declaration(path, print) {
-    const parts = printModifiers(path, print, "declarationOnly");
-
-    parts.push("record ", path.call(print, "nameNode"));
+    const modifiers = printModifiers(path, print, "declarationOnly");
+    const parts = ["record ", path.call(print, "nameNode")];
 
     if (hasChild(path, "type_parametersNode")) {
       parts.push(group(path.call(print, "type_parametersNode")));
@@ -426,7 +425,7 @@ export default {
       parts.push(" ");
     }
 
-    return [group(parts), path.call(print, "bodyNode")];
+    return [...modifiers, group(parts), path.call(print, "bodyNode")];
   },
 
   compact_constructor_declaration(path, print) {

--- a/test/unit-test/records/_input.java
+++ b/test/unit-test/records/_input.java
@@ -185,3 +185,9 @@ record Aaaaaaaaaa<Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gg
 
   void a() {}
 }
+
+@A
+record B(
+  C c,
+  D d
+) {}

--- a/test/unit-test/records/_output.java
+++ b/test/unit-test/records/_output.java
@@ -215,3 +215,6 @@ record Aaaaaaaaaa<
 {
   void a() {}
 }
+
+@A
+record B(C c, D d) {}


### PR DESCRIPTION
## What changed with this PR:

Record declarations with annotations no longer forcefully wrap their parameters.

## Example

### Input

```java
@A
record B(
  C c,
  D d
) {}
```

### Output

```java
@A
record B(C c, D d) {}
```

## Relative issues or prs:

Closes #889