### PR TITLE
fix: prevent wrapping of annotated catch parameters

### DIFF
--- a/src/printers/blocks-and-statements.ts
+++ b/src/printers/blocks-and-statements.ts
@@ -362,7 +362,7 @@ export default {
   },
 
   catch_formal_parameter(path, print) {
-    const parts = printModifiers(path, print);
+    const parts = printModifiers(path, print, "noBreak");
 
     const catchTypeIndex = path.node.namedChildren.findIndex(
       ({ type }) => type === SyntaxType.CatchType

--- a/test/unit-test/try_catch/_input.java
+++ b/test/unit-test/try_catch/_input.java
@@ -115,4 +115,13 @@ public class TryCatch {
       d;
     } // d2
   }
+
+  void annotations() {
+    try {
+    } catch (
+      @What
+      Exception e
+    ) {
+    }
+  }
 }

--- a/test/unit-test/try_catch/_output.java
+++ b/test/unit-test/try_catch/_output.java
@@ -160,4 +160,9 @@ public class TryCatch {
       d;
     } // d2
   }
+
+  void annotations() {
+    try {
+    } catch (@What Exception e) {}
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

Annotations on catch clause parameters no longer wrap.

## Example

### Input

```java
try {
} catch (
  @What
  Exception e
) {
}
```

### Output

```java
try {
} catch (@What Exception e) {}
```

## Relative issues or prs:

Closes #885