### PR TITLE
fix: keep comment on root of field access argument

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -198,6 +198,14 @@ function handleMemberChainComments(commentNode: CommentNode) {
   ) {
     util.addLeadingComment(enclosingNode, commentNode);
     return true;
+  } else if (
+    followingNode &&
+    isMember(followingNode) &&
+    precedingNode !== enclosingNode &&
+    !isPrettierIgnore(commentNode)
+  ) {
+    util.addDanglingComment(followingNode, commentNode, undefined);
+    return true;
   }
   return false;
 }

--- a/test/unit-test/member_chain/_input.java
+++ b/test/unit-test/member_chain/_input.java
@@ -148,4 +148,10 @@ public class BreakLongFunctionCall {
         dtoEntities.stream().map(UserDto::toString).forEach(LOGGER::info);
     }
 
+    void fieldAccessArgumentComment() {
+        a(
+            // comment
+            b.c
+        );
+    }
 }

--- a/test/unit-test/member_chain/_output.java
+++ b/test/unit-test/member_chain/_output.java
@@ -202,4 +202,11 @@ public class BreakLongFunctionCall {
   void methodReferences() {
     dtoEntities.stream().map(UserDto::toString).forEach(LOGGER::info);
   }
+
+  void fieldAccessArgumentComment() {
+    a(
+      // comment
+      b.c
+    );
+  }
 }

--- a/test/unit-test/template-expression/_output.java
+++ b/test/unit-test/template-expression/_output.java
@@ -10,9 +10,9 @@ class TemplateExpression {
     file.exists() ? "does" : "does not"
   } exist";
 
-  String time = STR."The time is \{DateTimeFormatter.ofPattern("HH:mm:ss")
-    // The java.time.format package is very useful
-    .format(LocalTime.now())} right now";
+  String time =
+    STR."The time is \{// The java.time.format package is very useful
+    DateTimeFormatter.ofPattern("HH:mm:ss").format(LocalTime.now())} right now";
 
   String data = STR."\{index++}, \{index++}, \{index++}, \{index++}";
 


### PR DESCRIPTION
## What changed with this PR:

Comments on the root of a field access chain are no longer moved to the last field access.

## Example

### Input

```java
a(
  // comment
  b.c
);
```

### Output

```java
a(
  // comment
  b.c
);
```

## Relative issues or prs:

Closes #899