### PR TITLE
fix: don't break member chain for trailing comment

### DIFF
--- a/src/printers/expressions.ts
+++ b/src/printers/expressions.ts
@@ -1034,9 +1034,13 @@ function printMemberChain(
   const cutoff = shouldMerge ? 3 : 2;
   const flatGroups = groups.flat();
 
-  const nodeHasComment = flatGroups.some(node =>
-    node.node.comments?.some(({ leading, trailing }) => leading || trailing)
-  );
+  const nodeHasComment =
+    flatGroups.some(node =>
+      node.node.comments?.some(({ leading }) => leading)
+    ) ||
+    flatGroups
+      .slice(0, -1)
+      .some(node => node.node.comments?.some(({ trailing }) => trailing));
 
   // If we only have a single `.`, we shouldn't do anything fancy and just
   // render everything concatenated together.

--- a/test/unit-test/member_chain/_input.java
+++ b/test/unit-test/member_chain/_input.java
@@ -148,10 +148,32 @@ public class BreakLongFunctionCall {
         dtoEntities.stream().map(UserDto::toString).forEach(LOGGER::info);
     }
 
-    void fieldAccessArgumentComment() {
+    void argumentComment() {
         a(
             // comment
             b.c
+        );
+
+        a(
+            // comment
+            b.c[0]
+        );
+
+        a(
+            // comment
+            b.c()
+        );
+
+        a(
+            b.c // comment
+        );
+
+        a(
+            b.c[0] // comment
+        );
+
+        a(
+            b.c() // comment
         );
     }
 }

--- a/test/unit-test/member_chain/_output.java
+++ b/test/unit-test/member_chain/_output.java
@@ -203,10 +203,32 @@ public class BreakLongFunctionCall {
     dtoEntities.stream().map(UserDto::toString).forEach(LOGGER::info);
   }
 
-  void fieldAccessArgumentComment() {
+  void argumentComment() {
     a(
       // comment
       b.c
+    );
+
+    a(
+      // comment
+      b.c[0]
+    );
+
+    a(
+      // comment
+      b.c()
+    );
+
+    a(
+      b.c // comment
+    );
+
+    a(
+      b.c[0] // comment
+    );
+
+    a(
+      b.c() // comment
     );
   }
 }


### PR DESCRIPTION
## What changed with this PR:

Member chains with trailing comments no longer break.

## Example

### Input

```java
a(
  b.c // comment
);
```

### Output

```java
a(
  b.c // comment
);
```

## Relative issues or prs:

Closes #887