### PR TITLE
fix: prevent argument list comments from moving to next argument

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,6 +1,13 @@
 import { util, type AstPath, type Doc } from "prettier";
 import { builders } from "prettier/doc";
-import { SyntaxType, type CommentNode, type SyntaxNode } from "./node-types.ts";
+import {
+  SyntaxType,
+  type ArrayAccessNode,
+  type CommentNode,
+  type FieldAccessNode,
+  type MethodInvocationNode,
+  type SyntaxNode
+} from "./node-types.ts";
 import parser from "./parser.ts";
 import printer from "./printer.ts";
 import {
@@ -190,18 +197,20 @@ function handleLabeledStatementComments(commentNode: CommentNode) {
 function handleMemberChainComments(commentNode: CommentNode) {
   const { enclosingNode, precedingNode, followingNode } = commentNode;
   if (
+    precedingNode &&
     (enclosingNode?.type === SyntaxType.FieldAccess ||
       (enclosingNode?.type === SyntaxType.MethodInvocation &&
-        precedingNode?.end.row !== commentNode.start.row)) &&
-    (followingNode?.type === SyntaxType.Identifier ||
-      followingNode?.type === SyntaxType.TypeArguments)
+        precedingNode.end.row < commentNode.start.row)) &&
+    precedingNode === enclosingNode.objectNode
   ) {
     util.addLeadingComment(enclosingNode, commentNode);
     return true;
   } else if (
     followingNode &&
     isMember(followingNode) &&
-    precedingNode !== enclosingNode &&
+    (!precedingNode ||
+      (precedingNode !== getMemberObject(followingNode) &&
+        precedingNode.end.row < commentNode.start.row)) &&
     !isPrettierIgnore(commentNode)
   ) {
     util.addDanglingComment(followingNode, commentNode, undefined);
@@ -289,6 +298,14 @@ function isMember(node: SyntaxNode) {
     node.type === SyntaxType.FieldAccess ||
     node.type === SyntaxType.MethodInvocation
   );
+}
+
+function getMemberObject(
+  node: ArrayAccessNode | FieldAccessNode | MethodInvocationNode
+) {
+  return node.type === SyntaxType.ArrayAccess
+    ? node.arrayNode
+    : node.objectNode;
 }
 
 const binaryOperators = new Set([

--- a/test/unit-test/member_chain/_input.java
+++ b/test/unit-test/member_chain/_input.java
@@ -175,5 +175,28 @@ public class BreakLongFunctionCall {
         a(
             b.c() // comment
         );
+
+        a(
+            b, // comment
+            c.d
+        );
+
+        a(
+            b, // comment
+            c.d[0]
+        );
+
+        a(
+            b, // comment
+            c.d()
+        );
+    }
+
+    void prettierIgnore() {
+        a ->
+            // prettier-ignore
+            b
+                .c().d()
+                .e().f();
     }
 }

--- a/test/unit-test/member_chain/_output.java
+++ b/test/unit-test/member_chain/_output.java
@@ -230,5 +230,28 @@ public class BreakLongFunctionCall {
     a(
       b.c() // comment
     );
+
+    a(
+      b, // comment
+      c.d
+    );
+
+    a(
+      b, // comment
+      c.d[0]
+    );
+
+    a(
+      b, // comment
+      c.d()
+    );
+  }
+
+  void prettierIgnore() {
+    a ->
+      // prettier-ignore
+      b
+                .c().d()
+                .e().f();
   }
 }


### PR DESCRIPTION
## What changed with this PR:

Trailing comments on arguments no longer move to be leading comments on the next argument if that argument is a member node. In general, member chain comment attachment is made more solid.

## Example

### Input

```java
a(
  b, // comment
  c()
);
```

### Output

```java
a(
  b, // comment
  c()
);
```
