### PR TITLE
fix: preserve annotations on generic method return types

### DIFF
--- a/src/printers/classes.ts
+++ b/src/printers/classes.ts
@@ -138,6 +138,15 @@ export default {
       declaration.push(group(path.call(print, "type_parametersNode")), " ");
     }
 
+    path.each(child => {
+      if (
+        child.node.type === SyntaxType.Annotation ||
+        child.node.type === SyntaxType.MarkerAnnotation
+      ) {
+        declaration.push(print(child), " ");
+      }
+    }, "children");
+
     declaration.push(path.call(print, "typeNode"));
 
     if (hasChild(path, "dimensionsNode")) {

--- a/test/unit-test/generic_class/_input.java
+++ b/test/unit-test/generic_class/_input.java
@@ -41,4 +41,6 @@ public class Foo<T> {
     public <U extends @NotNull T> void example(U u) {}
 
     public <U extends com.java.Any.@NotNull T> void example(U u) {}
+
+    <T> @Nullable T foo() {}
 }

--- a/test/unit-test/generic_class/_output.java
+++ b/test/unit-test/generic_class/_output.java
@@ -32,4 +32,6 @@ public class Foo<T> {
   public <U extends @NotNull T> void example(U u) {}
 
   public <U extends com.java.Any.@NotNull T> void example(U u) {}
+
+  <T> @Nullable T foo() {}
 }


### PR DESCRIPTION
## What changed with this PR:

Annotations on generic method return types are no longer removed.

## Example

### Input

```java
<T> @Nullable T foo() {}
```

### Output

```java
<T> @Nullable T foo() {}
```

## Relative issues or prs:

Closes #909