### PR TITLE
fix: keep package declaration with annotations before import declarations

### DIFF
--- a/src/printers/packages-and-modules.ts
+++ b/src/printers/packages-and-modules.ts
@@ -20,7 +20,7 @@ export default {
 
     const parts: Doc[] = [];
 
-    if (path.node.namedChildren[0].type === SyntaxType.PackageDeclaration) {
+    if (path.node.namedChildren[0].type !== SyntaxType.ImportDeclaration) {
       parts.push(path.call(print, "namedChildren", 0));
     }
 
@@ -48,7 +48,7 @@ export default {
           ? staticImports
           : imports
         ).push({ doc, names });
-      } else if (child.node.type !== SyntaxType.PackageDeclaration) {
+      } else if (!child.isFirst) {
         otherDeclarations.push(doc);
       }
     }, "namedChildren");

--- a/test/unit-test/package_and_imports/packageWithAnnotationsAndImports/_input.java
+++ b/test/unit-test/package_and_imports/packageWithAnnotationsAndImports/_input.java
@@ -1,0 +1,6 @@
+@A
+@B
+package a;
+
+import a.A;
+import b.B;

--- a/test/unit-test/package_and_imports/packageWithAnnotationsAndImports/_output.java
+++ b/test/unit-test/package_and_imports/packageWithAnnotationsAndImports/_output.java
@@ -1,0 +1,6 @@
+@A
+@B
+package a;
+
+import a.A;
+import b.B;

--- a/test/unit-test/package_and_imports/package_and_imports-spec.ts
+++ b/test/unit-test/package_and_imports/package_and_imports-spec.ts
@@ -14,4 +14,5 @@ describe("prettier-java", () => {
   testSample(path.resolve(__dirname, "./moduleWithNoImports"));
   testSample(path.resolve(__dirname, "./moduleWithOnlyStaticImports"));
   testSample(path.resolve(__dirname, "./moduleWithOnlyNonStaticImports"));
+  testSample(path.resolve(__dirname, "./packageWithAnnotationsAndImports"));
 });


### PR DESCRIPTION
## What changed with this PR:

Package declarations with multiple annotations are no longer moved after import declarations. This was actually caused by a bug with the tree-sitter Java grammar, which thinks the package declaration with multiple annotations is a local variable declaration, but it was easy enough to work around here.

## Example

### Input

```java
@A
@B
package a;

import a.A;
import b.B;
```

### Output

```java
@A
@B
package a;

import a.A;
import b.B;
```

## Relative issues or prs:

Closes #910