### PR TITLE
fix: treat text blocks as complex arguments

### DIFF
--- a/src/printers/expressions.ts
+++ b/src/printers/expressions.ts
@@ -1329,13 +1329,7 @@ function isSimpleCallArgument(node: NamedNode, depth = 2): boolean {
   const isChildSimple = (child: NamedNode) =>
     isSimpleCallArgument(child, depth - 1);
 
-  if (
-    node.type.endsWith("_literal") ||
-    node.type === "true" ||
-    node.type === "false" ||
-    node.type === SyntaxType.Identifier ||
-    node.type === "this"
-  ) {
+  if (isLiteral(node) || isSingleWordType(node)) {
     return true;
   }
 
@@ -1377,6 +1371,30 @@ function isSimpleCallArgument(node: NamedNode, depth = 2): boolean {
   }
 
   return false;
+}
+
+function isLiteral(node: NamedNode) {
+  return (
+    [
+      SyntaxType.True,
+      SyntaxType.False,
+      SyntaxType.NullLiteral,
+      SyntaxType.BinaryIntegerLiteral,
+      SyntaxType.DecimalFloatingPointLiteral,
+      SyntaxType.DecimalIntegerLiteral,
+      SyntaxType.HexFloatingPointLiteral,
+      SyntaxType.HexIntegerLiteral,
+      SyntaxType.OctalIntegerLiteral,
+      SyntaxType.CharacterLiteral
+    ].includes(node.type) ||
+    (node.type === SyntaxType.StringLiteral && node.children[0].value === '"')
+  );
+}
+
+function isSingleWordType(node: NamedNode) {
+  return [SyntaxType.Identifier, SyntaxType.This, SyntaxType.Super].includes(
+    node.type
+  );
 }
 
 function couldExpandArg(arg: NamedNode, lambdaChainRecursion = false) {

--- a/test/unit-test/member_chain/_input.java
+++ b/test/unit-test/member_chain/_input.java
@@ -199,4 +199,15 @@ public class BreakLongFunctionCall {
                 .c().d()
                 .e().f();
     }
+
+    void complexArguments() {
+        "SOME TEXT"
+            .replace("SOME", "OTHER")
+            .replace("TEXT", "OTHER")
+            .replace(
+                "SOME",
+                """
+                FOO"""
+            );
+    }
 }

--- a/test/unit-test/member_chain/_output.java
+++ b/test/unit-test/member_chain/_output.java
@@ -254,4 +254,15 @@ public class BreakLongFunctionCall {
                 .c().d()
                 .e().f();
   }
+
+  void complexArguments() {
+    "SOME TEXT"
+      .replace("SOME", "OTHER")
+      .replace("TEXT", "OTHER")
+      .replace(
+        "SOME",
+        """
+        FOO"""
+      );
+  }
 }


### PR DESCRIPTION
## What changed with this PR:

Text blocks are no longer considered simple method arguments when determining whether to break member chains.

## Example

### Input

```java
"SOME TEXT".replace("SOME", "OTHER").replace("TEXT", "OTHER").replace(
  "SOME",
  """
  FOO"""
);
```

### Output

```java
"SOME TEXT"
  .replace("SOME", "OTHER")
  .replace("TEXT", "OTHER")
  .replace(
    "SOME",
    """
    FOO"""
  );
```

## Relative issues or prs:

Closes #918