### PR TITLE
fix: prevent forced wrapping of annotated enums

### DIFF
--- a/src/printers/classes.ts
+++ b/src/printers/classes.ts
@@ -343,9 +343,9 @@ export default {
   },
 
   enum_declaration(path, print) {
-    const parts = printModifiers(path, print);
+    const modifiers = printModifiers(path, print, "declarationOnly");
+    const parts = ["enum ", path.call(print, "nameNode")];
 
-    parts.push("enum ", path.call(print, "nameNode"));
     if (hasChild(path, "interfacesNode")) {
       const hasBody = path.node.bodyNode.namedChildren.length > 0;
       parts.push(
@@ -355,7 +355,7 @@ export default {
     } else {
       parts.push(" ");
     }
-    return [group(parts), path.call(print, "bodyNode")];
+    return [...modifiers, group(parts), path.call(print, "bodyNode")];
   },
 
   enum_body(path, print, options) {

--- a/test/unit-test/enum/_input.java
+++ b/test/unit-test/enum/_input.java
@@ -170,3 +170,7 @@ enum Aaaaaaaaaa implements Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Fffff
 }
 
 enum Aaaaaaaaaa implements Bbbbbbbbbb, Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg {}
+
+@A
+enum B
+  implements C {}

--- a/test/unit-test/enum/_output.java
+++ b/test/unit-test/enum/_output.java
@@ -203,3 +203,6 @@ enum Aaaaaaaaaa
     Eeeeeeeeee,
     Ffffffffff,
     Gggggggggg {}
+
+@A
+enum B implements C {}


### PR DESCRIPTION
## What changed with this PR:

Enum declarations with annotations no longer forcefully wrap their headers.

## Example

### Input

```java
@A
enum B
  implements C {}
```

### Output

```java
@A
enum B implements C {}
```

## Relative issues or prs:

Closes #919