### PR TITLE
fix: inline single simple type arguments

### DIFF
--- a/src/printers/classes.ts
+++ b/src/printers/classes.ts
@@ -10,13 +10,13 @@ import {
   printBlockStatements,
   printBodyDeclarations,
   printModifiers,
+  printTypeParameters,
   printValue,
   printVariableDeclaration,
   type NamedNodePrinters
 } from "./helpers.ts";
 
-const { group, hardline, indent, indentIfBreak, join, line, softline } =
-  builders;
+const { group, hardline, indent, indentIfBreak, join, line } = builders;
 
 export default {
   class_declaration(path, print) {
@@ -58,14 +58,7 @@ export default {
     ];
   },
 
-  type_parameters(path, print) {
-    return [
-      "<",
-      indent([softline, join([",", line], path.map(print, "namedChildren"))]),
-      softline,
-      ">"
-    ];
-  },
+  type_parameters: printTypeParameters,
 
   superclass(path, print) {
     return ["extends ", path.call(print, "namedChildren", 0)];

--- a/src/printers/helpers.ts
+++ b/src/printers/helpers.ts
@@ -283,6 +283,36 @@ export function printBodyDeclarations(
   }, "namedChildren");
 }
 
+export function printTypeParameters(
+  path: NamedNodePath<SyntaxType.TypeArguments | SyntaxType.TypeParameters>,
+  print: PrintFunction
+) {
+  const parameters = path.node.namedChildren;
+
+  const shouldInline =
+    parameters.length === 0 ||
+    (parameters.length === 1 &&
+      isSimpleType(parameters[0]) &&
+      !parameters.some(
+        ({ comments }) =>
+          comments?.length &&
+          comments.some(({ type }) => type === SyntaxType.LineComment)
+      ));
+
+  if (shouldInline) {
+    return ["<", join(", ", path.map(print, "namedChildren")), ">"];
+  }
+
+  const parts = [
+    "<",
+    indent([softline, join([",", line], path.map(print, "namedChildren"))]),
+    softline,
+    ">"
+  ];
+
+  return path.node.type === SyntaxType.TypeArguments ? group(parts) : parts;
+}
+
 export function printVariableDeclaration(
   path: NamedNodePath<
     | SyntaxType.ConstantDeclaration
@@ -362,6 +392,34 @@ export function textBlockContents(node: NamedNode<SyntaxType.StringLiteral>) {
     .map(line => line.slice(baseIndent))
     .join("\n")
     .slice(0, -3);
+}
+
+function isSimpleType(node: NamedNode): boolean {
+  const { type, children, namedChildren } = node;
+  const lastNamedChild = namedChildren.at(-1);
+
+  return (
+    [
+      SyntaxType.BooleanType,
+      SyntaxType.FloatingPointType,
+      SyntaxType.IntegralType,
+      SyntaxType.TypeIdentifier,
+      SyntaxType.VoidType
+    ].includes(type) ||
+    (type === SyntaxType.AnnotatedType &&
+      lastNamedChild &&
+      isSimpleType(lastNamedChild)) ||
+    (type === SyntaxType.ArrayType && isSimpleType(node.elementNode)) ||
+    (type === SyntaxType.ScopedTypeIdentifier &&
+      lastNamedChild &&
+      isSimpleType(namedChildren[0]) &&
+      isSimpleType(lastNamedChild)) ||
+    (type === SyntaxType.TypeParameter &&
+      (lastNamedChild?.type !== SyntaxType.TypeBound ||
+        lastNamedChild.namedChildren.length === 1)) ||
+    (type === SyntaxType.Wildcard &&
+      (children.at(-1)!.type === "?" || isSimpleType(namedChildren.at(-1)!)))
+  );
 }
 
 function findBaseIndent(lines: string[]) {

--- a/src/printers/types-values-and-variables.ts
+++ b/src/printers/types-values-and-variables.ts
@@ -1,7 +1,11 @@
 import { builders } from "prettier/doc";
-import { printValue, type NamedNodePrinters } from "./helpers.ts";
+import {
+  printTypeParameters,
+  printValue,
+  type NamedNodePrinters
+} from "./helpers.ts";
 
-const { group, indent, join, line, softline } = builders;
+const { group, indent, join, line } = builders;
 
 export default {
   boolean_type: printValue,
@@ -42,18 +46,7 @@ export default {
     return bound;
   },
 
-  type_arguments(path, print) {
-    const types = path.map(print, "namedChildren");
-
-    return types.length
-      ? group([
-          "<",
-          indent([softline, join([",", line], types)]),
-          softline,
-          ">"
-        ])
-      : "<>";
-  },
+  type_arguments: printTypeParameters,
 
   wildcard(path, print) {
     return join(" ", path.map(print, "children"));

--- a/test/unit-test/arrays/_output.java
+++ b/test/unit-test/arrays/_output.java
@@ -2,9 +2,8 @@ class Array {
 
   boolean[] skip = new boolean[candidates.length];
 
-  Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa<
-    Bbbbbbbbbbbbbbbb
-  >[1].getClass();
+  Class<?> aaaaaaaaaaaaaaaa =
+    new Aaaaaaaaaaaaaaaa<Bbbbbbbbbbbbbbbb>[1].getClass();
   Class<?> aaaaaaaaaaaaaaaa =
     new Aaaaaaaaaaaaaaaa[1111111111111111111].getClass();
   Class<?> aaaaaaaaaaaaaaaa = new Aaaaaaaaaaaaaaaa[] {

--- a/test/unit-test/member_chain/_input.java
+++ b/test/unit-test/member_chain/_input.java
@@ -1,213 +1,225 @@
 public class BreakLongFunctionCall {
 
-    public void doSomething() {
-        return new Object().something().more();
-    }
+  public void doSomething() {
+    return new Object().something().more();
+  }
 
-    public void doSomethingNewWithComment() {
-        // comment
-        new Object().something().more();
+  public void doSomethingNewWithComment() {
+    // comment
+    new Object().something().more();
 
-        new Object() // comment
-            .something().more();
+    new Object() // comment
+      .something().more();
 
-        new Object()
-            // comment
-            .something().more();
+    new Object()
+      // comment
+      .something().more();
 
-        new Object().something() // comment
-            .more();
+    new Object().something() // comment
+      .more();
 
-        new Object().something()
-            // comment
-            .more();
+    new Object().something()
+      // comment
+      .more();
 
-        new Object().something().more(); // comment
+    new Object().something().more(); // comment
 
-        new Object().something().more();
-        // comment
-    }
+    new Object().something().more();
+    // comment
+  }
 
-    public void doSomethingWithComment() {
-        Object
-            // comment
-            .something().more();
+  public void doSomethingWithComment() {
+    Object
+      // comment
+      .something().more();
 
-        java.Object
-            // comment
-            .something().more();
+    java.Object
+      // comment
+      .something().more();
 
-        java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
-            // comment
-            .something().more();
+    java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
+      // comment
+      .something().more();
 
-        java
-            // comment
-            .averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
-            .something().more();
+    java
+      // comment
+      .averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
+      .something().more();
 
-        java
-            .averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong
-            // comment
-            .Object
-            .something().more();
+    java
+      .averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong
+      // comment
+      .Object
+      .something().more();
 
-        java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
-            .something().more();
+    java.averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.Object
+      .something().more();
 
-        Object.something()
-            // comment
-            .more();
+    Object.something()
+      // comment
+      .more();
 
-        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
-            // comment
-            .util()
-            .java.java();
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+      // comment
+      .util()
+      .java.java();
 
-        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong
-            // comment
-            .java
-            .util()
-            .java.java();
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong
+      // comment
+      .java
+      .util()
+      .java.java();
 
-        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
-            /* comment */
-            .util()
-            .java.java();
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+      /* comment */
+      .util()
+      .java.java();
 
-        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java/* comment */
-            .util()
-            .java.java();
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java/* comment */
+      .util()
+      .java.java();
 
-        averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
-            /* comment */.util()
-            .java.java();
-    }
+    averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong.java
+      /* comment */.util()
+      .java.java();
+  }
 
-    public void doSomethingWithComment() {
-        object
-            // comment
-            .something().more();
+  public void doSomethingWithComment() {
+    object
+      // comment
+      .something().more();
 
-        object.something()
-            // comment
-            .more();
-    }
+    object.something()
+      // comment
+      .more();
+  }
 
-    public void doSomethingNewWithComment() {
-        return new Object()
-            /* comment */
-            .something().more();
-    }
+  public void doSomethingNewWithComment() {
+    return new Object()
+      /* comment */
+      .something().more();
+  }
 
-    public void doSomethingWithComment() {
-        return Object
-            /* comment */
-            .something().more();
-    }
+  public void doSomethingWithComment() {
+    return Object
+      /* comment */
+      .something().more();
+  }
 
-    public void doSomethingWithComment() {
-        return object
-            /* comment */
-            .something().more();
-    }
+  public void doSomethingWithComment() {
+    return object
+      /* comment */
+      .something().more();
+  }
 
-    public void genericMethodWithLeadingComment() {
-        a
-            // 1
-            .b()
-            // 2
-            .<C>c();
-    }
+  public void genericMethodWithLeadingComment() {
+    a
+      // 1
+      .b()
+      // 2
+      .<C>c();
+  }
 
-    public void doSomethingLongNew() {
-        return something().more().and().that().as().well().but().not().something().something();
-    }
+  public void doSomethingLongNew() {
+    return something().more().and().that().as().well().but().not().something().something();
+  }
 
-    public void doSomethingLongWithArgument() {
-        return something().more(firstArgument, secondArgument).and(firstArgument, secondArgument, thirdArgument, fourthArgument, fifthArgument);
-    }
+  public void doSomethingLongWithArgument() {
+    return something().more(firstArgument, secondArgument).and(firstArgument, secondArgument, thirdArgument, fourthArgument, fifthArgument);
+  }
 
-    public void doSomethingLongNew2() {
-        return new Object().something().more().and().that().as().well().but().not().something();
-    }
+  public void doSomethingLongNew2() {
+    return new Object().something().more().and().that().as().well().but().not().something();
+  }
 
-    public void doSomethingLongStatic() {
-        return Object.something().more().and().that().as().well().but().not().something();
-    }
+  public void doSomethingLongStatic() {
+    return Object.something().more().and().that().as().well().but().not().something();
+  }
 
-    public void singleInvocationOnNewExpression() {
-        new Instance(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).invocation(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
-    }
+  public void singleInvocationOnNewExpression() {
+    new Instance(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).invocation(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
+  }
 
-    public void multipleInvocationsOnNewExpression() {
-        new Instance(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).invocation(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).andAnother();
-    }
+  public void multipleInvocationsOnNewExpression() {
+    new Instance(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).invocation(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).andAnother();
+  }
 
-    void methodReferences() {
-        dtoEntities.stream().map(UserDto::toString).forEach(LOGGER::info);
-    }
+  void methodReferences() {
+    dtoEntities.stream().map(UserDto::toString).forEach(LOGGER::info);
+  }
 
-    void argumentComment() {
-        a(
-            // comment
-            b.c
-        );
+  void argumentComment() {
+    a(
+      // comment
+      b.c
+    );
 
-        a(
-            // comment
-            b.c[0]
-        );
+    a(
+      // comment
+      b.c[0]
+    );
 
-        a(
-            // comment
-            b.c()
-        );
+    a(
+      // comment
+      b.c()
+    );
 
-        a(
-            b.c // comment
-        );
+    a(
+      b.c // comment
+    );
 
-        a(
-            b.c[0] // comment
-        );
+    a(
+      b.c[0] // comment
+    );
 
-        a(
-            b.c() // comment
-        );
+    a(
+      b.c() // comment
+    );
 
-        a(
-            b, // comment
-            c.d
-        );
+    a(
+      b, // comment
+      c.d
+    );
 
-        a(
-            b, // comment
-            c.d[0]
-        );
+    a(
+      b, // comment
+      c.d[0]
+    );
 
-        a(
-            b, // comment
-            c.d()
-        );
-    }
+    a(
+      b, // comment
+      c.d()
+    );
+  }
 
-    void prettierIgnore() {
-        a ->
-            // prettier-ignore
-            b
-                .c().d()
-                .e().f();
-    }
+  void prettierIgnore() {
+    a ->
+      // prettier-ignore
+      b
+        .c().d()
+        .e().f();
+  }
 
-    void complexArguments() {
-        "SOME TEXT"
-            .replace("SOME", "OTHER")
-            .replace("TEXT", "OTHER")
-            .replace(
-                "SOME",
-                """
-                FOO"""
-            );
-    }
+  void complexArguments() {
+    "SOME TEXT"
+      .replace("SOME", "OTHER")
+      .replace("TEXT", "OTHER")
+      .replace(
+        "SOME",
+        """
+        FOO"""
+      );
+  }
+
+  void typeArguments() {
+    a().b().<Cccccccccc>dddddddddd("eeeeeeeeee", "ffffffffff", "gggggggggg", "hhhhhhhhhh");
+
+    a().b().<Cccccccccccccccccccccccccccccccccccccccc>dddddddddddddddddddddddddddddddddddddddd("eeeeeeeeee");
+
+    a().b().<Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg>hhhhhhhhhh("iiiiiiiiii");
+
+    a().b().<Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg, Hhhhhhhhhh>iiiiiiiiii("jjjjjjjjjj");
+
+    a().b().<Cccccccccc, Dddddddddd, Eeeeeeeeee, Ffffffffff, Gggggggggg, Hhhhhhhhhh>iiiiiiiiii("jjjjjjjjjj", "kkkkkkkkkk", "llllllllll", "mmmmmmmmmm", "nnnnnnnnnn");
+  }
 }

--- a/test/unit-test/member_chain/_output.java
+++ b/test/unit-test/member_chain/_output.java
@@ -251,8 +251,8 @@ public class BreakLongFunctionCall {
     a ->
       // prettier-ignore
       b
-                .c().d()
-                .e().f();
+        .c().d()
+        .e().f();
   }
 
   void complexArguments() {
@@ -264,5 +264,54 @@ public class BreakLongFunctionCall {
         """
         FOO"""
       );
+  }
+
+  void typeArguments() {
+    a()
+      .b()
+      .<Cccccccccc>dddddddddd(
+        "eeeeeeeeee",
+        "ffffffffff",
+        "gggggggggg",
+        "hhhhhhhhhh"
+      );
+
+    a()
+      .b()
+      .<Cccccccccccccccccccccccccccccccccccccccc>dddddddddddddddddddddddddddddddddddddddd(
+        "eeeeeeeeee"
+      );
+
+    a()
+      .b()
+      .<
+        Cccccccccc,
+        Dddddddddd,
+        Eeeeeeeeee,
+        Ffffffffff,
+        Gggggggggg
+      >hhhhhhhhhh("iiiiiiiiii");
+
+    a()
+      .b()
+      .<
+        Cccccccccc,
+        Dddddddddd,
+        Eeeeeeeeee,
+        Ffffffffff,
+        Gggggggggg,
+        Hhhhhhhhhh
+      >iiiiiiiiii("jjjjjjjjjj");
+
+    a()
+      .b()
+      .<
+        Cccccccccc,
+        Dddddddddd,
+        Eeeeeeeeee,
+        Ffffffffff,
+        Gggggggggg,
+        Hhhhhhhhhh
+      >iiiiiiiiii("jjjjjjjjjj", "kkkkkkkkkk", "llllllllll", "mmmmmmmmmm", "nnnnnnnnnn");
   }
 }

--- a/test/unit-test/snippets/types-values-and-variables/wildcard/test.spec.ts
+++ b/test/unit-test/snippets/types-values-and-variables/wildcard/test.spec.ts
@@ -19,7 +19,7 @@ describe("Wildcard", () => {
     const snippet =
       "List<@Annotation1 @Annotation2 @Annotation3 @Annotation4 @Annotation5 @Annotation6 @Annotation7 ?>l;";
     const expectedOutput =
-      "List<\n  @Annotation1 @Annotation2 @Annotation3 @Annotation4 @Annotation5 @Annotation6 @Annotation7 ?\n> l;\n";
+      "List<@Annotation1 @Annotation2 @Annotation3 @Annotation4 @Annotation5 @Annotation6 @Annotation7 ?> l;\n";
 
     await expectSnippetToBeFormatted({
       snippet,

--- a/test/unit-test/variables/_output.java
+++ b/test/unit-test/variables/_output.java
@@ -268,9 +268,7 @@ public class Variables {
       & ExtremelyLongAndObnoxiousInterfaceName
       & ExtremelyLongAndObnoxiousInterfaceName
   > void breakOnTypeArguments(
-    ExtremelyLongAndObnoxiousClassName<
-      ExtremelyLongAndObnoxiousClassName
-    > parameter,
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName> parameter,
     ExtremelyLongAndObnoxiousClassName<
       ExtremelyLongAndObnoxiousClassName<
         ExtremelyLongAndObnoxiousClassName,
@@ -279,9 +277,7 @@ public class Variables {
       ExtremelyLongAndObnoxiousClassName
     > parameter
   ) {
-    ExtremelyLongAndObnoxiousClassName<
-      ExtremelyLongAndObnoxiousClassName
-    > variable;
+    ExtremelyLongAndObnoxiousClassName<ExtremelyLongAndObnoxiousClassName> variable;
 
     ExtremelyLongAndObnoxiousClassName<
       ExtremelyLongAndObnoxiousClassName<


### PR DESCRIPTION
## What changed with this PR:

Type arguments/parameters that are singular and simple are no longer allowed to break.

## Example

### Input

```java
a()
  .b()
  .<
    Cccccccccc
  >dddddddddd("eeeeeeeeee", "ffffffffff", "gggggggggg", "hhhhhhhhhh");

a()
  .b()
  .<
    Cccccccccccccccccccccccccccccccccccccccc
  >dddddddddddddddddddddddddddddddddddddddd("eeeeeeeeee");
```

### Output

```java
a()
  .b()
  .<Cccccccccc>dddddddddd(
    "eeeeeeeeee",
    "ffffffffff",
    "gggggggggg",
    "hhhhhhhhhh"
  );

a()
  .b()
  .<Cccccccccccccccccccccccccccccccccccccccc>dddddddddddddddddddddddddddddddddddddddd(
    "eeeeeeeeee"
  );
```

## Relative issues or prs:

Closes #920