### PR TITLE
fix: omit parentheses around lambda body assignment expressions

### DIFF
--- a/src/printers/helpers.ts
+++ b/src/printers/helpers.ts
@@ -680,7 +680,11 @@ export function needsParentheses(path: NamedNodePath) {
         return false;
       }
 
-      if (parent?.type === SyntaxType.AssignmentExpression) {
+      if (
+        parent?.type === SyntaxType.AssignmentExpression ||
+        (parent?.type === SyntaxType.LambdaExpression &&
+          parent.bodyNode === node)
+      ) {
         return false;
       }
 

--- a/test/unit-test/lambda/arrow-parens-always/_input.java
+++ b/test/unit-test/lambda/arrow-parens-always/_input.java
@@ -337,6 +337,10 @@ public class Lambda {
     void lambdaInParentheses() {
         (aaaaaaaaaa -> bbbbbbbbbb.cccccccccc().dddddddddd().eeeeeeeeee().ffffffffff());
     }
+
+    void lambdaWithAssignmentBody() {
+        a -> b = c;
+    }
 }
 
 class T {

--- a/test/unit-test/lambda/arrow-parens-always/_output.java
+++ b/test/unit-test/lambda/arrow-parens-always/_output.java
@@ -571,6 +571,10 @@ public class Lambda {
     (aaaaaaaaaa) ->
       bbbbbbbbbb.cccccccccc().dddddddddd().eeeeeeeeee().ffffffffff();
   }
+
+  void lambdaWithAssignmentBody() {
+    (a) -> b = c;
+  }
 }
 
 class T {

--- a/test/unit-test/lambda/arrow-parens-avoid/_input.java
+++ b/test/unit-test/lambda/arrow-parens-avoid/_input.java
@@ -337,6 +337,10 @@ public class Lambda {
     void lambdaInParentheses() {
         (aaaaaaaaaa -> bbbbbbbbbb.cccccccccc().dddddddddd().eeeeeeeeee().ffffffffff());
     }
+
+    void lambdaWithAssignmentBody() {
+        a -> b = c;
+    }
 }
 
 class T {

--- a/test/unit-test/lambda/arrow-parens-avoid/_output.java
+++ b/test/unit-test/lambda/arrow-parens-avoid/_output.java
@@ -571,6 +571,10 @@ public class Lambda {
     aaaaaaaaaa ->
       bbbbbbbbbb.cccccccccc().dddddddddd().eeeeeeeeee().ffffffffff();
   }
+
+  void lambdaWithAssignmentBody() {
+    a -> b = c;
+  }
 }
 
 class T {


### PR DESCRIPTION
## What changed with this PR:

Lambda expression bodies that are assignment expressions are no longer wrapped in parentheses. Apparently doing so can cause the Java compiler to consider the lambda as strictly having a return value (so the lambda can no longer be used as a `Consumer`, for example), even though assignments always evaluate to a value, and without parentheses they can be used as the body of lambdas with or without a return value. This resolves the issue described in https://github.com/jhipster/prettier-java/issues/921#issuecomment-4776432807.

## Example

### Input

```java
(a) -> (b = c);
```

### Output

```java
(a) -> b = c;
```
