### PR TITLE
fix: prevent dropping children of parenthesized expressions

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -100,14 +100,14 @@ function processTree(
     Object.keys(multiFields).forEach(name => (javaNode[`${name}Nodes`] = []));
   }
 
-  node.children
-    .flatMap(child =>
+  node.children.forEach((child, index) => {
+    const fieldName = node.fieldNameForChild(index);
+    const children =
       child.type === SyntaxType.ParenthesizedExpression &&
       !isParenthesizedParent(javaNode)
         ? child.namedChildren
-        : [child]
-    )
-    .forEach((child, index) => {
+        : [child];
+    children.forEach(child => {
       const { type, text: value, startPosition, endPosition } = child;
       if (type === SyntaxType.BlockComment || type === SyntaxType.LineComment) {
         comments.push({
@@ -128,7 +128,6 @@ function processTree(
           printed: false
         });
       } else {
-        const fieldName = node.fieldNameForChild(index);
         const javaChild = processTree(child, fieldName, comments);
 
         javaNode.children.push(javaChild);
@@ -145,6 +144,7 @@ function processTree(
         }
       }
     });
+  });
 
   return javaNode;
 }

--- a/test/unit-test/comments/expression/_input.java
+++ b/test/unit-test/comments/expression/_input.java
@@ -7,5 +7,9 @@ class Example {
     a +
       // comment
       (b);
+
+    a = (//
+      b
+    );
   }
 }

--- a/test/unit-test/comments/expression/_output.java
+++ b/test/unit-test/comments/expression/_output.java
@@ -7,5 +7,8 @@ class Example {
     a +
       // comment
       b;
+
+    a = //
+      b;
   }
 }


### PR DESCRIPTION
## What changed with this PR:

Children of parenthesized expressions which are children of nodes with named fields are no longer lost.

Because of the way the parser was recently updated to omit parenthesized expressions, index alignment could easily be broken, and the index of child nodes was used to determine their field name.

## Example

### Input

```java
a = (//
  b
);
```

### Output

```java
a = //
  b;
```

## Relative issues or prs:
Closes #949