### PR TITLE
fix: update Java grammar to fix parsing of lambda switch rule results and keyword statement labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mitata": "^1.0.34",
     "mocha": "^11.7.5",
     "prettier": "^3.8.1",
-    "tree-sitter-java-orchard": "0.5.6",
+    "tree-sitter-java-orchard": "0.5.8",
     "tsdown": "^0.22.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.57.1"

--- a/test/unit-test/expressions/_input.java
+++ b/test/unit-test/expressions/_input.java
@@ -97,6 +97,10 @@ public class Expressions {
     }
   }
 
+  void labeledStatement() {
+    record: if (true) {}
+  }
+
   public void printSwitch() {
     switch(myValue == 42 || myValue == 42 && myValue == 42 && myValue == 42 || myValue == 42 && myValue == 42) {
 

--- a/test/unit-test/expressions/_output.java
+++ b/test/unit-test/expressions/_output.java
@@ -107,6 +107,11 @@ public class Expressions {
     }
   }
 
+  void labeledStatement() {
+    record: if (true) {
+    }
+  }
+
   public void printSwitch() {
     switch (
       myValue == 42 ||

--- a/test/unit-test/lambda/arrow-parens-always/_input.java
+++ b/test/unit-test/lambda/arrow-parens-always/_input.java
@@ -341,6 +341,15 @@ public class Lambda {
     void lambdaWithAssignmentBody() {
         a -> b = c;
     }
+
+    void switchRulesWithLambdaResults() {
+        Function<Integer, Integer> f = switch (o) {
+            case false -> a -> a + 1;
+            case B -> a -> a + 2;
+            case Boolean b when b -> a -> a + 3;
+            default -> c -> c + 4;
+        };
+    }
 }
 
 class T {

--- a/test/unit-test/lambda/arrow-parens-always/_output.java
+++ b/test/unit-test/lambda/arrow-parens-always/_output.java
@@ -575,6 +575,15 @@ public class Lambda {
   void lambdaWithAssignmentBody() {
     (a) -> b = c;
   }
+
+  void switchRulesWithLambdaResults() {
+    Function<Integer, Integer> f = switch (o) {
+      case false -> (a) -> a + 1;
+      case B -> (a) -> a + 2;
+      case Boolean b when b -> (a) -> a + 3;
+      default -> (c) -> c + 4;
+    };
+  }
 }
 
 class T {

--- a/test/unit-test/lambda/arrow-parens-avoid/_input.java
+++ b/test/unit-test/lambda/arrow-parens-avoid/_input.java
@@ -341,6 +341,15 @@ public class Lambda {
     void lambdaWithAssignmentBody() {
         a -> b = c;
     }
+
+    void switchRulesWithLambdaResults() {
+        Function<Integer, Integer> f = switch (o) {
+            case false -> a -> a + 1;
+            case B -> a -> a + 2;
+            case Boolean b when b -> a -> a + 3;
+            default -> c -> c + 4;
+        };
+    }
 }
 
 class T {

--- a/test/unit-test/lambda/arrow-parens-avoid/_output.java
+++ b/test/unit-test/lambda/arrow-parens-avoid/_output.java
@@ -575,6 +575,15 @@ public class Lambda {
   void lambdaWithAssignmentBody() {
     a -> b = c;
   }
+
+  void switchRulesWithLambdaResults() {
+    Function<Integer, Integer> f = switch (o) {
+      case false -> a -> a + 1;
+      case B -> a -> a + 2;
+      case Boolean b when b -> a -> a + 3;
+      default -> c -> c + 4;
+    };
+  }
 }
 
 class T {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4751,10 +4751,10 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-tree-sitter-java-orchard@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/tree-sitter-java-orchard/-/tree-sitter-java-orchard-0.5.6.tgz#9bcac73eee928ef8fbf4c2c8c57de2d0627711b3"
-  integrity sha512-nn6D9bE73ltYTtLudi3fxJ4/lFQCcRyXb9qaVRGOcv5Xi+y0xQNZ/z4PJaVki+KqaiIcR70tViZztLhnSvouYA==
+tree-sitter-java-orchard@0.5.8:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/tree-sitter-java-orchard/-/tree-sitter-java-orchard-0.5.8.tgz#c3e2f02ce4c1aabe2fa66cd21c91ffc0620b7b56"
+  integrity sha512-vT7d1MbTL2ceVkfqZZRr0AVfNC2b2Vl/bReql4kJ4cMfbT3K/RS4FlK05bjaW/Q6gAa7FEHFP9HODIQDLXr1Zg==
   dependencies:
     node-addon-api "^8.3.1"
     node-gyp-build "^4.8.4"


### PR DESCRIPTION
## What changed with this PR:

The tree-sitter-java-orchard package is updated to inherit fixes to its grammar related to parsing switch rules with lambda results and statement labels that are contextual keywords.

## Example

### Input

```java
void switchRulesWithLambdaResults() {
  Function<Integer, Integer> f = switch (o) {
    case false -> a -> a + 1;
    case B -> a -> a + 2;
    case Boolean b when b -> a -> a + 3;
    default -> c -> c + 4;
  };
}

void labeledStatement() {
  record: if (true) {}
}
```

### Output

```java
void switchRulesWithLambdaResults() {
  Function<Integer, Integer> f = switch (o) {
    case false -> (a) -> a + 1;
    case B -> (a) -> a + 2;
    case Boolean b when b -> (a) -> a + 3;
    default -> (c) -> c + 4;
  };
}

void labeledStatement() {
  record: if (true) {
  }
}
```

## Relative issues or prs:
Closes #946
Closes #950