### PR TITLE
fix: treat class literals as simple arguments, like field access

### DIFF
--- a/src/printers/expressions.ts
+++ b/src/printers/expressions.ts
@@ -1356,7 +1356,11 @@ function isSimpleCallArgument(node: NamedNode, depth = 2): boolean {
   const isChildSimple = (child: NamedNode) =>
     isSimpleCallArgument(child, depth - 1);
 
-  if (isLiteral(node) || isSingleWordType(node)) {
+  if (
+    isLiteral(node) ||
+    isSingleWordType(node) ||
+    node.type === SyntaxType.ClassLiteral
+  ) {
     return true;
   }
 
@@ -1389,9 +1393,12 @@ function isSimpleCallArgument(node: NamedNode, depth = 2): boolean {
     );
   }
 
+  if (node.type === SyntaxType.UnaryExpression) {
+    return isSimpleCallArgument(node.operandNode, depth);
+  }
+
   if (
     node.type === SyntaxType.MethodReference ||
-    node.type === SyntaxType.UnaryExpression ||
     node.type === SyntaxType.UpdateExpression
   ) {
     return isSimpleCallArgument(node.namedChildren[0], depth);

--- a/test/unit-test/member_chain/_input.java
+++ b/test/unit-test/member_chain/_input.java
@@ -148,6 +148,12 @@ public class BreakLongFunctionCall {
     dtoEntities.stream().map(UserDto::toString).forEach(LOGGER::info);
   }
 
+  void classLiteralArgument() {
+    a()
+      .b(C.class)
+      .d();
+  }
+
   void argumentComment() {
     a(
       // comment

--- a/test/unit-test/member_chain/_output.java
+++ b/test/unit-test/member_chain/_output.java
@@ -203,6 +203,10 @@ public class BreakLongFunctionCall {
     dtoEntities.stream().map(UserDto::toString).forEach(LOGGER::info);
   }
 
+  void classLiteralArgument() {
+    a().b(C.class).d();
+  }
+
   void argumentComment() {
     a(
       // comment


### PR DESCRIPTION
## What changed with this PR:

Class literals are now treated as simple arguments when deciding whether to break member chains, just like field access expressions (which are visually very similar).

## Example

### Input

```java
a()
  .b(C.class)
  .d();
```

### Output

```java
a().b(C.class).d();
```

## Relative issues or prs:

Closes #956