### PR TITLE
fix: omit indentation from text block assignments

### DIFF
--- a/src/printers/helpers.ts
+++ b/src/printers/helpers.ts
@@ -403,20 +403,8 @@ export function printAssignment(
   ]);
 }
 
-export function printTextBlock(
-  path: NamedNodePath<SyntaxType.StringLiteral>,
-  contents: Doc
-) {
-  const parts = ['"""', hardline, contents, '"""'];
-  const parentType = (path.parent as NamedNode | null)?.type;
-  const grandparentType = (path.grandparent as NamedNode | null)?.type;
-  return parentType === SyntaxType.AssignmentExpression ||
-    parentType === SyntaxType.VariableDeclarator ||
-    (path.node.fieldName === "object" &&
-      (grandparentType === SyntaxType.AssignmentExpression ||
-        grandparentType === SyntaxType.VariableDeclarator))
-    ? indent(parts)
-    : parts;
+export function printTextBlock(contents: Doc) {
+  return ['"""', hardline, contents, '"""'];
 }
 
 export function embedTextBlock(path: NamedNodePath<SyntaxType.StringLiteral>) {
@@ -438,7 +426,7 @@ export function embedTextBlock(path: NamedNodePath<SyntaxType.StringLiteral>) {
     textToDoc: (text: string, options: Options) => Promise<Doc>
   ) => {
     const doc = await textToDoc(text, { parser: language });
-    return printTextBlock(path, [escapeDocForTextBlock(doc), hardline]);
+    return printTextBlock([escapeDocForTextBlock(doc), hardline]);
   };
 }
 

--- a/src/printers/lexical-structure.ts
+++ b/src/printers/lexical-structure.ts
@@ -19,7 +19,6 @@ export default {
     }
 
     return printTextBlock(
-      path,
       join(hardline, textBlockContents(path.node).split("\n"))
     );
   },

--- a/test/unit-test/text-blocks/_output.java
+++ b/test/unit-test/text-blocks/_output.java
@@ -2,34 +2,34 @@ public class TextBlock {
 
   void method() {
     String myTextBlock = """
-           my text
+         my text
 
 
-      sentence\"""
+    sentence\"""
 
-      """;
+    """;
 
     String source = """
-      public void print(%s object) {
-          System.out.println(Objects.toString(object));
-      }
-      """.formatted(type);
+    public void print(%s object) {
+        System.out.println(Objects.toString(object));
+    }
+    """.formatted(type);
 
     String html = """
-      <html>\r
-          <body>\r
-              <p>Hello, world</p>\r
-          </body>\r
-      </html>\r
-      """;
+    <html>\r
+        <body>\r
+            <p>Hello, world</p>\r
+        </body>\r
+    </html>\r
+    """;
 
     html = """
-      <html>\r
-          <body>\r
-              <p>Hello, world</p>\r
-          </body>\r
-      </html>\r
-      """;
+    <html>\r
+        <body>\r
+            <p>Hello, world</p>\r
+        </body>\r
+    </html>\r
+    """;
 
     System.out.println(
       // leading comment
@@ -54,83 +54,83 @@ public class TextBlock {
   }
 
   String escapes = """
-    1+1 equals \
-    2 maybe
-    """;
+  1+1 equals \
+  2 maybe
+  """;
 
   String escapes = """
-    \"""var msg = hello world!\""";
-    """;
+  \"""var msg = hello world!\""";
+  """;
 
   String escapes = """
-    \n\t\r\f\b\s\\
-    \077
-    \u0041""";
+  \n\t\r\f\b\s\\
+  \077
+  \u0041""";
 
   void json() {
     // language = json
     String someJson = """
-      { "glossary": { "title": "example 'glossary'" } }
-      """;
+    { "glossary": { "title": "example 'glossary'" } }
+    """;
 
     // language=json
     String config = """
-      { "name": "example", "enabled": true, "timeout": 30 }
-      """;
+    { "name": "example", "enabled": true, "timeout": 30 }
+    """;
 
     /* language = JSON */
     String query = """
-      {
-        "sql": "SELECT * FROM users WHERE active=1 AND deleted=0",
-        "limit": 10
-      }
-      """;
+    {
+      "sql": "SELECT * FROM users WHERE active=1 AND deleted=0",
+      "limit": 10
+    }
+    """;
   }
 
   void java() {
     // language=Java
     String java = """
-      class Class {
+    class Class {
 
-        void method() {
-          // comment
-        }
+      void method() {
+        // comment
       }
-      """;
+    }
+    """;
   }
 
   void html() {
     // language=html
     String html = """
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>Page Title</title>
-        </head>
-        <body>
-          <h1>My First Heading</h1>
-          <p>My first paragraph.</p>
-        </body>
-      </html>
-      """;
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Page Title</title>
+      </head>
+      <body>
+        <h1>My First Heading</h1>
+        <p>My first paragraph.</p>
+      </body>
+    </html>
+    """;
   }
 
   void typescript() {
     // language=typescript
     String typescript = """
-      const s = `""\"`;
-      """;
+    const s = `""\"`;
+    """;
 
     // language=typescript
     String typescript = """
-      const s = ""; // "
-      """;
+    const s = ""; // "
+    """;
   }
 
   void unsupported() {
     // language=unsupported
     String unsupported = """
-      function f(){let i=0;}
-      """;
+    function f(){let i=0;}
+    """;
   }
 }


### PR DESCRIPTION
## What changed with this PR:

Text blocks are no longer indented when used as the value of an assignment expression. Prettier JS/TS doesn't have an equivalent to Java text blocks, where we can choose a level of indentation but cannot change the difference in indentation between the closing `"""` and the least-indented line. I've decided to align their formatting with that of method invocations or other parenthesized expressions, except that the contents can't have their indentation changed WRT the closing `"""` (or else the multiline string will be altered). I'm not absolutely sold on this way of formatting them, but I think it's a bit better than what is currently in main.

## Example

### Input

```java
String source = """
  public void print(%s object) {
      System.out.println(Objects.toString(object));
  }
  """.formatted(
  aaaaaaaaaa,
  bbbbbbbbbb,
  cccccccccc,
  dddddddddd,
  eeeeeeeeee,
  ffffffffff
);
```

### Output

```java
String source = """
public void print(%s object) {
    System.out.println(Objects.toString(object));
}
""".formatted(
  aaaaaaaaaa,
  bbbbbbbbbb,
  cccccccccc,
  dddddddddd,
  eeeeeeeeee,
  ffffffffff
);
```

## Relative issues or prs:

Closes #977