### PR TITLE
fix: update tree-sitter-java-orchard to 0.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "postcss": "^8.5.15",
     "prettier": "^3.8.1",
     "prettier-plugin-css-order": "^2.2.0",
-    "tree-sitter-java-orchard": "0.5.8",
+    "tree-sitter-java-orchard": "0.5.10",
     "tsdown": "^0.22.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.57.1"

--- a/test/unit-test/cast/_input.java
+++ b/test/unit-test/cast/_input.java
@@ -26,4 +26,9 @@ public class Cast {
         Object o5 = (A & B) + x;
         Object o6 = (A & B) - x;
     }
+
+    void castUpdateExpression() {
+        int a = (int) x++;
+        int b = (int) (x)--;
+    }
 }

--- a/test/unit-test/cast/_output.java
+++ b/test/unit-test/cast/_output.java
@@ -69,4 +69,9 @@ public class Cast {
     Object o5 = (A & B) + x;
     Object o6 = (A & B) - x;
   }
+
+  void castUpdateExpression() {
+    int a = (int) x++;
+    int b = (int) x--;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,10 +3477,10 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-addon-api@^8.3.1:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.6.0.tgz#b22497201b465cd0a92ef2c01074ee5068c79a6d"
-  integrity sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==
+node-addon-api@^8.5.0:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.9.0.tgz#d2467090e6195c428ccd510dfd604f01c027f0a0"
+  integrity sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==
 
 node-gyp-build@^4.8.4:
   version "4.8.4"
@@ -4808,12 +4808,12 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-tree-sitter-java-orchard@0.5.8:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/tree-sitter-java-orchard/-/tree-sitter-java-orchard-0.5.8.tgz#c3e2f02ce4c1aabe2fa66cd21c91ffc0620b7b56"
-  integrity sha512-vT7d1MbTL2ceVkfqZZRr0AVfNC2b2Vl/bReql4kJ4cMfbT3K/RS4FlK05bjaW/Q6gAa7FEHFP9HODIQDLXr1Zg==
+tree-sitter-java-orchard@0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/tree-sitter-java-orchard/-/tree-sitter-java-orchard-0.5.10.tgz#711e61a2fe2851075b4331c92df0748ad87c35f7"
+  integrity sha512-nEHVdVjyvd1m8Qk10oLVYpMQmhl6lJlfRogdAr8jMuv1Cr6uk0LcL3szitNXy3VOyMEd1cBiMv4tm+UK+yeZhg==
   dependencies:
-    node-addon-api "^8.3.1"
+    node-addon-api "^8.5.0"
     node-gyp-build "^4.8.4"
 
 treeverse@^3.0.0:


### PR DESCRIPTION
## What changed with this PR:

The tree-sitter-java-orchard grammar is updated to 0.5.10, which fixes a precedence issue between cast expression and update expression.

## Example

### Input

```java
int a = (int) x++;
int b = (int) (x)--;
```

### Output

```java
int a = (int) x++;
int b = (int) x--;
```

## Relative issues or prs:

Closes #987