### PR TITLE
docs: downgrade @codemirror/view and type check website in pages CI

### DIFF
--- a/.github/workflows/github-pages-test.yml
+++ b/.github/workflows/github-pages-test.yml
@@ -31,5 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Type check website
+        run: yarn typecheck
       - name: Test build website
         run: yarn build

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
     "@codemirror/language": "6.12.4",
     "@codemirror/search": "6.7.1",
     "@codemirror/state": "6.7.1",
-    "@codemirror/view": "6.43.6",
+    "@codemirror/view": "6.43.5",
     "@docusaurus/core": "3.10.2",
     "@docusaurus/preset-classic": "3.10.2",
     "@mdx-js/react": "3.1.1",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1158,17 +1158,7 @@
   dependencies:
     "@marijn/find-cluster-break" "^1.0.0"
 
-"@codemirror/view@6.43.6":
-  version "6.43.6"
-  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.43.6.tgz#81e4eeb2855e7cb6c62305fba8df319b5476280c"
-  integrity sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==
-  dependencies:
-    "@codemirror/state" "^6.7.0"
-    crelt "^1.0.6"
-    style-mod "^4.1.0"
-    w3c-keyname "^2.2.4"
-
-"@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.37.0", "@codemirror/view@^6.39.15":
+"@codemirror/view@6.43.5", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.37.0", "@codemirror/view@^6.39.15":
   version "6.43.5"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.43.5.tgz#796ea80b24c9d3581fb4a82808cfb02e0138804e"
   integrity sha512-7uT/vUgH6dfXWn3WqOe23KneILMvGy5wQjNMEcRXLKzziJ9NOktpW6tGoyQpwVkBgE5Gj6hKkCcsddbnkaWrOQ==


### PR DESCRIPTION
## What changed with this PR:

For some reason, the latest version of `@codemirror/view` seems to be incompatible with the latest version of `@codemirror/commands`, causing a type check failure which also caused the editors on the website to be missing syntax highlighting, auto completion, and other features. This PR downgrades the version of `@codemirror/view` back to the previous version, and introduces type checking for the website into its CI, to hopefully catch issues like this in the future before they are merged.