### PR TITLE
fix(printer): don't wrap broken when-guards in parentheses

### DIFF
--- a/src/printers/expressions.ts
+++ b/src/printers/expressions.ts
@@ -705,15 +705,12 @@ export default {
   },
 
   guard(path, print) {
-    return [
-      "when ",
-      group([
-        ifBreak("("),
-        indent([softline, path.call(print, "namedChildren", 0)]),
-        softline,
-        ifBreak(")")
-      ])
-    ];
+    // Break after `when` without wrapping the guard expression in parentheses
+    // (issue #1001). A space is used when the group fits on one line.
+    return group([
+      "when",
+      indent([line, path.call(print, "namedChildren", 0)])
+    ]);
   }
 } satisfies Partial<NamedNodePrinters>;
 

--- a/test/unit-test/expressions/_output.java
+++ b/test/unit-test/expressions/_output.java
@@ -292,9 +292,8 @@ public class Expressions {
     )[ffffffffff];
 
     switch (a) {
-      case Bbbbbbbbbb bbbbbbbbbb when (
-        cccccccccc && dddddddddd && eeeeeeeeee
-      ) -> ffffffffff;
+      case Bbbbbbbbbb bbbbbbbbbb when
+        cccccccccc && dddddddddd && eeeeeeeeee -> ffffffffff;
     }
 
     return (

--- a/test/unit-test/pattern-matching/_output.java
+++ b/test/unit-test/pattern-matching/_output.java
@@ -33,32 +33,27 @@ class T {
       case Buyer b when this.bestPrice > b.bestPrice -> {
         return true;
       }
-      case Buyer titi when (
-        this.bestPriceaaaaaaaazzzzzaaaaaaaaaq > b.bestPrice
-      ) -> true;
-      case Buyer titi when (
-        this.bestPriceaaaaaazzzaaaaaaaaaq > b.bestPrice
-      ) -> true;
-      case Buyer b when (
+      case Buyer titi when
+        this.bestPriceaaaaaaaazzzzzaaaaaaaaaq > b.bestPrice -> true;
+      case Buyer titi when
+        this.bestPriceaaaaaazzzaaaaaaaaaq > b.bestPrice -> true;
+      case Buyer b when
         this.bestPrice > b.bestPrice &&
         this.bestPrice > b.bestPrice &&
         this.bestPrice > b.bestPrice &&
-        this.bestPrice > b.bestPrice
-      ) -> true;
-      case Buyer b when (
+        this.bestPrice > b.bestPrice -> true;
+      case Buyer b when
         this.bestPrice > b.bestPrice &&
         this.bestPrice > b.bestPrice &&
         this.bestPrice > b.bestPrice &&
-        this.bestPrice > b.bestPrice
-      ) -> {
+        this.bestPrice > b.bestPrice -> {
         return true;
       }
-      case Buyer b when (
+      case Buyer b when
         this.bestPrice > b.bestPrice &&
         this.bestPrice > b.bestPrice &&
         this.bestPrice > b.bestPrice &&
-        this.bestPrice > b.bestPrice
-      ) -> {
+        this.bestPrice > b.bestPrice -> {
         return true;
       }
       default -> false;
@@ -94,17 +89,15 @@ class T {
       case MyRecord(
         LongTypeName longVariableName,
         LongTypeName longVariableName
-      ) when (
+      ) when
         this.longVariableName > longVariableName &&
-        this.longVariableName > longVariableName
-      ) -> 0;
+        this.longVariableName > longVariableName -> 0;
       case MyRecord(
         LongTypeName longVariableName,
         LongTypeName longVariableName
-      ) when (
+      ) when
         this.longVariableName > longVariableName &&
-        this.longVariableName > longVariableName
-      ) -> longMethodName(
+        this.longVariableName > longVariableName -> longMethodName(
         longVariableName,
         longVariableName,
         longVariableName,

--- a/test/unit-test/switch-when-guard-parens/.prettierrc.json
+++ b/test/unit-test/switch-when-guard-parens/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "printWidth": 40
+}

--- a/test/unit-test/switch-when-guard-parens/_input.java
+++ b/test/unit-test/switch-when-guard-parens/_input.java
@@ -1,0 +1,8 @@
+class T {
+  boolean f(Object x) {
+    return switch (x) {
+      case A a when a.equals(a.aaaa) -> true;
+      default -> false;
+    };
+  }
+}

--- a/test/unit-test/switch-when-guard-parens/_output.java
+++ b/test/unit-test/switch-when-guard-parens/_output.java
@@ -1,0 +1,9 @@
+class T {
+  boolean f(Object x) {
+    return switch (x) {
+      case A a when
+        a.equals(a.aaaa) -> true;
+      default -> false;
+    };
+  }
+}

--- a/test/unit-test/unnamed-variables-and-patterns/_output.java
+++ b/test/unit-test/unnamed-variables-and-patterns/_output.java
@@ -120,10 +120,9 @@ class T {
       case
         MyRecord(LongTypeName longVariableName, LongTypeName longVariableName),
         MyRecord(LongTypeName longVariableName, LongTypeName longVariableName)
-      when (
+      when
         this.longVariableName > longVariableName &&
-        this.longVariableName > longVariableName
-      ) -> longMethodName(
+        this.longVariableName > longVariableName -> longMethodName(
         longVariableName,
         longVariableName,
         longVariableName,


### PR DESCRIPTION
## Summary
With a narrow `printWidth`, `when` guards in switch rules wrapped the expression in parentheses (`when ( … )`). Those parens are unnecessary for Java pattern guards and look noisy next to the trailing `->`.

## Changes
- Print `when` guards by breaking/indenting the expression instead of using `ifBreak("(" / ")")`.
- Update the existing wrapping snapshot and add a regression fixture for #1001 (`printWidth: 40`).

## Test plan
- [ ] `npm test` (or the repo’s usual unit-test command for `test/unit-test`)
- [ ] Fixture `switch-when-guard-parens` matches expected output

Fixes #1001
