### PR TITLE
fix: update tree-sitter-java to support special chars in identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "postcss": "^8.5.15",
     "prettier": "^3.8.1",
     "prettier-plugin-css-order": "^2.2.0",
-    "tree-sitter-java-orchard": "0.5.15",
+    "tree-sitter-java-orchard": "0.5.16",
     "tsdown": "^0.23.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.57.1"

--- a/test/unit-test/expressions/_input.java
+++ b/test/unit-test/expressions/_input.java
@@ -245,4 +245,14 @@ public class Expressions {
     int e = ~~x;
     int f = -+x;
   }
+
+  void specialCharacters() {
+    int αρετη = 1;
+    int _ = 2;
+    int $ = 3;
+    int Ⅳ = 4;
+    int v1€ = 5;
+    int foo‿bar = 6;
+    int é = 7;
+  }
 }

--- a/test/unit-test/expressions/_output.java
+++ b/test/unit-test/expressions/_output.java
@@ -329,4 +329,14 @@ public class Expressions {
     int e = ~~x;
     int f = -+x;
   }
+
+  void specialCharacters() {
+    int αρετη = 1;
+    int _ = 2;
+    int $ = 3;
+    int Ⅳ = 4;
+    int v1€ = 5;
+    int foo‿bar = 6;
+    int é = 7;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,7 +3557,7 @@ picocolors@1.1.1, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^4.0.2, picomatch@^4.0.4, picomatch@^4.0.5, picomatch@^4.0.7:
+picomatch@^4.0.2, picomatch@^4.0.4, picomatch@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.7.tgz#6313360034ccb36b3dc61ecbdff78121f90fe21f"
   integrity sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==
@@ -4049,7 +4049,7 @@ tar@7.5.22, tar@^7.4.3, tar@^7.5.4:
     minizlib "^3.1.0"
     yallist "^5.0.0"
 
-tinyexec@^1.2.4, tinyexec@^1.3.1:
+tinyexec@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.3.1.tgz#16a2e3c6e23fafce72640e678e651db36145b9c6"
   integrity sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==
@@ -4080,10 +4080,10 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-tree-sitter-java-orchard@0.5.15:
-  version "0.5.15"
-  resolved "https://registry.yarnpkg.com/tree-sitter-java-orchard/-/tree-sitter-java-orchard-0.5.15.tgz#7e49373df139b899871f4992fec921f1a5d3c1a9"
-  integrity sha512-8pu64bvuPyMD/BtVDd2rsi648HvVaChD4GKsgzJ6qFfv9Vf6U6rFdxawTkulEnin3a+2jialL1fE4J2M06e/Pg==
+tree-sitter-java-orchard@0.5.16:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/tree-sitter-java-orchard/-/tree-sitter-java-orchard-0.5.16.tgz#da1328006c29526b552e46d3113acf6c9f4e92c2"
+  integrity sha512-n83EZW6VQnEHLX/us9KoZkvc2gvOHrfIJHGk1VxGwG67UEnlH/v+xGxKf1v2OgcuT0vc7nyg0tIda8ue0yqSPg==
   dependencies:
     node-addon-api "^8.5.0"
     node-gyp-build "^4.8.4"


### PR DESCRIPTION
## What changed with this PR:

The tree-sitter-java-orchard dependency is updated to inherit the fix for supporting special characters in identifiers.

## Example

### Input

```java
int αρετη = 1;
int _ = 2;
int $ = 3;
int Ⅳ = 4;
int v1€ = 5;
int foo‿bar = 6;
int é = 7;
```

### Output

```java
int αρετη = 1;
int _ = 2;
int $ = 3;
int Ⅳ = 4;
int v1€ = 5;
int foo‿bar = 6;
int é = 7;
```

## Relative issues or prs:

Closes #1046